### PR TITLE
Add selective receive to the console port.

### DIFF
--- a/libs/estdlib/console.erl
+++ b/libs/estdlib/console.erl
@@ -18,7 +18,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 -module(console).
 
--export([start/0, puts/1, puts/2]).
+-export([start/0, puts/1, puts/2, flush/0, flush/1]).
 
 -opaque console() :: any().
 
@@ -29,16 +29,26 @@ puts(String) ->
 %% @hidden
 -spec puts(console(), string()) -> ok.
 puts(Console, String) ->
-    call(Console, String).
+    call(Console, {puts, String}).
+
+-spec flush() -> ok.
+flush() ->
+    flush(get_pid()).
+
+%% @hidden
+-spec flush(console()) -> ok.
+flush(Console) ->
+    call(Console, flush).
 
 %% Internal operations
 
 %% @private
 -spec call(console(), string()) -> ok.
 call(Console, Msg) ->
-    Console ! {self(), Msg},
+    Ref = make_ref(),
+    Console ! {self(), Ref, Msg},
     receive
-        ok -> ok
+        {Ref, Reply} -> Reply
     end.
 
 %% @private

--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -87,3 +87,22 @@ void port_ensure_available(Context *ctx, size_t size)
         memory_ensure_free(ctx, size);
     }
 }
+
+int port_is_standard_port_command(term t)
+{
+    if (!term_is_tuple(t)) {
+        return 0;
+    } else if (term_get_tuple_arity(t) != 3) {
+        return 0;
+    } else {
+        term pid = term_get_tuple_element(t, 0);
+        term ref = term_get_tuple_element(t, 1);
+        if (!term_is_pid(pid)) {
+            return 0;
+        } else if (!term_is_reference(ref)) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+}

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -32,6 +32,11 @@ static inline term_ref port_make_atom(CContext *cc, AtomString atom)
     return ccontext_make_term_ref(cc, context_make_atom(cc->ctx, atom));
 }
 
+static inline term_ref port_make_ok_atom(CContext *cc)
+{
+    return ccontext_make_term_ref(cc, context_make_atom(cc->ctx, port_ok_a));
+}
+
 term_ref port_create_tuple2(CContext *cc, term_ref a, term_ref b);
 term_ref port_create_tuple3(CContext *cc, term_ref a, term_ref b, term_ref c);
 term_ref port_create_tuple_n(CContext *cc, size_t num_terms, term_ref *terms);
@@ -39,5 +44,6 @@ term_ref port_create_error_tuple(CContext *cc, const char *reason);
 term_ref port_create_ok_tuple(CContext *cc, term_ref t);
 void port_send_reply(CContext *cc, term_ref pid, term_ref ref, term_ref reply);
 void port_ensure_available(Context *ctx, size_t size);
+int port_is_standard_port_command(term msg);
 
 #endif

--- a/tests/erlang_tests/hello_world.erl
+++ b/tests/erlang_tests/hello_world.erl
@@ -9,9 +9,10 @@ do_open_port(PortName, Param) ->
     open_port({spawn, PortName}, Param).
 
 write(Console, String) ->
-    Console ! {self(), String},
+    Ref = make_ref(),
+    Console ! {self(), Ref, {puts, String}},
     receive
-        ReturnStatus ->
+        {Ref, ReturnStatus} ->
             ReturnStatus
     end.
 


### PR DESCRIPTION
This change adds selective receive when sending messages to the console port, using a reference to tag the request.  This way, the calling application can be assured that the request it made was serviced by the port.

This change also adds a flush operation to the console port, to flush any messages buffered by the standard library or OS.

Corresponding changes are made to the console erlang application.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.