### PR TITLE
Fixed clang warnings around format strings and GCC #pragmas

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1066,7 +1066,13 @@ static void display_term(term t, Context *ctx)
         }
 
     } else if (term_is_reference(t)) {
-        printf("#Ref<0.0.0.%li>", term_to_ref_ticks(t));
+        const char *format =
+#ifdef __clang__
+        "#Ref<0.0.0.%llu>";
+#else
+        "#Ref<0.0.0.%lu>";
+#endif
+        printf(format, term_to_ref_ticks(t));
     }
 }
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -467,7 +467,11 @@ static int64_t large_integer_to_int64(uint8_t *compact_term, int *next_operand_o
 #endif
 
 #pragma GCC diagnostic push
+#ifdef __GNUC__
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+#endif
 
 #ifdef IMPL_CODE_LOADER
     int read_core_chunk(Module *mod)


### PR DESCRIPTION
Fixed clang warnings around format strings and GCC #pragmas.

These are insignificant changes that should only affect builds using the clang compiler.

These changes are licensed under the terms of the LGPLv2 and Apache2 licenses.