### PR TITLE
Phase I changes to the network port driver.

### DIFF
--- a/examples/erlang/esp32/CMakeLists.txt
+++ b/examples/erlang/esp32/CMakeLists.txt
@@ -7,3 +7,4 @@ project(examples_erlang_esp32)
 include(BuildErlang)
 
 pack_runnable(blink blink eavmlib estdlib)
+pack_runnable(setup_network setup_network eavmlib estdlib)

--- a/examples/erlang/esp32/setup_network.erl
+++ b/examples/erlang/esp32/setup_network.erl
@@ -1,0 +1,17 @@
+-module(setup_network).
+
+-export([start/0]).
+
+start() ->
+    NetworkConfig = [{sta, [
+        {ssid, "mynetwokid"},
+        {psk, "mypassword"}
+    ]}],
+    case network:setup(NetworkConfig) of
+        ok ->
+            timer:sleep(24*60*60*1000);
+            %erlang:display(network:ifconfig());
+        Error ->
+            erlang:display(Error)
+    end.
+

--- a/libs/eavmlib/network.erl
+++ b/libs/eavmlib/network.erl
@@ -1,13 +1,58 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%   Copyright 2018 by Davide Bettio <davide@uninstall.it>                 *
+%   Copyright 2018 by Fred Dushin <fred@dushin.net>                       %
+%                                                                         %
+%   This program is free software; you can redistribute it and/or modify  %
+%   it under the terms of the GNU Lesser General Public License as        %
+%   published by the Free Software Foundation; either version 2 of the    %
+%   License, or (at your option) any later version.                       %
+%                                                                         %
+%   This program is distributed in the hope that it will be useful,       %
+%   but WITHOUT ANY WARRANTY; without even the implied warranty of        %
+%   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         %
+%   GNU General Public License for more details.                          %
+%                                                                         %
+%   You should have received a copy of the GNU General Public License     %
+%   along with this program; if not, write to the                         %
+%   Free Software Foundation, Inc.,                                       %
+%   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%
+%% @doc WARNING: Interfaces around management of  networking are under
+%% revision and may change without notice.
+%%
 -module(network).
 
--export([open/0, setup/2]).
+-export([setup/1, ifconfig/0]).
 
-open() ->
-    open_port({spawn, "network"}, []).
+setup(Config) ->
+    call({setup, Config}).
 
-setup(Network, Config) ->
-    Network ! {self(), make_ref(), setup, Config},
+
+ifconfig() ->
+    call(ifconfig).
+
+
+%% Internal operations
+
+call(Msg) ->
+    Pid = get_pid(),
+    Ref = erlang:make_ref(),
+    Pid ! {self(), Ref, Msg},
     receive
-        Ret ->
+        {Ref, Ret} ->
             Ret
     end.
+
+get_pid() ->
+    case erlang:whereis(network) of
+        undefined ->
+            start();
+        Pid -> Pid
+    end.
+
+start() ->
+    Pid = erlang:open_port({spawn, "network"}, []),
+    erlang:register(network, Pid),
+    Pid.

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -23,6 +23,8 @@ if(${CMAKE_GENERATOR} STREQUAL "Xcode")
         memory.h
         module.h
         opcodesswitch.h
+        network.h
+        network_driver.h
         nifs.h
         port.h
         scheduler.h
