### PR TITLE
Add support for apply/1 (#112) opcode.

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -160,6 +160,19 @@ int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string)
     return (int) atom_index;
 }
 
+AtomString globalcontext_atomstring_from_term(GlobalContext *glb, term t)
+{
+    if (!term_is_atom(t)) {
+        abort();
+    }
+    unsigned long atom_index = term_to_atom_index(t);
+    unsigned long ret = valueshashtable_get_value(glb->atoms_ids_table, atom_index, ULONG_MAX);
+    if (ret == ULONG_MAX) {
+        return NULL;
+    }
+    return (AtomString) ret;
+}
+
 int globalcontext_insert_module(GlobalContext *global, Module *module, AtomString module_name_atom)
 {
     if (!atomshashtable_insert(global->modules_table, module_name_atom, TO_ATOMSHASHTABLE_VALUE(module))) {

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -31,6 +31,7 @@
 #include <time.h>
 
 #include "atom.h"
+#include "term.h"
 #include "linkedlist.h"
 
 struct Context;
@@ -138,6 +139,20 @@ int globalcontext_get_registered_process(GlobalContext *glb, int atom_index);
  * @returns newly added atom id or -1 in case of failure.
  */
 int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string);
+
+/**
+ * @brief   Returns the AtomString value of a term.
+ *
+ * @details This function fetches the AtomString value of the atom associated
+ *          with the supplied term.  The input term must be an atom type.
+ *          If no such atom is registered in the global table, this function
+ *          returns NULL.  The caller should NOT free the data associated with
+ *          the returned value.
+ * @param   glb the global context
+ * @param   t the atom term
+ * @returns the AtomString associated with the supplied atom term.
+ */
+AtomString globalcontext_atomstring_from_term(GlobalContext *glb, term t);
 
 /*
  * @brief Insert an already loaded module with a certain filename to the modules table.

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -429,10 +429,8 @@ static term nif_erlang_spawn_3(Context *ctx, int argc, term argv[])
 
     Context *new_ctx = context_new(ctx->global);
 
-    int mod_atom_index = term_to_atom_index(argv[0]);
-    AtomString module_string = (AtomString) valueshashtable_get_value(ctx->global->atoms_ids_table, mod_atom_index, (unsigned long) NULL);
-    int func_atom_index = term_to_atom_index(argv[1]);
-    AtomString function_string = (AtomString) valueshashtable_get_value(ctx->global->atoms_ids_table, func_atom_index, (unsigned long) NULL);
+    AtomString module_string = globalcontext_atomstring_from_term(ctx->global, argv[0]);
+    AtomString function_string = globalcontext_atomstring_from_term(ctx->global, argv[1]);
 
     Module *found_module = globalcontext_get_module(ctx->global, module_string);
     if (UNLIKELY(!found_module)) {

--- a/src/platforms/generic_unix/mapped_file.c
+++ b/src/platforms/generic_unix/mapped_file.c
@@ -39,7 +39,6 @@ MappedFile *mapped_file_open_beam(const char *file_name)
 
     mf->fd = open(file_name, O_RDONLY);
     if (UNLIKELY(mf->fd < 0)) {
-        fprintf(stderr, "Cannot open %s\n", file_name);
         free(mf);
         return NULL;
     }

--- a/src/platforms/generic_unix/sys.c
+++ b/src/platforms/generic_unix/sys.c
@@ -177,6 +177,9 @@ Module *sys_load_module(GlobalContext *global, const char *module_name)
     MappedFile *beam_file = NULL;
     if (!(global->avmpack_data && avmpack_find_section_by_name(global->avmpack_data, module_name, &beam_module, &beam_module_size))) {
         beam_file = mapped_file_open_beam(module_name);
+        if (IS_NULL_PTR(beam_file)) {
+            return NULL;
+        }
         if (UNLIKELY(!iff_is_valid_beam(beam_file->mapped))) {
             fprintf(stderr, "%s is not a valid BEAM file.\n", module_name);
         }

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -103,6 +103,7 @@ compile_erlang(test_bif_badargument)
 compile_erlang(test_bif_badargument2)
 compile_erlang(test_bif_badargument3)
 compile_erlang(test_tuple_nifs_badargs)
+compile_erlang(test_apply)
 compile_erlang(long_atoms)
 compile_erlang(test_concat_badarg)
 compile_erlang(register_and_whereis_badarg)
@@ -275,6 +276,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_bif_badargument2.beam
     test_bif_badargument3.beam
     test_tuple_nifs_badargs.beam
+    test_apply.beam
     long_atoms.beam
     test_concat_badarg.beam
     register_and_whereis_badarg.beam

--- a/tests/erlang_tests/test_apply.erl
+++ b/tests/erlang_tests/test_apply.erl
@@ -1,0 +1,26 @@
+-module(test_apply).
+
+-export([start/0, add/2]).
+
+start() ->
+    NoModule = try_apply(list_to_atom("foo"), list_to_atom("bar")),
+    NoFunction = try_apply(?MODULE, no_such_function),
+    Initial = NoModule + NoFunction,
+    do_apply({?MODULE, add}, {erlang, list_to_integer}, ["1","2","3","4","5"], Initial).
+
+do_apply(_, _, [], Sum) ->
+    Sum;
+do_apply({M1, F1} = MF1, {M2, F2} = MF2, [H|T], Sum) ->
+    NewSum = M1:F1(M2:F2(H), Sum),
+    do_apply(MF1, MF2, T, NewSum).
+
+add(A, B) ->
+    A + B.
+
+
+try_apply(M, F) ->
+    try
+        M:F(), 0
+    catch
+        _Class:_Reason -> 1
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -216,6 +216,8 @@ struct Test tests[] =
     {"copy_terms17.beam", 11},
     {"copy_terms18.beam", -19},
 
+    {"test_apply.beam", 17},
+
     //TEST CRASHES HERE: {"memlimit.beam", 0},
 
     {NULL, 0}


### PR DESCRIPTION
This PR adds support for the apply/1 opcode (#112), which supports Module:Function(...) calls.

An additional common function is added to the global_context module to simplify the retrieval of AtomStrings from term objects, and some code paths were cleaned up to allow for the possibility of loading code that does not exist (user error).  A unit test is added for exported module and NIF use cases, as well as for error conditions.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.