### PR TITLE
Ensure adequate memory on UDP receive.

### DIFF
--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -80,3 +80,10 @@ void port_send_reply(CContext *cc, term_ref pid, term_ref ref, term_ref reply)
     term_ref msg = port_create_tuple2(cc, ref, reply);
     mailbox_send(target, ccontext_get_term(cc, msg));
 }
+
+void port_ensure_available(Context *ctx, size_t size)
+{
+    if (context_avail_free_memory(ctx) < size) {
+        memory_ensure_free(ctx, size);
+    }
+}

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -38,5 +38,6 @@ term_ref port_create_tuple_n(CContext *cc, size_t num_terms, term_ref *terms);
 term_ref port_create_error_tuple(CContext *cc, const char *reason);
 term_ref port_create_ok_tuple(CContext *cc, term_ref t);
 void port_send_reply(CContext *cc, term_ref pid, term_ref ref, term_ref reply);
+void port_ensure_available(Context *ctx, size_t size);
 
 #endif

--- a/src/libAtomVM/socket.c
+++ b/src/libAtomVM/socket.c
@@ -76,6 +76,8 @@ static void socket_consume_mailbox(Context *ctx)
         abort();
     }
     ccontext_init(cc, ctx);
+    
+    port_ensure_available(ctx, 16);
 
     Message *message = mailbox_dequeue(ctx);
     term     msg = message->message;


### PR DESCRIPTION
This change ensures there is adequate room in the process heap to store enough data received on a UDP packet.

This change imposes an artificial limitation of 128 bytes on a received packet.  We will revisit this limitation in the future.

This change also fixes a potential memory corruption issue when copying an erlang reference to the event listener for the receive operation.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.