### PR TITLE
Adds support for building Erlang libraries and examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,15 @@
 cmake_minimum_required (VERSION 2.6)
 
-project (AtomVM)
+project(AtomVM)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
 
 add_subdirectory(src)
 add_subdirectory(tests)
 add_subdirectory(tools/packbeam)
+add_subdirectory(libs)
+add_subdirectory(examples)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Coverage")
-    set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
     include(CodeCoverage)
     SETUP_TARGET_FOR_COVERAGE(NAME coverage EXECUTABLE test-erlang DEPENDENCIES test-erlang)
 endif()

--- a/CMakeModules/BuildErlang.cmake
+++ b/CMakeModules/BuildErlang.cmake
@@ -1,0 +1,73 @@
+##
+## Copyright (c) 2018 Fred Dushin <fred@dushin.net>
+##
+
+
+macro(pack_archive avm_name)
+
+    foreach(module_name ${ARGN})
+        add_custom_command(
+            OUTPUT ${module_name}.beam
+            COMMAND erlc ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
+            COMMENT "Compiling ${module_name}.erl"
+            VERBATIM
+        )
+        set(BEAMS ${BEAMS} ${module_name}.beam)
+    endforeach()
+
+    add_custom_target(
+        ${avm_name}
+        DEPENDS ${BEAMS}
+    )
+    
+    add_custom_command(
+        OUTPUT  ${avm_name}.avm
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM -a ${avm_name}.avm ${BEAMS}
+        DEPENDS ${avm_name} PackBEAM
+        COMMENT "Packing archive ${avm_name}.avm"
+        VERBATIM
+    )
+    
+    add_custom_target(
+        ${avm_name}_avm ALL
+        DEPENDS ${avm_name}.avm
+    )
+    
+endmacro()
+
+
+macro(pack_runnable avm_name main)
+
+    add_custom_command(
+        OUTPUT ${main}.beam
+        COMMAND erlc ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
+        COMMENT "Compiling ${main}.erl"
+        VERBATIM
+    )
+
+    add_custom_target(
+        ${avm_name}_main
+        DEPENDS ${main}.beam
+    )
+    
+    foreach(archive_name ${ARGN})
+        set(ARCHIVES ${ARCHIVES} ${CMAKE_BINARY_DIR}/libs/${archive_name}/${archive_name}.avm)
+        set(ARCHIVE_TARGETS ${ARCHIVE_TARGETS} ${archive_name}_avm)
+    endforeach()
+    
+    add_custom_command(
+        OUTPUT  ${avm_name}.avm
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${avm_name}.avm ${main}.beam ${ARCHIVES}
+        DEPENDS ${avm_name}_main ${ARCHIVE_TARGETS} PackBEAM
+        COMMENT "Packing runnable ${avm_name}.avm"
+        VERBATIM
+    )
+    
+    add_custom_target(
+        ${avm_name}_avm ALL
+        DEPENDS ${avm_name}.avm
+    )
+    
+endmacro()

--- a/README.ESP32.Md
+++ b/README.ESP32.Md
@@ -41,18 +41,10 @@ Running Hello World
 This example will print a Hello World message.
 
 ```
-$ cd examples/erlang
+# Flash the hello_world.avm to the device
+$ $IDF_PATH/components/esptool_py/esptool/esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 115200 --before default_reset --after hard_reset write_flash -u --flash_mode dio --flash_freq 40m --flash_size detect  0x110000 build/examples/erlang/hello_world.avm
 
-# Compile the hello world
-$ erlc hello_world.erl
-
-# Pack it (the path to PackBEAM needs to be adjusted)
-$ path/to/PackBEAM hello_world.avm hello_world.beam
-
-# Flash it to the device
-$ $IDF_PATH/components/esptool_py/esptool/esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 115200 --before default_reset --after hard_reset write_flash -u --flash_mode dio --flash_freq 40m --flash_size detect  0x110000 hello_world.avm
-
-$ cd ../../src/platforms/esp32
+$ cd src/platforms/esp32
 
 # Open the serial monitor
 $ make monitor
@@ -63,17 +55,9 @@ Running Blink Example
 
 This example will switch on and off a led connected to GPIO 2 every second.
 
-Compile and flash blink example using following commands:
+Flash blink example using following commands:
 
 ```
-$ cd examples/erlang/esp32
-
-# Compile blink example
-$ erlc blink.erl
-
-# Pack it (the path to PackBEAM needs to be adjusted)
-$ path/to/PackBEAM blink.avm blink.beam
-
-# Flash it to the device
-$ $IDF_PATH/components/esptool_py/esptool/esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 115200 --before default_reset --after hard_reset write_flash -u --flash_mode dio --flash_freq 40m --flash_size detect  0x110000 blink.avm
+# Flash the blink.avm to the device
+$ $IDF_PATH/components/esptool_py/esptool/esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 115200 --before default_reset --after hard_reset write_flash -u --flash_mode dio --flash_freq 40m --flash_size detect  0x110000 build/examples/erlang/esp32/blink.avm
 ```

--- a/README.Md
+++ b/README.Md
@@ -30,11 +30,11 @@ Getting Started (on Linux)
 
 
 ```
