### PR TITLE
Place CContext on stack instead of heap.

### DIFF
--- a/src/libAtomVM/socket.c
+++ b/src/libAtomVM/socket.c
@@ -69,12 +69,8 @@ static void socket_consume_mailbox(Context *ctx)
     if (UNLIKELY(ctx->native_handler != socket_consume_mailbox)) {
         abort();
     }
-
-    struct CContext *cc = malloc(sizeof(struct CContext));
-    if (!cc) {
-        fprintf(stderr, "malloc %s:%d", __FILE__, __LINE__);
-        abort();
-    }
+    CContext ccontext;
+    CContext *cc = &ccontext;
     ccontext_init(cc, ctx);
 
     port_ensure_available(ctx, 16);
@@ -108,8 +104,6 @@ static void socket_consume_mailbox(Context *ctx)
     }
 
     ccontext_release_all_refs(cc);
-    free(cc);
-
     free(message);
     TRACE("END socket_consume_mailbox\n");
 }


### PR DESCRIPTION
This change puts the CContext object in the socket port on the stack, instead of on the heap, in conformance with the rest of the ports.

This change is made under the terms of the LGPLv2 and Apache2 licenses.