@@ -50,6 +52,7 @@ set(SOURCE_FILES
     mailbox.c
     memory.c
     module.c
+    network.c
     nifs.c
     port.c
     scheduler.c

--- a/src/libAtomVM/network.c
+++ b/src/libAtomVM/network.c
@@ -1,0 +1,81 @@
+/***************************************************************************
+ *   Copyright 2018 by Davide Bettio <davide@uninstall.it>                 *
+ *   Copyright 2018 by Fred Dushin <fred@dushin.net>                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License as        *
+ *   published by the Free Software Foundation; either version 2 of the    *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        *
+ ***************************************************************************/
+
+#include "ccontext.h"
+#include "port.h"
+#include "network.h"
+#include "network_driver.h"
+
+#include "context.h"
+#include "globalcontext.h"
+#include "mailbox.h"
+#include "utils.h"
+#include "term.h"
+
+static const char *const setup_a = "\x5" "setup";
+static const char *const ifconfig_a = "\x8" "ifconfig";
+
+static void network_consume_mailbox(Context *ctx)
+{
+    Message *message = mailbox_dequeue(ctx);
+    term msg = message->message;
+    
+    if (port_is_standard_port_command(msg)) {
+        CContext ccontext;
+        CContext *cc = &ccontext;
+        ccontext_init(cc, ctx);
+        
+        port_ensure_available(ctx, 32);
+        
+        term_ref pid = ccontext_make_term_ref(cc, term_get_tuple_element(msg, 0));
+        term_ref ref = ccontext_make_term_ref(cc, term_get_tuple_element(msg, 1));
+        term cmd = term_get_tuple_element(msg, 2);
+        
+        if (term_is_atom(cmd) && cmd == context_make_atom(ctx, ifconfig_a)) {
+            term_ref reply = network_driver_ifconfig(cc);
+            port_send_reply(cc, pid, ref, reply);
+        } else if (term_is_tuple(cmd) && term_get_tuple_arity(cmd) == 2) {
+            term cmd_name = term_get_tuple_element(cmd, 0);
+            term config = term_get_tuple_element(cmd, 1);
+            if (cmd_name == context_make_atom(ctx, setup_a)) {
+                network_driver_setup(cc, pid, ref, config);
+            } else {
+                port_send_reply(cc, pid, ref, port_create_error_tuple(cc, "unrecognized tuple command"));
+            }
+        } else {
+            port_send_reply(cc, pid, ref, port_create_error_tuple(cc, "unrecognized command"));
+        }
+
+        ccontext_release_all_refs(cc);
+    } else {
+        fprintf(stderr, "WARNING: Invalid port command.  Unable to send reply");
+    }
+
+    free(message);
+}
+
+
+void network_init(Context *ctx, term opts)
+{
+    UNUSED(opts);
+    ctx->native_handler = network_consume_mailbox;
+    ctx->platform_data = NULL;
+}
+

--- a/src/libAtomVM/network.h
+++ b/src/libAtomVM/network.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright 2018 by Davide Bettio <davide@uninstall.it>                 *
- *   Copyright 2018 by Fred Dushin <fred@dushin.net>                       *
+ *   Copyright 2018 by Fred Dushin <fred@dushin.nt>                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU Lesser General Public License as        *
@@ -18,16 +18,12 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        *
  ***************************************************************************/
 
-#include "network_driver.h"
-#include "port.h"
+#ifndef _NETWORK_H_
+#define _NETWORK_H_
 
-void network_driver_setup(CContext *cc, term_ref pid, term_ref ref, term config)
-{
-    UNUSED(config);
-    port_send_reply(cc, pid, ref, port_create_error_tuple(cc, "unimplemented"));
-}
+#include "context.h"
+#include "term.h"
 
-term_ref network_driver_ifconfig(CContext *cc)
-{
-    return port_create_error_tuple(cc, "unimplemented");
-}
+void network_init(Context *ctx, term opts);
+
+#endif

--- a/src/libAtomVM/network_driver.h
+++ b/src/libAtomVM/network_driver.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright 2018 by Davide Bettio <davide@uninstall.it>                 *
+ *   Copyright 2018 by Fred Dushin <fred@dushin.nt>                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU Lesser General Public License as        *
@@ -17,11 +18,13 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        *
  ***************************************************************************/
 
-#ifndef _NETWORKDRIVER_H_
-#define _NETWORKDRIVER_H_
+#ifndef _NETWORK_DRIVER_H_
+#define _NETWORK_DRIVER_H_
 
-#include "context.h"
+#include "ccontext.h"
+#include "term.h"
 
-void networkdriver_init(Context *ctx);
+void network_driver_setup(CContext *cc, term pid, term_ref ref, term config);
+term_ref network_driver_ifconfig(CContext *cc);
 
 #endif

--- a/src/platforms/esp32/main/sys.c
+++ b/src/platforms/esp32/main/sys.c
@@ -24,7 +24,7 @@
 #include "globalcontext.h"
 #include "socket.h"
 #include "gpio_driver.h"
-#include "network_driver.h"
+#include "network.h"
 
 #include "freertos/FreeRTOS.h"
 #include "esp_system.h"
@@ -136,7 +136,7 @@ Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
     if (!strcmp(driver_name, "socket")) {
         socket_init(new_ctx, opts);
     } else if (!strcmp(driver_name, "network")) {
-        networkdriver_init(new_ctx);
+        network_init(new_ctx, opts);
     } else if (!strcmp(driver_name, "gpio")) {
         gpiodriver_init(new_ctx);
     } else {

--- a/src/platforms/generic_unix/sys.c
+++ b/src/platforms/generic_unix/sys.c
@@ -25,7 +25,7 @@
 #include "scheduler.h"
 #include "socket.h"
 #include "gpio_driver.h"
-#include "network_driver.h"
+#include "network.h"
 #include "utils.h"
 
 #include <limits.h>
@@ -209,7 +209,7 @@ Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
     if (!strcmp(driver_name, "socket")) {
         socket_init(new_ctx, opts);
     } else if (!strcmp(driver_name, "network")) {
-        networkdriver_init(new_ctx);
+        network_init(new_ctx, opts);
     } else if (!strcmp(driver_name, "gpio")) {
         gpiodriver_init(new_ctx);
     } else {


### PR DESCRIPTION
This change set makes an initial set of improvements to the network port driver, including:

* Factored out common parts of the port driver code (the parts that interface directly with AtomVM i/o parameters) into a common set of functions in the libAtomVM module, similar to patterns used in the socket and console drivers;
* Modified the protocol between AtomVM and the network driver to use a reference, to support selective receive;
* Added a setup_network example.

This is part of a multi-phase change to this driver.  Subsequent changes will include a re-design of the network interface, to allow applications to respond to events in the Wifi driver, such as connect, disconnect, and IP acquisition events, as well as acquisition of netwrk information (e.g., ifconfig) and documentation as the interfaces settle down.  Further changes after that will support SoftAP and combined SoftAP+STA mode, as well as support for wifi scan.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.