### PR TITLE
Add support for PackBeam to take AVM files as input.

### DIFF
--- a/tools/packbeam/README.md
+++ b/tools/packbeam/README.md
@@ -5,26 +5,32 @@ The `PackBEAM` tool is used to pack a collection of BEAM files into a single Ato
 
 Packing multiple BEAM files into a single AVM file allows you to load multiple BEAM modules into AtomVM, instead of just running a single module.
 
-> Note.  Future versions of this tool will allow you to pack multiple AVM files, as "libraries" to include into a single output AVM file.
+Two types of AVM file may be created:
+
+* Runnable AVM files, suitable for flashing or supplying to the AtomVM command;
+* Archive AVM files, which are used to aggregate collections of BEAM files into libraries, for subsequent use when creating runnable AVM files.
+
+The only difference between runnable and archive AVM files is that the first module in a runnable AVM file contains the exported function `start/0`, which is the initial entry point for the AtomVM program.  Archive AVM files do not require a `start/0` entrypoint.
+
+Archive AVM files are typically used to create AtomVM "libraries", which can then be used as inputs when creating a runnable AVM.
 
 When creating an AVM file, you must specify:
 
-* Name name of the output AVM file, first in the list, followed by:
-* a sequence of compiled BEAM files (as compiled by the `erlc` compiler).  The first BEAM file in this list is required and must contain an exported function called `start` with arity 0.
+* Name name of the output AVM file, first in the list, followed by
+* a sequence of compiled BEAM files (as compiled by the `erlc` compiler), or previsouly created AVM files.
+    * If you are creating a runnable AVM, the first file in this sequence must either be a BEAM file that contain an exported `start/0` function or an AVM file whose first module contain an exported `start/0` function.
 
 When listing modules in an AVM file, just specify the AVM file to list its included modules.
 
 ## Usage
 
-    Usage: PackBEAM [-h] [-l] <avm-file> [<options>]
-        -h    Print this help menu.
-        -l    List modules in an AVM file.
-              Without the -l flag, <options> must be: <beam-file> [<beam-file>]*, where
-              <beam-file> is a compiled ERTS beam file, and
-              the first beam file in the list contains an exported start/0 function.
+    Usage: PackBEAM <options>
+    Options:
+        -h                                                Print this help menu.
+        -l <input-avm-file>                               List the contents of an AVM file.
+        [-a] <output-avm-file> <input-beam-or-avm-file>+  Create an AVM file (archive if -a specified).
 
 ## Examples
-
 
 Consider the three modules `mail.erl`, `foo.erl`, and `bar.erl`, defined as follows:
 
@@ -56,9 +62,26 @@ You can compile these modules using `erlc`:
 
     shell$ erlc main.erl hello.erl greet.erl
 
-And then pack them as follows:
+And then pack the second two beam files into an archive using the `-a flag` as follows:
 
-    shell$ PackBEAM main.avm main.beam hello.beam greet.beam
+    shell$ PackBEAM -a lib.avm hello.beam greet.beam
+
+This will create the archive AVM `lib.avm`.
+
+You can list the contents of this AVM via the `-l` flag:
+
+    shell$ PackBEAM -l lib.avm 
+    greet.beam
+    hello.beam
+
+Note that this AVM file is not runnable:
+
+    shell$ AtomVM lib.avm
+    lib.avm cannot be started.
+
+To create a runnable AVM file, specify the output AVM file, the beam file that contains the `start/0` function, and a sequence of 1 or more BEAM files or AVM files.  For example,
+
+    shell$ PackBEAM -a main.avm main.beam lib.avm
 
 This will create the output file `main.avm`, which you can run through AtomVM, e.g.,
 
@@ -66,11 +89,18 @@ This will create the output file `main.avm`, which you can run through AtomVM, e
     {hello,world}
     Return value: 3b
 
-You can list the contents of an AVM file via the `-l` flag:
+You can list the modules in an AVM file via the `-l` flag:
 
     shell$ PackBEAM -l main.avm
     main.beam *
     hello.beam 
     greet.beam 
 
