### PR TITLE
Added script for cleaning whitespace in source modules.

### DIFF
--- a/src/libAtomVM/avmpack.c
+++ b/src/libAtomVM/avmpack.c
@@ -125,6 +125,6 @@ void *avmpack_fold(void *accum, const void *avmpack_binary, avmpack_fold_fun fol
             offset += size;
         }
     } while(size > 0);
-    
+
     return accum;
 }

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -310,7 +310,7 @@ static term nif_erlang_open_port_2(Context *ctx, int argc, term argv[])
     }
 
     free(driver_name);
-    
+
     if (!new_ctx) {
         RAISE_ERROR(badarg_atom);
     } else {

--- a/src/platforms/esp32/main/sys.c
+++ b/src/platforms/esp32/main/sys.c
@@ -132,7 +132,7 @@ Module *sys_load_module(GlobalContext *global, const char *module_name)
 Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
 {
     Context *new_ctx = context_new(glb);
-    
+
     if (!strcmp(driver_name, "socket")) {
         socket_init(new_ctx, opts);
     } else if (!strcmp(driver_name, "network")) {
@@ -143,7 +143,7 @@ Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
         context_destroy(new_ctx);
         return NULL;
     }
-    
+
     return new_ctx;
 }
 

--- a/src/platforms/generic_unix/sys.c
+++ b/src/platforms/generic_unix/sys.c
@@ -208,7 +208,7 @@ void sys_platform_periodic_tasks()
 Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
 {
     Context *new_ctx = context_new(glb);
-    
+
     if (!strcmp(driver_name, "socket")) {
         socket_init(new_ctx, opts);
     } else if (!strcmp(driver_name, "network")) {
@@ -219,6 +219,6 @@ Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
         context_destroy(new_ctx);
         return NULL;
     }
-    
+
     return new_ctx;
 }

--- a/tools/dev/clean-whitespace.sh
+++ b/tools/dev/clean-whitespace.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+ROOT_DIR=$(cd $(dirname $0)/../.. && pwd)
+
+function clean_file {
+    file=$1
+    cat ${file} | sed "s/[ ]\+$//g" | sed -e '$a\' > ${file}.cleaned
+    if [ -n "$(diff ${file} ${file}.cleaned)" ]; then
+        cat ${file}.cleaned > ${file}
+        echo "Cleaned ${file}"
+    fi
+    rm ${file}.cleaned
+}
+
+cd ${ROOT_DIR}
+for f in $(git ls-files); do
+    case $f in
+        *.sh | *.erl | *.c | *.h | *.txt)
+            clean_file $f
+            ;;
+    esac
+done
+

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -72,7 +72,7 @@ static void usage(const char *program)
 int main(int argc, char **argv)
 {
     int opt;
-    
+
     const char *action = "pack";
     int is_archive = 0;
     while ((opt = getopt(argc, argv, "hal")) != -1) {
@@ -137,7 +137,7 @@ FileData read_file_data(FILE *file)
         exit(EXIT_FAILURE);
     }
     assert(fread(data, sizeof(uint8_t), size, file) == size);
-    
+
     FileData file_data = {
         .data = data,
         .size = size
@@ -188,11 +188,11 @@ static void validate_pack_options(int argc, char ** argv)
         }
     }
 }
-        
+
 static int do_pack(int argc, char **argv, int is_archive)
 {
     validate_pack_options(argc, argv);
-    
+
     FILE *pack = fopen(argv[0], "w");
     if (!pack) {
         char buf[BUF_SIZE];
@@ -224,7 +224,7 @@ static int do_pack(int argc, char **argv, int is_archive)
         fseek(file, 0, SEEK_END);
         size_t file_size = ftell(file);
         fseek(file, 0, SEEK_SET);
-        
+
 
         uint8_t *file_data = malloc(file_size);
         if (!file_data) {
@@ -239,17 +239,17 @@ static int do_pack(int argc, char **argv, int is_archive)
             pack_beam_file(pack, file_data, file_size, filename, !is_archive && i == 1);
         }
     }
-    
+
     add_module_header(pack, "end", END_OF_FILE);
     fclose(pack);
-    
+
     return EXIT_SUCCESS;
 }
 
 static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const char *section_name, int is_entrypoint)
 {
     size_t zero_pos = ftell(pack);
-    
+
     if (is_entrypoint) {
         add_module_header(pack, section_name, BEAM_CODE_FLAG | BEAM_START_FLAG);
     } else {
@@ -348,7 +348,7 @@ static int do_list(int argc, char **argv)
 {
     UNUSED(argc);
     validate_list_options(argv[0]);
-    
+
     MappedFile *mapped_file = mapped_file_open_beam(argv[0]);
     if (IS_NULL_PTR(mapped_file)) {
         char buf[BUF_SIZE];
@@ -356,7 +356,7 @@ static int do_list(int argc, char **argv)
         perror(buf);
         return EXIT_FAILURE;
     }
-    
+
     int ret = EXIT_SUCCESS;
     if (avmpack_is_valid(mapped_file->mapped, mapped_file->size)) {
         avmpack_fold(NULL, mapped_file->mapped, print_section);


### PR DESCRIPTION
This commit adds a script for cleaning source modules so that there are no modules with trailing whitespace and so that files end in the newline character appropriate for the platform.

In addition, whitespace fixes to existing source modules are made.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.