-$ cmake .
-
+$ mkdir build
+$ cd build
+$ cmake ...
 $ make
-
-$ ./src/AtomVM hello_world.beam
+$ ./src/AtomVM ./examples/erlang/hello_world.avm
 ```
 
 Project Status

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,6 @@
+##
+## Copyright (c) 2018 Fred Dushin <fred@dushin.net>
+##
+project(libs)
+
+add_subdirectory(erlang)

--- a/examples/erlang/CMakeLists.txt
+++ b/examples/erlang/CMakeLists.txt
@@ -1,0 +1,13 @@
+##
+## Copyright (c) 2018 Fred Dushin <fred@dushin.net>
+##
+
+project(examples_erlang)
+
+include(BuildErlang)
+
+add_subdirectory(esp32)
+
+pack_runnable(hello_world hello_world estdlib)
+pack_runnable(udp_server udp_server estdlib)
+pack_runnable(udp_client udp_client estdlib)

--- a/examples/erlang/esp32/CMakeLists.txt
+++ b/examples/erlang/esp32/CMakeLists.txt
@@ -1,0 +1,9 @@
+##
+## Copyright (c) 2018 Fred Dushin <fred@dushin.net>
+##
+
+project(examples_erlang_esp32)
+
+include(BuildErlang)
+
+pack_runnable(blink blink eavmlib estdlib)

--- a/examples/erlang/esp32/blink.erl
+++ b/examples/erlang/esp32/blink.erl
@@ -1,38 +1,16 @@
 -module (blink).
--export([start/0, do_open_port/2, set_direction/3, set_level/3]).
+-export([start/0]).
 
 start() ->
-    GPIO = do_open_port("gpio", []),
-    set_direction(GPIO, 2, output),
-    loop(GPIO, 0).
+    GPIO = gpio:open(),
+    gpio:set_direction(GPIO, 2, output),
+    loop(GPIO, off).
 
-loop(GPIO, 0) ->
-    set_level(GPIO, 2, 0),
-    sleep(1000),
-    loop(GPIO, 1);
-loop(GPIO, 1) ->
-    set_level(GPIO, 2, 1),
-    sleep(1000),
-    loop(GPIO, 0).
-
-do_open_port(PortName, Param) ->
-    open_port({spawn, PortName}, Param).
-
-set_direction(GPIO, GPIONum, Direction) ->
-    GPIO ! {self(), set_direction, GPIONum, Direction},
-    receive
-        Ret ->
-            Ret
-    end.
-
-set_level(GPIO, GPIONum, Level) ->
-    GPIO ! {self(), set_level, GPIONum, Level},
-    receive
-        Ret ->
-            Ret
-    end.
-
-sleep(T) ->
-    receive
-        after T -> ok
-    end.
+loop(GPIO, off) ->
+    gpio:set_level(GPIO, 2, 0),
+    timer:sleep(1000),
+    loop(GPIO, on);
+loop(GPIO, on) ->
+    gpio:set_level(GPIO, 2, 1),
+    timer:sleep(1000),
+    loop(GPIO, off).

--- a/examples/erlang/hello_world.erl
+++ b/examples/erlang/hello_world.erl
@@ -1,16 +1,5 @@
 -module (hello_world).
--export([start/0, do_open_port/2, write/2]).
+-export([start/0]).
 
 start() ->
-    Console = do_open_port("console", []),
-    write(Console, "Hello World\n").
-
-do_open_port(PortName, Param) ->
-    open_port({spawn, PortName}, Param).
-
-write(Console, String) ->
-    Console ! {self(), String},
-    receive
-        ReturnStatus ->
-            ReturnStatus
-    end.
+    console:puts("Hello World\n").

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,0 +1,7 @@
+##
+## Copyright (c) 2018 Fred Dushin <fred@dushin.net>
+##
+project(libs)
+
+add_subdirectory(estdlib)
+add_subdirectory(eavmlib)

--- a/libs/eavmlib/CMakeLists.txt
+++ b/libs/eavmlib/CMakeLists.txt
@@ -1,0 +1,14 @@
+##
+## Copyright (c) 2018 Fred Dushin <fred@dushin.net>
+##
+
+project(eavmlib)
+
+include(BuildErlang)
+
+set(ERLANG_MODULES
+    gpio
+    network
+)
+
+pack_archive(eavmlib ${ERLANG_MODULES})

--- a/libs/estdlib/CMakeLists.txt
+++ b/libs/estdlib/CMakeLists.txt
@@ -1,0 +1,17 @@
+##
+## Copyright (c) 2018 Fred Dushin <fred@dushin.net>
+##
+
+project(estdlib)
+
+include(BuildErlang)
+
+set(ERLANG_MODULES
+    calendar
+    console
+    gen_udp
+    lists
+    timer
+)
+
+pack_archive(estdlib ${ERLANG_MODULES})

--- a/src/libAtomVM/avmpack.c
+++ b/src/libAtomVM/avmpack.c
@@ -117,8 +117,8 @@ void *avmpack_fold(void *accum, const void *avmpack_binary, avmpack_fold_fun fol
             int section_name_len = pad(strlen(section_name) + 1);
             accum = fold_fun(
                 accum,
-                (uint32_t *) (size_ptr + 3 + section_name_len/sizeof(uint32_t)),
-                size,
+                size_ptr, size,
+                size_ptr + 3 + section_name_len/sizeof(uint32_t),
                 flags,
                 section_name
             );

--- a/src/libAtomVM/avmpack.h
+++ b/src/libAtomVM/avmpack.h
@@ -32,9 +32,19 @@
 #define BEAM_CODE_FLAG 2
 
 /**
- * @brief callback function for AVMPack section traversal.
+ * @brief callback function for AVMPack section fold.
+ * @details Instances of this function are supplied to the avmpack_fold function, in order to
+ * provide a callback mechanism for folding over the contents of the AVM binary.
+ * @param accum The accumulator supplied by the application.
+ * @param section_ptr a pointer to the start of the AVM section (including the module header)
+ * @param section_size the size of the entire section (including the module header)
+ * @param beam_ptr the start of the beam module portion of the section.  This pointers starts immeadiately after
+ * the (aligned) header.
+ * @param flags the section flags, as defined in the module header
+ * @param section_name the section name, as defined in the module header
+ * @return an acculator, which will be supplied to the next call to this funtion, and eventually returned from the avmpack_fold function.
  */
-typedef void *(*avmpack_fold_fun)(void *accum, const void *ptr, uint32_t size, uint32_t flags, const char *name);
+typedef void *(*avmpack_fold_fun)(void *accum, const void *section_ptr, uint32_t section_size, const void *beam_ptr, uint32_t flags, const char *section_name);
 
 /**
  * @brief Finds an AVM Pack section that has certain flags set.
@@ -72,11 +82,12 @@ int avmpack_find_section_by_name(const void *avmpack_binary, const char *name, c
 int avmpack_is_valid(const void *avmpack_binary, uint32_t size);
 
 /**
- * @brief Traverse all the sections in an AVM Pack.
+ * @brief Fold over all the sections in an AVM Pack.
  *
- * @details This function will call the callback on each section of the AVM Pack.
+ * @details This function will call the callback on each section of the AVM Pack, passing in
+ * the current section of each module in the AVM binary to the supplied fold function.
  * @param avmpack_binary a pointer to an AVM Pack binary.
- * @param callback callback funtion will be called for each section.
+ * @param fold_fun funtion that will be called for each AVM section.
  */
 void *avmpack_fold(void *accum, const void *avmpack_binary, avmpack_fold_fun fold_fun);
 

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -115,10 +115,14 @@ int main(int argc, char **argv)
 }
 
 
-static void *pack_beam_fun(void *accum, const void *data, uint32_t size, uint32_t flags, const char *section_name)
+static void *pack_beam_fun(void *accum, const void *section_ptr, uint32_t section_size, const void *beam_ptr, uint32_t flags, const char *section_name)
 {
+    UNUSED(beam_ptr);
+    UNUSED(flags);
+    UNUSED(section_name);
+    
     FILE *pack = (FILE *)accum;
-    pack_beam_file(pack, data, size, section_name, 0);
+    assert(fwrite(section_ptr, sizeof(unsigned char), section_size, pack) == section_size);
     return accum;
 }
 
@@ -315,10 +319,11 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
 }
 
 
-static void *print_section(void *accum, const void *data, uint32_t size, uint32_t flags, const char *section_name)
+static void *print_section(void *accum, const void *section_ptr, uint32_t section_size, const void *beam_ptr, uint32_t flags, const char *section_name)
 {
-    UNUSED(data);
-    UNUSED(size);
+    UNUSED(section_ptr);
+    UNUSED(section_size);
+    UNUSED(beam_ptr);
     printf("%s %s\n", section_name, flags & BEAM_START_FLAG ? "*" : "");
     return accum;
 }


### PR DESCRIPTION
This change set adds CMake rules for building AVM files for libraries and examples.

In addition, a bug in the PackBEAM executable is fixed, which fixes an issue with packing previously packed AVM files.

As part of this fix, the avmpack_fold fold function signature was changed, to supply accurate section addresses.  The API documentation was clarified and corrected.

These changes are submitted under the terms of the LGPLv2 and Apache2 licenses.