-The file containing the `start/0` entrypoint will contain an asterisk (`*`).
+The module containing the `start/0` entrypoint will contain an asterisk (`*`).
+
+## Additional Notes
+
+* `PackBeam` does not require that BEAM or AVM files have any specific file suffix.  You may use any suffix you like, though `.beam` and `.avm` are conventional.
+* `PackBeam` makes no effort to find beam files with the `start/0` function, and order them first.  In order to create a runnable AVM file, the first input file must be either a BEAM file with an exported `start/0` function, or another AVM file whose first module has an exported `start/0` function.
+* `PackBeam` makes no effort the remove duplicates modules that are packed.  AtomVM will only use the first module by name in an AVM files, so adding duplicate modules has no effect on the runtime behavior of the output AVM file.
+* Because `PackBeam` uses positional arguments when creating AVM files, an attempt to specify a BEAM file (or other non-AVM file) as output, if it already exists, will result in a failure.  This is to prevent accidental omission of an output AVM file as the first argument to `PackBeam` when creating AVM files.

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -37,27 +37,33 @@
 #define END_OF_FILE 0
 #define BEAM_START_FLAG 1
 #define BEAM_CODE_FLAG 2
+#define BUF_SIZE 1024
+
+typedef struct FileData {
+    uint8_t *data;
+    size_t   size;
+} FileData;
 
 static void pad_and_align(FILE *f);
 static void *uncompress_literals(const uint8_t *litT, int size, size_t *uncompressedSize);
 static void add_module_header(FILE *f, const char *module_name, uint32_t flags);
+static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const char *filename, int is_entrypoint);
 
-static int do_pack(int argc, char **argv);
+static int do_pack(int argc, char **argv, int is_archive);
 static int do_list(int argc, char **argv);
 
