### PR TITLE
PackBeam enhancements

### DIFF
--- a/src/libAtomVM/avmpack.h
+++ b/src/libAtomVM/avmpack.h
@@ -32,6 +32,11 @@
 #define BEAM_CODE_FLAG 2
 
 /**
+ * @brief callback function for AVMPack section traversal.
+ */
+typedef void *(*avmpack_fold_fun)(void *accum, const void *ptr, uint32_t size, uint32_t flags, const char *name);
+
+/**
  * @brief Finds an AVM Pack section that has certain flags set.
  *
  * @details Finds an AVM Pack section that has certain flags set and returns a pointer to it, its size and its name.
@@ -65,5 +70,14 @@ int avmpack_find_section_by_name(const void *avmpack_binary, const char *name, c
  * @returns 1 if it is a valid AVM Pack binary, 0 otherwise.
  */
 int avmpack_is_valid(const void *avmpack_binary, uint32_t size);
+
+/**
+ * @brief Traverse all the sections in an AVM Pack.
+ *
+ * @details This function will call the callback on each section of the AVM Pack.
+ * @param avmpack_binary a pointer to an AVM Pack binary.
+ * @param callback callback funtion will be called for each section.
+ */
+void *avmpack_fold(void *accum, const void *avmpack_binary, avmpack_fold_fun fold_fun);
 
 #endif

--- a/tools/packbeam/CMakeLists.txt
+++ b/tools/packbeam/CMakeLists.txt
@@ -12,10 +12,15 @@ else()
     set(ZLIB_LIBRARIES "")
 endif (ZLIB_FOUND)
 
+set(
+    PLATFORM_LIB_SUFFIX
+    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+)
+
 if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -ggdb")
 endif()
 
 add_executable(PackBEAM packbeam.c)
-target_link_libraries(PackBEAM ${ZLIB_LIBRARIES})
+target_link_libraries(PackBEAM ${ZLIB_LIBRARIES} libAtomVM libAtomVM${PLATFORM_LIB_SUFFIX})
 set_property(TARGET PackBEAM PROPERTY C_STANDARD 99)

--- a/tools/packbeam/README.md
+++ b/tools/packbeam/README.md
@@ -1,0 +1,76 @@
+
+# `PackBEAM`
+
+The `PackBEAM` tool is used to pack a collection of BEAM files into a single AtomVM (`.avm`) file, or to list the contents of a previously created AVM file.
+
+Packing multiple BEAM files into a single AVM file allows you to load multiple BEAM modules into AtomVM, instead of just running a single module.
+
+> Note.  Future versions of this tool will allow you to pack multiple AVM files, as "libraries" to include into a single output AVM file.
+
+When creating an AVM file, you must specify:
+
+* Name name of the output AVM file, first in the list, followed by:
+* a sequence of compiled BEAM files (as compiled by the `erlc` compiler).  The first BEAM file in this list is required and must contain an exported function called `start` with arity 0.
+
+When listing modules in an AVM file, just specify the AVM file to list its included modules.
+
+## Usage
+
+    Usage: PackBEAM [-h] [-l] <avm-file> [<options>]
+        -h    Print this help menu.
+        -l    List modules in an AVM file.
+              Without the -l flag, <options> must be: <beam-file> [<beam-file>]*, where
+              <beam-file> is a compiled ERTS beam file, and
+              the first beam file in the list contains an exported start/0 function.
+
+## Examples
+
+
+Consider the three modules `mail.erl`, `foo.erl`, and `bar.erl`, defined as follows:
+
+`main.erl`:
+
+    -module(main).
+    -export([start/0]).
+    
+    start() ->
+        hello:say_hello(world).
+
+`hello.erl`:
+
+    -module(hello).
+    -export([say_hello/1]).
+    
+    say_hello(Term) ->
+        greet:say(hello, Term).
+
+`greet.erl`:
+
+    -module(greet).
+    -export([say/2]).
+    
+    say(Greeting, Entity) ->
+        erlang:display({Greeting, Entity}).
+
+You can compile these modules using `erlc`:
+
+    shell$ erlc main.erl hello.erl greet.erl
+
+And then pack them as follows:
+
+    shell$ PackBEAM main.avm main.beam hello.beam greet.beam
+
+This will create the output file `main.avm`, which you can run through AtomVM, e.g.,
+
+    shell$ AtomVM main.avm
+    {hello,world}
+    Return value: 3b
+
+You can list the contents of an AVM file via the `-l` flag:
+
+    shell$ PackBEAM -l main.avm
+    main.beam *
+    hello.beam 
+    greet.beam 
+
+The file containing the `start/0` entrypoint will contain an asterisk (`*`).


### PR DESCRIPTION
This change set makes several small improvements to the PackBeam tool.

* Adds help via the -h flag, which displays a summary of options
* Add a list option via the -l flag, to list the contents (modules) of an AVM file
* Adds a README with documentation and an example.

Future enhancements can include generation of a PackBeam file using the contents of other PackBeam "library" files.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.