### PR TITLE
Refactor term_from_atom_string

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -32,8 +32,8 @@
 #pragma GCC diagnostic pop
 
 #define RAISE_ERROR(error_type_atom) \
-    ctx->x[0] = term_from_atom_string(ctx->global, error_atom); \
-    ctx->x[1] = term_from_atom_string(ctx->global, (error_type_atom)); \
+    ctx->x[0] = context_make_atom(ctx, error_atom); \
+    ctx->x[1] = context_make_atom(ctx, (error_type_atom)); \
     return term_invalid_term();
 
 #define VERIFY_VALUE(value, verify_function) \
@@ -47,11 +47,6 @@ static const char *const error_atom = "\x05" "error";
 static const char *const badarith_atom = "\x08" "badarith";
 static const char *const badarg_atom = "\x6" "badarg";
 
-static inline term term_from_atom_string(GlobalContext *glb, AtomString string)
-{
-    int global_atom_index = globalcontext_insert_atom(glb, string);
-    return term_from_atom_index(global_atom_index);
-}
 
 BifImpl bif_registry_get_handler(AtomString module, AtomString function, int arity)
 {
@@ -99,36 +94,36 @@ term bif_erlang_byte_size_1(Context *ctx, int live, term arg1)
 term bif_erlang_is_atom_1(Context *ctx, term arg1)
 {
     if (term_is_atom(arg1)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
 term bif_erlang_is_binary_1(Context *ctx, term arg1)
 {
     if (term_is_binary(arg1)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
 term bif_erlang_is_integer_1(Context *ctx, term arg1)
 {
     if (term_is_integer(arg1)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
 term bif_erlang_is_list_1(Context *ctx, term arg1)
 {
     if (term_is_list(arg1)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -136,36 +131,36 @@ term bif_erlang_is_number_1(Context *ctx, term arg1)
 {
     //TODO: change to term_is_number
     if (term_is_integer(arg1)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
 term bif_erlang_is_pid_1(Context *ctx, term arg1)
 {
     if (term_is_pid(arg1)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
 term bif_erlang_is_reference_1(Context *ctx, term arg1)
 {
     if (term_is_reference(arg1)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
 term bif_erlang_is_tuple_1(Context *ctx, term arg1)
 {
     if (term_is_tuple(arg1)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -411,8 +406,8 @@ term bif_erlang_bnot_1(Context *ctx, int live, term arg1)
 
 term bif_erlang_not_1(Context *ctx, term arg1)
 {
-    term true_term = term_from_atom_string(ctx->global, true_atom);
-    term false_term = term_from_atom_string(ctx->global, false_atom);
+    term true_term = context_make_atom(ctx, true_atom);
+    term false_term = context_make_atom(ctx, false_atom);
 
     if (arg1 == true_term) {
         return false_term;
@@ -428,8 +423,8 @@ term bif_erlang_not_1(Context *ctx, term arg1)
 
 term bif_erlang_and_2(Context *ctx, term arg1, term arg2)
 {
-    term true_term = term_from_atom_string(ctx->global, true_atom);
-    term false_term = term_from_atom_string(ctx->global, false_atom);
+    term true_term = context_make_atom(ctx, true_atom);
+    term false_term = context_make_atom(ctx, false_atom);
 
     if ((arg1 == false_term) && (arg2 == false_term)) {
         return false_term;
@@ -451,8 +446,8 @@ term bif_erlang_and_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_or_2(Context *ctx, term arg1, term arg2)
 {
-    term true_term = term_from_atom_string(ctx->global, true_atom);
-    term false_term = term_from_atom_string(ctx->global, false_atom);
+    term true_term = context_make_atom(ctx, true_atom);
+    term false_term = context_make_atom(ctx, false_atom);
 
     if ((arg1 == false_term) && (arg2 == false_term)) {
         return false_term;
@@ -474,8 +469,8 @@ term bif_erlang_or_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_xor_2(Context *ctx, term arg1, term arg2)
 {
-    term true_term = term_from_atom_string(ctx->global, true_atom);
-    term false_term = term_from_atom_string(ctx->global, false_atom);
+    term true_term = context_make_atom(ctx, true_atom);
+    term false_term = context_make_atom(ctx, false_atom);
 
     if ((arg1 == false_term) && (arg2 == false_term)) {
         return false_term;
@@ -500,9 +495,9 @@ term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2)
     //TODO: fix this implementation
     //it should compare any kind of type, and 5.0 == 5
     if (arg1 == arg2) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -511,9 +506,9 @@ term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2)
     //TODO: fix this implementation
     //it should compare any kind of type, and 5.0 != 5 is false
     if (arg1 != arg2) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -521,9 +516,9 @@ term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2)
 {
     //TODO: fix this implementation, it needs to cover more types
     if (arg1 == arg2) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -531,9 +526,9 @@ term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2)
 {
     //TODO: fix this implementation, it needs to cover more types
     if (arg1 != arg2) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -542,9 +537,9 @@ term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2)
 {
     //TODO: fix this implementation, it needs to cover more types
     if (term_to_int32(arg1) > term_to_int32(arg2)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -552,9 +547,9 @@ term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2)
 {
     //TODO: fix this implementation, it needs to cover more types
     if (term_to_int32(arg1) < term_to_int32(arg2)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -562,9 +557,9 @@ term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2)
 {
     //TODO: fix this implementation, it needs to cover more types
     if (term_to_int32(arg1) <= term_to_int32(arg2)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }
 
@@ -572,8 +567,8 @@ term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2)
 {
     //TODO: fix this implementation, it needs to cover more types
     if (term_to_int32(arg1) >= term_to_int32(arg2)) {
-        return term_from_atom_string(ctx->global, true_atom);
+        return context_make_atom(ctx, true_atom);
     } else {
-        return term_from_atom_string(ctx->global, false_atom);
+        return context_make_atom(ctx, false_atom);
     }
 }

--- a/src/libAtomVM/ccontext.h
+++ b/src/libAtomVM/ccontext.h
@@ -27,6 +27,7 @@
 #ifndef _CCONTEXT_H_
 #define _CCONTEXT_H_
 
+#include "context.h"
 #include "memory.h"
 #include "term.h"
 
@@ -38,11 +39,11 @@ typedef unsigned long term_ref;
 /**
  * Holds information required to handle term references.
  */
-struct CContext
+typedef struct CContext
 {
     Context *ctx;
     unsigned int terms_count;
-};
+} CContext;
 
 /**
  * @brief Initializes a CContext
@@ -78,7 +79,7 @@ static inline void ccontext_release_all_refs(struct CContext *ccontext)
  * @param t the term that will be referenced.
  * @return a new term reference.
  */
-term_ref ccontext_make_term_ref(struct CContext *ccontext, term t)
+static inline term_ref ccontext_make_term_ref(struct CContext *ccontext, term t)
 {
     Context *ctx = ccontext->ctx;
 
@@ -112,7 +113,7 @@ static inline void ccontext_kill_term_ref(struct CContext *ccontext, term_ref tr
  * @param ccontext the current CContext.
  * @param tref a reference to a term.
  */
-term ccontext_get_term(const struct CContext *ccontext, term_ref tref)
+static inline term ccontext_get_term(const struct CContext *ccontext, term_ref tref)
 {
     return *(ccontext->ctx->e + ccontext->terms_count - tref);
 }

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -174,4 +174,19 @@ static inline int context_is_waiting_timeout(const Context *ctx)
     return ctx->timeout_at.tv_sec || ctx->timeout_at.tv_nsec;
 }
 
+/**
+ * @brief Returns a term representing an atom, from the suppliend string
+ *
+ * @details Converns a string to an atom.  Note that this function may have a side-effect on the
+ *          global context.
+ * @param glb pointer to the global context
+ * @param string an AtomString
+ * @return an atom term formed from the supplied atom string.
+ */
+static inline term context_make_atom(Context *ctx, AtomString string)
+{
+    int global_atom_index = globalcontext_insert_atom(ctx->global, string);
+    return term_from_atom_index(global_atom_index);
+}
+
 #endif

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -234,11 +234,6 @@ static const struct Nif flat_size_nif =
 #include "nifs_hash.h"
 #pragma GCC diagnostic pop
 
-static inline term term_from_atom_string(GlobalContext *glb, AtomString string)
-{
-    int global_atom_index = globalcontext_insert_atom(glb, string);
-    return term_from_atom_index(global_atom_index);
-}
 
 const struct Nif *nifs_get(AtomString module, AtomString function, int arity)
 {
@@ -553,7 +548,7 @@ term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
     struct timespec ts;
     sys_time(&ts);
 
-    term minute_atom = term_from_atom_string(ctx->global, "\x6" "minute");
+    term minute_atom = context_make_atom(ctx, "\x6" "minute");
     if (argv[0] == minute_atom) {
         // FIXME: This is not standard, however we cannot hold seconds since 1970 in just 27 bits.
         return term_from_int32(ts.tv_sec / 60);
@@ -769,7 +764,7 @@ static term binary_to_atom(Context *ctx, int argc, term argv[], int create_new)
     term a_binary = argv[0];
     VERIFY_VALUE(a_binary, term_is_binary);
 
-    if (UNLIKELY(argv[1] != term_from_atom_string(ctx->global, latin1_atom))) {
+    if (UNLIKELY(argv[1] != context_make_atom(ctx, latin1_atom))) {
         fprintf(stderr, "binary_to_atom: only latin1 is supported.\n");
         abort();
     }

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -409,12 +409,6 @@
 static const char *const true_atom = "\x04" "true";
 static const char *const false_atom = "\x05" "false";
 
-static inline term term_from_atom_string(GlobalContext *glb, AtomString string)
-{
-    int global_atom_index = globalcontext_insert_atom(glb, string);
-    return term_from_atom_index(global_atom_index);
-}
-
 
 #ifdef IMPL_EXECUTE_LOOP
 struct Int24
@@ -2260,8 +2254,8 @@ static int64_t large_integer_to_int64(uint8_t *compact_term, int *next_operand_o
                     static const char *const true_atom = "\x04" "true";
                     static const char *const false_atom = "\x05" "false";
 
-                    term true_term = term_from_atom_string(ctx->global, true_atom);
-                    term false_term = term_from_atom_string(ctx->global, false_atom);
+                    term true_term = context_make_atom(ctx, true_atom);
+                    term false_term = context_make_atom(ctx, false_atom);
 
                     if ((arg1 == true_term) || (arg1 == false_term)) {
                         NEXT_INSTRUCTION(next_off);

--- a/src/platforms/esp32/main/udpdriver.c
+++ b/src/platforms/esp32/main/udpdriver.c
@@ -57,11 +57,6 @@ static const char *const error_a = "\x5" "error";
 
 static const char *const send_a = "\x4" "send";
 
-static inline term term_from_atom_string(GlobalContext *glb, AtomString string)
-{
-    int global_atom_index = globalcontext_insert_atom(glb, string);
-    return term_from_atom_index(global_atom_index);
-}
 
 void udpdriver_init(Context *ctx)
 {
@@ -81,8 +76,6 @@ static void consume_udpdriver_mailbox(Context *ctx)
 
     struct UDPDriverData *udp_driver_context = (struct UDPDriverData *) ctx->platform_data;
 
-    GlobalContext *glb = ctx->global;
-
     Message *message = mailbox_dequeue(ctx);
 
     term ret;
@@ -92,7 +85,7 @@ static void consume_udpdriver_mailbox(Context *ctx)
     term ref = term_get_tuple_element(msg, 1);
     term cmd = term_get_tuple_element(msg, 2);
 
-    if (cmd == term_from_atom_string(glb, send_a)) {
+    if (cmd == context_make_atom(ctx, send_a)) {
         term ipaddr_term = term_get_tuple_element(msg, 3);
         term dest_port_term = term_get_tuple_element(msg, 4);
         term buffer_term = term_get_tuple_element(msg, 5);
@@ -110,11 +103,11 @@ static void consume_udpdriver_mailbox(Context *ctx)
 
         int sent_data = sendto(udp_driver_context->sockfd, buffer, buf_len, 0, (struct sockaddr *) &addr, sizeof(addr));
 
-        ret = term_from_atom_string(glb, ok_a);
+        ret = context_make_atom(ctx, ok_a);
 
     } else {
         TRACE("udpdriver: unrecognized command\n");
-        ret = term_from_atom_string(glb, error_a);
+        ret = context_make_atom(ctx, error_a);
     }
 
     free(message);

--- a/src/platforms/generic_unix/udpdriver.c
+++ b/src/platforms/generic_unix/udpdriver.c
@@ -50,12 +50,6 @@ static const char *const error_a = "\x5" "error";
 
 static const char *const send_a = "\x4" "send";
 
-static inline term term_from_atom_string(GlobalContext *glb, AtomString string)
-{
-    int global_atom_index = globalcontext_insert_atom(glb, string);
-    return term_from_atom_index(global_atom_index);
-}
-
 void udpdriver_init(Context *ctx)
 {
     struct UDPDriverData *udp_driver_context = calloc(1, sizeof(struct UDPDriverData));
@@ -74,8 +68,6 @@ static void consume_udpdriver_mailbox(Context *ctx)
 
     struct UDPDriverData *udp_driver_context = (struct UDPDriverData *) ctx->platform_data;
 
-    GlobalContext *glb = ctx->global;
-
     Message *message = mailbox_dequeue(ctx);
 
     term ret;
@@ -87,7 +79,7 @@ static void consume_udpdriver_mailbox(Context *ctx)
 
     UNUSED(ref);
 
-    if (cmd == term_from_atom_string(glb, send_a)) {
+    if (cmd == context_make_atom(ctx, send_a)) {
         term ipaddr_term = term_get_tuple_element(msg, 3);
         term dest_port_term = term_get_tuple_element(msg, 4);
         term buffer_term = term_get_tuple_element(msg, 5);
@@ -106,11 +98,11 @@ static void consume_udpdriver_mailbox(Context *ctx)
         int sent_data = sendto(udp_driver_context->sockfd, buffer, buf_len, 0, (struct sockaddr *) &addr, sizeof(addr));
         UNUSED(sent_data);
 
-        ret = term_from_atom_string(glb, ok_a);
+        ret = context_make_atom(ctx, ok_a);
 
     } else {
         TRACE("udpdriver: unrecognized command\n");
-        ret = term_from_atom_string(glb, error_a);
+        ret = context_make_atom(ctx, error_a);
     }
 
     free(message);


### PR DESCRIPTION
This PR refactors the definition and use of the `term_from_atom_string` function.

* Factored `term_from_atom_string` into a common inline static function in the context module (`context_from_atom_string`), and changed call points.
* Removed multiple instances of static inline definitions of `term_from_atom_string` 
* Changed the input type to Context * (from GlobalContext *)
* Fixed up `ccontext.h` module for inclusion later to include a typedef and static inline declarations

These changes are being submitted under the terms of the LGPLv2 and Apache2 licenses.