-void usage3(FILE *out, const char *program, const char *msg) {
+static void usage3(FILE *out, const char *program, const char *msg) {
     if (!IS_NULL_PTR(msg)) {
         fprintf(out, "%s\n", msg);
     }
     fprintf(out, "Usage: %s [-h] [-l] <avm-file> [<options>]\n", program);
-    fprintf(out, "    -h    Print this help menu.\n");
-    fprintf(out, "    -l    List modules in an AVM file.\n");
-    fprintf(out, "          Without the -l flag, <options> must be: <beam-file> [<beam-file>]*, where\n");
-    fprintf(out, "          <beam-file> is a compiled ERTS beam file, and\n");
-    fprintf(out, "          the first beam file in the list contains an exported start/0 function.\n");
+    fprintf(out, "    -h                                                Print this help menu.\n");
+    fprintf(out, "    -l <input-avm-file>                               List the contents of an AVM file.\n");
+    fprintf(out, "    [-a] <output-avm-file> <input-beam-or-avm-file>+  Create an AVM file (archive if -a specified).\n"
+    );
 }
 
-void usage(const char *program)
+static void usage(const char *program)
 {
     usage3(stdout, program, NULL);
 }
@@ -68,17 +74,21 @@ int main(int argc, char **argv)
     int opt;
     
     const char *action = "pack";
-    while ((opt = getopt(argc, argv, "lh")) != -1) {
+    int is_archive = 0;
+    while ((opt = getopt(argc, argv, "hal")) != -1) {
         switch(opt) {
             case 'h':
                 usage(argv[0]);
                 return EXIT_SUCCESS;
+            case 'a':
+                is_archive = 1;
+                break;
             case 'l':
                 action = "list";
                 break;
             case '?': {
-                char buf[20];
-                sprintf(buf, "Unknown option: %c", optopt);
+                char buf[BUF_SIZE];
+                snprintf(buf, BUF_SIZE, "Unknown option: %c", optopt);
                 usage3(stderr, argv[0], buf);
                 return EXIT_FAILURE;
             }
@@ -98,19 +108,91 @@ int main(int argc, char **argv)
             usage3(stderr, argv[0], "Missing options for pack\n");
             return EXIT_FAILURE;
         }
-        return do_pack(new_argc, new_argv);
+        return do_pack(new_argc, new_argv, is_archive);
     } else {
         return do_list(new_argc, new_argv);
     }
 }
-        
-        
-static int do_pack(int argc, char **argv)
+
+
+static void *pack_beam_fun(void *accum, const void *data, uint32_t size, uint32_t flags, const char *section_name)
 {
+    FILE *pack = (FILE *)accum;
+    pack_beam_file(pack, data, size, section_name, 0);
+    return accum;
+}
+
+FileData read_file_data(FILE *file)
+{
+    fseek(file, 0, SEEK_END);
+    size_t size = ftell(file);
+    fseek(file, 0, SEEK_SET);
+    uint8_t *data = malloc(size);
+    if (!data) {
+        fprintf(stderr, "Unable to allocate %zu bytes\n", size);
+        exit(EXIT_FAILURE);
+    }
+    assert(fread(data, sizeof(uint8_t), size, file) == size);
+    
+    FileData file_data = {
+        .data = data,
+        .size = size
+    };
+    return file_data;
+}
+
+static int is_avm_file(FILE *file)
+{
+    FileData file_data = read_file_data(file);
+    int ret = avmpack_is_valid(file_data.data, file_data.size);
+    free(file_data.data);
+    return ret;
+}
+
+static int is_beam_file(FILE *file)
+{
+    FileData file_data = read_file_data(file);
+    int ret = iff_is_valid_beam(file_data.data);
+    free(file_data.data);
+    return ret;
+}
+
+static void validate_pack_options(int argc, char ** argv)
+{
+    for (int i = 0;  i < argc;  ++i) {
+        const char *filename = argv[i];
+        FILE *file = fopen(filename, "r");
+        if (i == 0) {
+            if (file && !is_avm_file(file)) {
+                char buf[BUF_SIZE];
+                snprintf(buf, BUF_SIZE, "Invalid AVM file: %s", filename);
+                usage3(stderr, "PackBeam", buf);
+                exit(EXIT_FAILURE);
+            }
+        } else {
+            if (!file) {
+                char buf[BUF_SIZE];
+                snprintf(buf, BUF_SIZE, "%s does not exist", filename);
+                usage3(stderr, "PackBeam", buf);
+                exit(EXIT_FAILURE);
+            } else if (!is_avm_file(file) && !is_beam_file(file)) {
+                char buf[BUF_SIZE];
+                snprintf(buf, BUF_SIZE, "Invalid AVM or BEAM file: %s", filename);
+                usage3(stderr, "PackBeam", buf);
+                exit(EXIT_FAILURE);
+            }
+        }
+    }
+}
+        
+static int do_pack(int argc, char **argv, int is_archive)
+{
+    validate_pack_options(argc, argv);
+    
     FILE *pack = fopen(argv[0], "w");
     if (!pack) {
-        char buf[1024];
-        sprintf(buf, "Cannot open output file for writing %s", argv[0]);
+        char buf[BUF_SIZE];
+        snprintf(buf, BUF_SIZE, "Cannot open output file for writing %s", argv[0]);
         perror(buf);
         return EXIT_FAILURE;
     }
@@ -127,112 +209,145 @@ static int do_pack(int argc, char **argv)
     assert(fwrite(pack_header, sizeof(unsigned char), 24, pack) == 24);
 
     for (int i = 1; i < argc; i++) {
-        FILE *beam = fopen(argv[i], "r");
-        if (!beam) {
-            char buf[1024];
-            sprintf(buf, "Cannot open beam file %s", argv[i]);
+        FILE *file = fopen(argv[i], "r");
+        if (!file) {
+            char buf[BUF_SIZE];
+            snprintf(buf, BUF_SIZE, "Cannot open file %s", argv[i]);
             perror(buf);
             return EXIT_FAILURE;
         }
 
-        fseek(beam, 0, SEEK_END);
-        size_t beam_size = ftell(beam);
-        fseek(beam, 0, SEEK_SET);
-        size_t zero_pos = ftell(pack);
+        fseek(file, 0, SEEK_END);
+        size_t file_size = ftell(file);
+        fseek(file, 0, SEEK_SET);
+        
 
-        char *complete_name = strdup(argv[i]);
-        char *filename = basename(complete_name);
-        if (i == 1) {
-            add_module_header(pack, filename, BEAM_CODE_FLAG | BEAM_START_FLAG);
+        uint8_t *file_data = malloc(file_size);
+        if (!file_data) {
+            fprintf(stderr, "Unable to allocate %zu bytes\n", file_size);
+            return EXIT_FAILURE;
+        }
+        assert(fread(file_data, sizeof(uint8_t), file_size, file) == file_size);
+        if (avmpack_is_valid(file_data, file_size)) {
+            avmpack_fold(pack, file_data, pack_beam_fun);
         } else {
-            add_module_header(pack, filename, BEAM_CODE_FLAG);
+            char *filename = basename(argv[i]);
+            pack_beam_file(pack, file_data, file_size, filename, !is_archive && i == 1);
         }
-        free(complete_name);
-
-        int written_beam_header_pos = ftell(pack);
-        const unsigned char beam_header[12] =
-        {
-            0x46, 0x4f, 0x52, 0x31,
-            0x00, 0x00, 0x00, 0x00,
-            0x42, 0x45, 0x41, 0x4d
-        };
-        assert(fwrite(beam_header, 1, 12, pack) == 12);
-
-        uint8_t *data = malloc(beam_size);
-        assert(fread(data, sizeof(uint8_t), beam_size, beam) == beam_size);
-
-        unsigned long offsets[MAX_OFFS];
-        unsigned long sizes[MAX_SIZES];
-        scan_iff(data, beam_size, offsets, sizes);
-
-        if (offsets[AT8U]) {
-            assert(fwrite(data + offsets[AT8U], sizeof(uint8_t), sizes[AT8U] + IFF_SECTION_HEADER_SIZE, pack) == sizes[AT8U] + IFF_SECTION_HEADER_SIZE);
-            pad_and_align(pack);
-        }
-        if (offsets[CODE]) {
-            fwrite(data + offsets[CODE], sizeof(uint8_t), sizes[CODE] + IFF_SECTION_HEADER_SIZE, pack);
-            pad_and_align(pack);
-        }
-        if (offsets[EXPT]) {
-            fwrite(data + offsets[EXPT], sizeof(uint8_t), sizes[EXPT] + IFF_SECTION_HEADER_SIZE, pack);
-            pad_and_align(pack);
-        }
-        if (offsets[LOCT]) {
-            fwrite(data + offsets[LOCT], sizeof(uint8_t), sizes[LOCT] + IFF_SECTION_HEADER_SIZE, pack);
-            pad_and_align(pack);
-        }
-        if (offsets[IMPT]) {
-            fwrite(data + offsets[IMPT], sizeof(uint8_t), sizes[IMPT] + IFF_SECTION_HEADER_SIZE, pack);
-            pad_and_align(pack);
-        }
-
-        if (offsets[LITT]) {
-            size_t u_size;
-            void *deflated = uncompress_literals(data + offsets[LITT], sizes[LITT], &u_size);
-            assert(fwrite("LitU", sizeof(uint8_t), 4, pack) == 4);
-            uint32_t size_field = ENDIAN_SWAP_32(u_size);
-            assert(fwrite(&size_field, sizeof(size_field), 1, pack) == 1);
-            assert(fwrite(deflated, sizeof(uint8_t), u_size, pack) == u_size);
-            free(deflated);
-        }
-
-        pad_and_align(pack);
-
-        size_t end_of_module_pos = ftell(pack);
-
-        size_t size = end_of_module_pos - zero_pos;
-        uint32_t size_field = ENDIAN_SWAP_32(size);
-        fseek(pack, zero_pos, SEEK_SET);
-        assert(fwrite(&size_field, sizeof(uint32_t), 1, pack) == 1);
-        fseek(pack, end_of_module_pos, SEEK_SET);
-
-        int beam_written_size = end_of_module_pos - written_beam_header_pos;
-        uint32_t beam_written_size_field = ENDIAN_SWAP_32(beam_written_size);
-        fseek(pack, written_beam_header_pos + 4, SEEK_SET);
-        assert(fwrite(&beam_written_size_field , sizeof(uint32_t), 1, pack) == 1);
-        fseek(pack, end_of_module_pos, SEEK_SET);
     }
-
+    
     add_module_header(pack, "end", END_OF_FILE);
-
+    fclose(pack);
+    
     return EXIT_SUCCESS;
 }
 
-void *print_section(void *accum, const void *ptr, uint32_t size, uint32_t flags, const char *section_name)
+static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const char *section_name, int is_entrypoint)
 {
-    UNUSED(ptr);
+    size_t zero_pos = ftell(pack);
+    
+    if (is_entrypoint) {
+        add_module_header(pack, section_name, BEAM_CODE_FLAG | BEAM_START_FLAG);
+    } else {
+        add_module_header(pack, section_name, BEAM_CODE_FLAG);
+    }
+
+    int written_beam_header_pos = ftell(pack);
+    const unsigned char beam_header[12] =
+    {
+        0x46, 0x4f, 0x52, 0x31,
+        0x00, 0x00, 0x00, 0x00,
+        0x42, 0x45, 0x41, 0x4d
+    };
+    assert(fwrite(beam_header, 1, 12, pack) == 12);
+
+
+    unsigned long offsets[MAX_OFFS];
+    unsigned long sizes[MAX_SIZES];
+    scan_iff(data, size, offsets, sizes);
+
+    if (offsets[AT8U]) {
+        assert(fwrite(data + offsets[AT8U], sizeof(uint8_t), sizes[AT8U] + IFF_SECTION_HEADER_SIZE, pack) == sizes[AT8U] + IFF_SECTION_HEADER_SIZE);
+        pad_and_align(pack);
+    }
+    if (offsets[CODE]) {
+        fwrite(data + offsets[CODE], sizeof(uint8_t), sizes[CODE] + IFF_SECTION_HEADER_SIZE, pack);
+        pad_and_align(pack);
+    }
+    if (offsets[EXPT]) {
+        fwrite(data + offsets[EXPT], sizeof(uint8_t), sizes[EXPT] + IFF_SECTION_HEADER_SIZE, pack);
+        pad_and_align(pack);
+    }
+    if (offsets[LOCT]) {
+        fwrite(data + offsets[LOCT], sizeof(uint8_t), sizes[LOCT] + IFF_SECTION_HEADER_SIZE, pack);
+        pad_and_align(pack);
+    }
+    if (offsets[IMPT]) {
+        fwrite(data + offsets[IMPT], sizeof(uint8_t), sizes[IMPT] + IFF_SECTION_HEADER_SIZE, pack);
+        pad_and_align(pack);
+    }
+
+    if (offsets[LITT]) {
+        size_t u_size;
+        void *deflated = uncompress_literals(data + offsets[LITT], sizes[LITT], &u_size);
+        assert(fwrite("LitU", sizeof(uint8_t), 4, pack) == 4);
+        uint32_t size_field = ENDIAN_SWAP_32(u_size);
+        assert(fwrite(&size_field, sizeof(size_field), 1, pack) == 1);
+        assert(fwrite(deflated, sizeof(uint8_t), u_size, pack) == u_size);
+        free(deflated);
+    }
+
+    pad_and_align(pack);
+
+    size_t end_of_module_pos = ftell(pack);
+
+    size_t rsize = end_of_module_pos - zero_pos;
+    uint32_t size_field = ENDIAN_SWAP_32(rsize);
+    fseek(pack, zero_pos, SEEK_SET);
+    assert(fwrite(&size_field, sizeof(uint32_t), 1, pack) == 1);
+    fseek(pack, end_of_module_pos, SEEK_SET);
+
+    int beam_written_size = end_of_module_pos - written_beam_header_pos;
+    uint32_t beam_written_size_field = ENDIAN_SWAP_32(beam_written_size);
+    fseek(pack, written_beam_header_pos + 4, SEEK_SET);
+    assert(fwrite(&beam_written_size_field , sizeof(uint32_t), 1, pack) == 1);
+    fseek(pack, end_of_module_pos, SEEK_SET);
+}
+
+
+static void *print_section(void *accum, const void *data, uint32_t size, uint32_t flags, const char *section_name)
+{
+    UNUSED(data);
     UNUSED(size);
     printf("%s %s\n", section_name, flags & BEAM_START_FLAG ? "*" : "");
     return accum;
 }
 
+static void validate_list_options(const char *filename)
+{
+    FILE *file = fopen(filename, "r");
+    if (!file) {
+        char buf[BUF_SIZE];
+        snprintf(buf, BUF_SIZE, "%s does not exist", filename);
+        usage3(stderr, "PackBeam", buf);
+        exit(EXIT_FAILURE);
+    } else if (!is_avm_file(file)) {
+        char buf[BUF_SIZE];
+        snprintf(buf, BUF_SIZE, "Invalid AVM file: %s", filename);
+        usage3(stderr, "PackBeam", buf);
+        exit(EXIT_FAILURE);
+    }
+}
+
 static int do_list(int argc, char **argv)
 {
     UNUSED(argc);
+    validate_list_options(argv[0]);
+    
     MappedFile *mapped_file = mapped_file_open_beam(argv[0]);
     if (IS_NULL_PTR(mapped_file)) {
-        char buf[1024];
-        sprintf(buf, "Cannot open AVM file %s", argv[0]);
+        char buf[BUF_SIZE];
+        snprintf(buf, BUF_SIZE, "Cannot open AVM file %s", argv[0]);
         perror(buf);
         return EXIT_FAILURE;
     }
@@ -241,7 +356,9 @@ static int do_list(int argc, char **argv)
     if (avmpack_is_valid(mapped_file->mapped, mapped_file->size)) {
         avmpack_fold(NULL, mapped_file->mapped, print_section);
     } else {
-        fprintf(stderr, "%s is not an AVM file.\n", argv[1]);
+        char buf[BUF_SIZE];
+        snprintf(buf, BUF_SIZE, "%s is not an AVM file.\n", argv[1]);
+        usage3(stderr, "PackBeam", buf);
         ret = EXIT_FAILURE;
     }
     mapped_file_close(mapped_file);


### PR DESCRIPTION
This change set modifies the PackBeam executable to support previously created AVM files as inputs.  This allows the creation of AVM "archives", or "libraries", which can be built independently of an application (e.g., estdlib), and which can then be assembled into an AVM that can be flashed to a device or run from the command line.

These changes are backwards compatible with previous uses of PackBeam.

These changes are submitted under the terms of the LGPLv2 and Apache2 licenses.