### PR TITLE
Adds a gen_server module and other enhancements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
       before_install:
         - eval "${MATRIX_EVAL}"
 
@@ -61,6 +63,8 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
       before_install:
         - eval "${MATRIX_EVAL}"
 
@@ -92,6 +96,8 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
       before_install:
         - eval "${MATRIX_EVAL}"
 
@@ -123,6 +129,8 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
       before_install:
         - eval "${MATRIX_EVAL}"
 
@@ -154,6 +162,8 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
       before_install:
         - eval "${MATRIX_EVAL}"
 
@@ -180,6 +190,8 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
 
     - name: "GCC 4.8 (with -O2, 32 bit) on Trusty with OTP 20"
       os: linux
@@ -209,6 +221,8 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
 
     - name: "clang 5 (with -O2) on Trusty with OTP 20"
       os: linux
@@ -233,6 +247,8 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
       before_install:
@@ -264,5 +280,7 @@ matrix:
         - make
         - valgrind ./tests/test-erlang
         - ./tests/test-erlang
+        - ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        - ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
       before_install:
         - eval "${MATRIX_EVAL}"

--- a/CMakeModules/BuildErlang.cmake
+++ b/CMakeModules/BuildErlang.cmake
@@ -7,13 +7,13 @@ macro(pack_archive avm_name)
 
     foreach(module_name ${ARGN})
         add_custom_command(
-            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.beam
-            COMMAND erlc ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/beams/${module_name}.beam
+            COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/beams && erlc -o ${CMAKE_CURRENT_BINARY_DIR}/beams -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
             COMMENT "Compiling ${module_name}.erl"
             VERBATIM
         )
-        set(BEAMS ${BEAMS} ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.beam)
+        set(BEAMS ${BEAMS} ${CMAKE_CURRENT_BINARY_DIR}/beams/${module_name}.beam)
     endforeach()
 
     add_custom_target(
@@ -38,7 +38,7 @@ macro(pack_runnable avm_name main)
 
     add_custom_command(
         OUTPUT ${main}.beam
-        COMMAND erlc ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
+        COMMAND erlc -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
         COMMENT "Compiling ${main}.erl"
         VERBATIM
@@ -76,7 +76,7 @@ macro(pack_test test_avm_name)
 
     add_custom_target(
         ${test_avm_name} ALL
-        COMMAND erlc ${CMAKE_CURRENT_SOURCE_DIR}/tests.erl
+        COMMAND erlc -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/tests.erl
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${CMAKE_CURRENT_BINARY_DIR}/${test_avm_name}.avm ${CMAKE_CURRENT_BINARY_DIR}/tests.beam ${ARCHIVES}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tests.erl
         COMMENT "Packing runnable ${test_avm_name}.avm"

--- a/examples/erlang/CMakeLists.txt
+++ b/examples/erlang/CMakeLists.txt
@@ -8,6 +8,7 @@ include(BuildErlang)
 
 add_subdirectory(esp32)
 
-pack_runnable(hello_world hello_world estdlib)
-pack_runnable(udp_server udp_server estdlib)
-pack_runnable(udp_client udp_client estdlib)
+pack_runnable(hello_world hello_world eavmlib)
+pack_runnable(udp_server udp_server estdlib eavmlib)
+pack_runnable(udp_client udp_client estdlib eavmlib)
+pack_runnable(server server estdlib eavmlib)

--- a/examples/erlang/server.erl
+++ b/examples/erlang/server.erl
@@ -1,0 +1,36 @@
+-module(server).
+
+-export([start/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-record(state, {
+    %% fun stuff goes here
+}).
+
+
+start() ->
+    {ok, Pid} = gen_server:start(?MODULE, [], []),
+    Reply = gen_server:call(Pid, hello),
+    erlang:display(Reply),
+    ok.
+
+
+init(Args) ->
+    console:puts("init: "), erlang:display(Args),
+    {ok, #state{}}.
+
+handle_call(hello, _From, State) ->
+    {reply, hi, State};
+handle_call(Request, _From, State) ->
+    {reply, {unknown, Request}, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(Info, State) ->
+    erlang:display(Info),
+    {noreply, State}.
+
+terminate(Reason, _State) ->
+    erlang:display(Reason),
+    ok.

--- a/libs/eavmlib/CMakeLists.txt
+++ b/libs/eavmlib/CMakeLists.txt
@@ -7,7 +7,9 @@ project(eavmlib)
 include(BuildErlang)
 
 set(ERLANG_MODULES
+    console
     gpio
+    logger
     network
 )
 

--- a/libs/eavmlib/console.erl
+++ b/libs/eavmlib/console.erl
@@ -25,8 +25,6 @@
 
 -export([start/0, puts/1, puts/2, flush/0, flush/1]).
 
--opaque console() :: any().
-
 %%-----------------------------------------------------------------------------
 %% @param   String the string data to write to the console
 %% @returns ok if the data was written, or {error, Reason}, if there was
@@ -44,7 +42,7 @@ puts(String) ->
     puts(get_pid(), String).
 
 %% @hidden
--spec puts(console(), string()) -> ok.
+-spec puts(pid(), string()) -> ok.
 puts(Console, String) ->
     call(Console, {puts, String}).
 
@@ -59,14 +57,14 @@ flush() ->
     flush(get_pid()).
 
 %% @hidden
--spec flush(console()) -> ok.
+-spec flush(pid()) -> ok.
 flush(Console) ->
     call(Console, flush).
 
 %% Internal operations
 
 %% @private
--spec call(console(), string()) -> ok.
+-spec call(pid(), string()) -> ok.
 call(Console, Msg) ->
     Ref = make_ref(),
     Console ! {self(), Ref, Msg},
@@ -75,7 +73,7 @@ call(Console, Msg) ->
     end.
 
 %% @private
--spec get_pid() -> console().
+-spec get_pid() -> pid().
 get_pid() ->
     case whereis(console) of
         undefined ->
@@ -85,7 +83,7 @@ get_pid() ->
     end.
 
 %% @private
--spec start() -> console().
+-spec start() -> pid().
 start() ->
     Pid = erlang:open_port({spawn, "console"}, []),
     erlang:register(console, Pid),

--- a/libs/eavmlib/logger.erl
+++ b/libs/eavmlib/logger.erl
@@ -1,0 +1,141 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%   Copyright 2019 by Fred Dushin <fred@dushin.net>                       %
+%                                                                         %
+%   This program is free software; you can redistribute it and/or modify  %
+%   it under the terms of the GNU Lesser General Public License as        %
+%   published by the Free Software Foundation; either version 2 of the    %
+%   License, or (at your option) any later version.                       %
+%                                                                         %
+%   This program is distributed in the hope that it will be useful,       %
+%   but WITHOUT ANY WARRANTY; without even the implied warranty of        %
+%   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         %
+%   GNU General Public License for more details.                          %
+%                                                                         %
+%   You should have received a copy of the GNU General Public License     %
+%   along with this program; if not, write to the                         %
+%   Free Software Foundation, Inc.,                                       %
+%   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%-----------------------------------------------------------------------------
+%% @doc A simple logging module.
+%%
+%% This module can be used to log messages to the console.
+%%
+%% Most applications should use the logging macros defined in logger.hrl
+%% to do logging.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(logger).
+
+-export([start/0, start/1, log/3, stop/0]).
+-export([loop/1]).
+
+-record(state, {
+    pid,
+    config
+}).
+
+-type location() :: {
+    Module::module(), Function::atom(), Arity::non_neg_integer(), Line::non_neg_integer()
+}.
+-type level() :: debug | info | warning | error.
+-type config_item() :: {levels, [level()]}.
+-type config() :: [config_item()].
+
+%%-----------------------------------------------------------------------------
+%% @equiv   start([{levels, [info, warning, error]}])
+%% @doc     Start the logger.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start() -> {ok, pid()}.
+start() ->
+    start([{levels, [info, warning, error]}]).
+
+%%-----------------------------------------------------------------------------
+%% @param   Config the logging configuration
+%% @returns {ok, Pid}
+%% @doc     Start the logger.
+%%
+%%          This function will start the logger with the specified configuration.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start(Config::config()) -> {ok, pid()}.
+start(Config) ->
+    LoggerPid = case whereis(?MODULE) of
+        undefined ->
+            State = #state{pid=self(), config=Config},
+            Pid = spawn(?MODULE, loop, [State]),
+            receive
+                started -> ok
+            end,
+            erlang:register(?MODULE, Pid),
+            Pid;
+        Pid -> Pid
+    end,
+    {ok, LoggerPid}.
+
+%%-----------------------------------------------------------------------------
+%% @doc     Stop the logger.
+%%
+%%          This function is rarely used.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec stop() -> ok.
+stop() ->
+    {ok, Pid} = maybe_start(whereis(?MODULE)),
+    Pid ! stop,
+    ok.
+
+%%-----------------------------------------------------------------------------
+%% @param   Location the location in the source module
+%% @doc     Log a message the the specified location with the specified level.
+%%
+%%          Users should use the logging macros in logger.hrl instead of
+%%          calling this function directly.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec log(Location::location(), Level::level(), Msg::term()) -> ok.
+log(Location, Level, Msg) ->
+    {ok, Pid} = maybe_start(whereis(?MODULE)),
+    Pid ! {Location, erlang:universaltime(), self(), Level, Msg},
+    ok.
+
+%%
+%% Internal operations
+%%
+
+%% @private
+loop(#state{pid=Pid, config=Config} = State0) ->
+    State = case Pid of
+        undefined -> State0;
+        _ ->
+            Pid ! started,
+            State0#state{pid=undefined}
+    end,
+    receive
+        {_Location, _Time, _Pid, Level, _Msg} = Request ->
+            do_log(Request, Level, proplists:get_value(levels, Config)),
+            loop(State);
+        stop ->
+            ok;
+        _ ->
+            loop(State)
+    end.
+
+%% @private
+maybe_start(undefined) ->
+    start();
+maybe_start(Pid) ->
+    {ok, Pid}.
+
+%% @private
+do_log(_Request, _Level, undefined) ->
+    ok;
+do_log(Request, Level, Levels) ->
+    case lists:member(Level, Levels) of
+        true ->
+            erlang:display(Request);
+        _ ->
+            ok
+    end.

--- a/libs/estdlib/CMakeLists.txt
+++ b/libs/estdlib/CMakeLists.txt
@@ -8,11 +8,12 @@ include(BuildErlang)
 
 set(ERLANG_MODULES
     calendar
-    console
+    erlang
+    gen_server
     gen_udp
     lists
+    proplists
     timer
-    erlang
 )
 
 pack_archive(estdlib ${ERLANG_MODULES})

--- a/libs/estdlib/gen_server.erl
+++ b/libs/estdlib/gen_server.erl
@@ -1,0 +1,304 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%   Copyright 2019 by Fred Dushin <fred@dushin.net>                       %
+%                                                                         %
+%   This program is free software; you can redistribute it and/or modify  %
+%   it under the terms of the GNU Lesser General Public License as        %
+%   published by the Free Software Foundation; either version 2 of the    %
+%   License, or (at your option) any later version.                       %
+%                                                                         %
+%   This program is distributed in the hope that it will be useful,       %
+%   but WITHOUT ANY WARRANTY; without even the implied warranty of        %
+%   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         %
+%   GNU General Public License for more details.                          %
+%                                                                         %
+%   You should have received a copy of the GNU General Public License     %
+%   along with this program; if not, write to the                         %
+%   Free Software Foundation, Inc.,                                       %
+%   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of the Erlang/OTP gen_server interface.
+%%
+%% This module implements a strict susbset of the Erlang/OTP gen_server
+%% interface, supporting operations for local creation and management of
+%% gen_server instances.
+%%
+%% This module is designed to be API-compatible with gen_udp, with exceptions noted
+%% below.
+%%
+%% Caveats:
+%% <ul>
+%%     <li>No support for start_link</li>
+%%     <li>Support only for locally named procs</li>
+%%     <li>No support for abcast</li>
+%%     <li>No support for enter_loop</li>
+%%     <li>No support for format_status</li>
+%%     <li>No support for multi_call</li>
+%% </ul>
+%% @end
+%%-----------------------------------------------------------------------------
+-module(gen_server).
+
+-export([start/3, start/4, stop/1, stop/3, call/2, call/3, cast/2, reply/2]).
+-export([loop/1]).
+
+-record(state, {
+    name = undefined :: atom(),
+    mod :: module(),
+    mod_state :: term()
+}).
+
+-include("logger.hrl").
+
+-type options() :: list({atom(), term()}).
+-type server_ref() :: atom() | pid().
+
+
+%%-----------------------------------------------------------------------------
+%% @param   ServerName the name with which to register the gen_server
+%% @param   Module the module in which the gen_server callbacks are defined
+%% @param   Args the arguments to pass to the module's init callback
+%% @param   Options the options used to create the gen_server
+%% @returns the gen_server pid, if successfule; {error, Reason}, otherwise.
+%% @doc     Start a named gen_server.
+%%
+%%          This function will start a gen_server instance and register the
+%%          newly created process with the process registry.  Subsequent calls
+%%          may use the gen_server name, in lieu of the process id.
+%%
+%%          <em><b>Note.</b>  The Options argument is currently ignored.</em>
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start(ServerName::{local, Name::atom()}, Module::module(), Args::term(), Options::options()) -> {ok, pid()} | {error, Reason::term()}.
+start({local, Name}, Module, Args, Options) when is_atom(Name) ->
+    ?LOG_DEBUG({{local, Name}, Module, Args, Options}),
+    case erlang:whereis(Name) of
+        undefined ->
+            Response = start(Module, Args, [{name, Name} | Options]),
+            ?LOG_DEBUG({start_response, Response}),
+            case Response of
+                {ok, Pid} ->
+                    ?LOG_DEBUG({registering, Name, Pid}),
+                    erlang:register(Name, Pid),
+                    ok;
+                _ -> ok
+            end,
+            ?LOG_DEBUG({returning_response, Response}),
+            Response;
+        _Pid ->
+            {error, already_started}
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Module the module in which the gen_server callbacks are defined
+%% @param   Args the arguments to pass to the module's init callback
+%% @param   Options the options used to create the gen_server
+%% @returns the gen_server pid, if successfule; {error, Reason}, otherwise.
+%% @doc     Start an un-named gen_server.
+%%
+%%          This function will start a gen_server instance.
+%%
+%%          <em><b>Note.</b>  The Options argument is currently ignored.</em>
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start(Module::module(), Args::term(), Options::options()) -> {ok, pid()} | {error, Reason::term()}.
+start(Module, Args, Options) ->
+    ?LOG_DEBUG({Module, Args, Options}),
+    case Module:init(Args) of
+        {ok, ModState} ->
+            State = #state{
+                name = proplists:get_value(name, Options),
+                mod = Module,
+                mod_state = ModState
+            },
+            ?LOG_DEBUG({spawning_loop, State}),
+            Pid = spawn(?MODULE, loop, [State]),
+            ?LOG_DEBUG(ok),
+            {ok, Pid};
+        {stop, Reason} ->
+            {error, {init_stopped, Reason}};
+        _ ->
+            {error, unexepcted_reply_from_init}
+    end.
+
+
+%%-----------------------------------------------------------------------------
+%% @equiv   stop(ServerRef, normal, infinity)
+%% @doc     Stop a previously started gen_server instance.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec stop(ServerRef::server_ref()) -> ok | {error, Reason::term()}.
+stop(ServerRef) ->
+    stop(ServerRef, normal, infinity).
+
+%%-----------------------------------------------------------------------------
+%% @param   ServerRef a reference to the gen_server acquired via start
+%% @returns ok, if the gen_server stopped; {error, Reason}, otherwise.
+%% @doc     Stop a previously started gen_server instance.
+%%
+%%          This function will stop a gen_server instance, providing the supplied
+%%          Reason to the gen_server's terminate/2 callback function.
+%%          If the gen_server is named, then the gen_server name may be used
+%%          to stop the gen_server.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec stop(ServerRef::server_ref(), Reason::term(), Timeout::non_neg_integer() | infinity) -> ok | {error, Reason::term()}.
+stop(Name, Reason, Timeout) when is_atom(Name) ->
+    case erlang:whereis(Name) of
+        undefined ->
+            {error, undefined};
+        Pid when is_pid(Pid) ->
+            stop(Pid, Reason, Timeout)
+    end;
+stop(Pid, Reason, Timeout) when is_pid(Pid) ->
+    Ref = erlang:make_ref(),
+    call_internal(Pid, Ref, {'$stop', self(), Ref, Reason}, Timeout).
+
+%%-----------------------------------------------------------------------------
+%% @equiv   call(ServerRef, Request, 5000)
+%% @doc     Send a request to a gen_server instance, and wait for a reply.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec call(ServerRef::server_ref(), Request::term) -> Reply::term() | {error, Reason::term()}.
+call(ServerRef, Request) ->
+    call(ServerRef, Request, 5000).
+
+%%-----------------------------------------------------------------------------
+%% @param   ServerRef a reference to the gen_server acquired via start
+%% @param   Request the request to send to the gen_server
+%% @param   Timeout the amount of time in milliseconds to wait for a reply
+%% @returns the reply sent back from the gen_server; {error, Reason}, otherwise.
+%% @doc     Send a request to a gen_server instance, and wait for a reply.
+%%
+%%          This function will send the specified request to the specified
+%%          gen_server instance, and wait at least Timeout milliseconds for a
+%%          reply from the gen_server.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec call(ServerRef::server_ref(), Request::term(), Timeout::timeout()) -> Reply::term() | {error, Reason::term()}.
+call(Name, Request, Timeout) when is_atom(Name) ->
+    case erlang:whereis(Name) of
+        undefined ->
+            {error, undefined};
+        Pid when is_pid(Pid) ->
+            call(Pid, Request, Timeout)
+    end;
+call(Pid, Request, Timeout) when is_pid(Pid) ->
+    Ref = erlang:make_ref(),
+    call_internal(Pid, Ref, {'$call', self(), Ref, Request}, Timeout).
+
+%%-----------------------------------------------------------------------------
+%% @param   ServerRef a reference to the gen_server acquired via start
+%% @param   Request the request to send to the gen_server
+%% @returns ok | {error, Reason}
+%% @doc     Send a request to a gen_server instance.
+%%
+%%          This function will send the specified request to the specified
+%%          gen_server instance, but will not wait for a reply.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec cast(ServerRef::server_ref(), Request::term()) -> ok | {error, Reason::term()}.
+cast(Name, Request) when is_atom(Name) ->
+    ?LOG_DEBUG({cast, Name, Request}),
+    case erlang:whereis(Name) of
+        undefined ->
+            {error, undefined};
+        Pid when is_pid(Pid) ->
+            cast(Pid, Request)
+    end;
+cast(Pid, Request) when is_pid(Pid) ->
+    ?LOG_DEBUG({cast, Pid, Request}),
+    Pid ! {'$cast', Request},
+    ok.
+
+%%-----------------------------------------------------------------------------
+%% @param   Client the client to whom to send the reply
+%% @param   Reply the reply to send to the client
+%% @returns an arbitrary term, that should be ignored
+%% @doc     Send a reply to a calling client.
+%%
+%%          This function will send the specified reply back to the specified
+%%          gen_server client (e.g, via call/3).  The return value of this
+%%          function can be safely ignored.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec reply(Client::term(), Reply::term) -> term().
+reply({Pid, Ref} = _Client, Reply) ->
+    ?LOG_DEBUG({reply, {{Pid, Ref}, Reply}}),
+    Pid ! {Ref, Reply}, ok.
+
+
+%%
+%% Internal operations
+%%
+
+%% @private
+call_internal(Pid, Ref, Msg, Timeout) ->
+    ?LOG_DEBUG({call_internal, Pid, Ref, Msg, Timeout}),
+    Pid ! Msg,
+    ?LOG_DEBUG({waiting, Ref, Timeout}),
+    receive
+        {Ref, Reply} ->
+        ?LOG_DEBUG({reply, Reply}),
+        Reply
+    after Timeout ->
+        %% throw(timeout)
+        {error, timeout}
+    end.
+
+%% @private
+loop(#state{mod=Mod, mod_state=ModState} = State) ->
+    ?LOG_DEBUG({loop, State}),
+    receive
+        {'$call', Pid, Ref, Request} ->
+            ?LOG_DEBUG({'$call', Pid, Ref, Request}),
+            case Mod:handle_call(Request, {Pid, Ref}, ModState) of
+                {reply, Reply, NewModState} ->
+                    Pid ! {Ref, Reply},
+                    loop(State#state{mod_state=NewModState});
+                {noreply, NewModState} ->
+                    ?LOG_DEBUG({noreply, NewModState}),
+                    loop(State#state{mod_state=NewModState});
+                {stop, Reason, Reply, NewModState} ->
+                     Pid ! {Ref, Reply},
+                     do_terminate(State, Reason, NewModState);
+                {stop, Reason, NewModState} ->
+                    do_terminate(State, Reason, NewModState);
+                _ ->
+                    do_terminate(State, {error, unexpected_reply}, ModState)
+            end;
+        {'$cast', Request} ->
+            ?LOG_DEBUG({'$cast', Request}),
+            case Mod:handle_cast(Request, ModState) of
+                {noreply, NewModState} ->
+                    loop(State#state{mod_state=NewModState});
+                {stop, Reason, NewModState} ->
+                    do_terminate(State, Reason, NewModState);
+                _ ->
+                    do_terminate(State, {error, unexpected_reply}, ModState)
+            end;
+        {'$stop', Pid, Ref, Reason} ->
+            ?LOG_DEBUG({'$stop', Pid, Ref, Reason}),
+            do_terminate(State, Reason, ModState),
+            Pid ! {Ref, ok};
+        Info ->
+            ?LOG_DEBUG({'Info', Info}),
+            case Mod:handle_info(Info, ModState) of
+                {noreply, NewModState} ->
+                    loop(State#state{mod_state=NewModState});
+                {stop, Reason, NewModState} ->
+                    do_terminate(State, Reason, NewModState);
+                _ ->
+                    do_terminate(State, {error, unexpected_reply}, ModState)
+            end
+    end.
+
+%% @private
+do_terminate(#state{mod=Mod, name=Name} = _State, Reason, ModState) ->
+    case Name of
+        undefined -> ok;
+        _Pid -> ok %% TODO unregister
+    end,
+    Mod:terminate(Reason, ModState),
+    ok.

--- a/libs/estdlib/proplists.erl
+++ b/libs/estdlib/proplists.erl
@@ -1,5 +1,5 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%    Copyright 2017 by Davide Bettio <davide@uninstall.it>                %
+%   Copyright 2019 by Fred Dushin <fred@dushin.net>                       %
 %                                                                         %
 %   This program is free software; you can redistribute it and/or modify  %
 %   it under the terms of the GNU Lesser General Public License as        %
@@ -18,44 +18,47 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%-----------------------------------------------------------------------------
-%% @doc An implementation of the Erlang/OTP lists interface.
+%% @doc An implementation of the Erlang/OTP proplists interface.
 %%
-%% This module implements a strict susbset of the Erlang/OTP lists
+%% This module implements a strict susbset of the Erlang/OTP proplists
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
--module(lists).
+-module(proplists).
 
--export([nth/2, member/2]).
+-export([get_value/2, get_value/3]).
+
+-type property() :: atom() | {atom(), term()}.
 
 %%-----------------------------------------------------------------------------
-%% @param   N the index in the list to get
-%% @param   L the list from which to get the value
-%% @returns the value in the list at position N.
-%% @doc     Get the value in a list at position N.
+%% @equiv   get_value(Key, List, undefined)
+%% @doc     Get a value from a property list.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get_value(Key::atom(), List::list(property())) -> term() | true | undefined.
+get_value(Key, List) ->
+    get_value(Key, List, undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key the key with which to find the value
+%% @param   List the property list from which to get the value
+%% @param   Default the default value to return, if Key is not in the property list.
+%% @returns the value in the property list under the key, or Default, if Key is
+%%          not in List.
+%% @doc     Get a value from a property list.
 %%
-%%          Returns the value at the specified position in the list.
-%%          The bhavior of this function is undefined if N is outside of the
-%%          {1..length(L)}.
+%%          Returns the value under the specified key, or the specified Default,
+%%          if the Key is not in the supplied List.  If the Key corresponds to
+%%          an entry in the property list that is just a single atom, this
+%%          function returns the atom true.
 %% @end
 %%-----------------------------------------------------------------------------
--spec nth(N::non_neg_integer(), L::list()) -> term().
-nth(1, [H | _T]) ->
-    H;
-nth(Index, [_H | T]) when Index > 1 ->
-    nth(Index - 1, T).
-
-%%-----------------------------------------------------------------------------
-%% @param   E the member to search for
-%% @param   L the list from which to get the value
-%% @returns true if E is a member of L; false, otherwise.
-%% @doc     Determine whether a term is a member of a list.
-%% @end
-%%-----------------------------------------------------------------------------
--spec member(E::term(), L::list()) -> boolean().
-member(_, []) ->
-    false;
-member(E, [E | _]) ->
+-spec get_value(Key::atom(), list(property()), Default::term()) -> term().
+get_value(_Key, [], Default) ->
+    Default;
+get_value(Key, [{Key, Value} | _T], _Default) when is_atom(Key) ->
+    Value;
+get_value(Key, [Key | _T], _Default) when is_atom(Key) ->
     true;
-member(E, [_ | T]) ->
-    member(E, T).
+get_value(Key, [_Key | T], Default) when is_atom(Key) ->
+    get_value(Key, T, Default).

--- a/libs/etest/etest.erl
+++ b/libs/etest/etest.erl
@@ -74,10 +74,10 @@ assert_true(_) -> fail.
 run_test(Test) ->
     try
         Test:test(),
-        console:puts("+")
+        console:puts("+"), console:flush()
     catch
         _:_ ->
-            console:puts("-"),
+            console:puts("-"), console:flush(),
             exception
     end.
 

--- a/libs/include/logger.hrl
+++ b/libs/include/logger.hrl
@@ -1,0 +1,23 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%   Copyright 2019 by Fred Dushin <fred@dushin.net>                       %
+%                                                                         %
+%   This program is free software; you can redistribute it and/or modify  %
+%   it under the terms of the GNU Lesser General Public License as        %
+%   published by the Free Software Foundation; either version 2 of the    %
+%   License, or (at your option) any later version.                       %
+%                                                                         %
+%   This program is distributed in the hope that it will be useful,       %
+%   but WITHOUT ANY WARRANTY; without even the implied warranty of        %
+%   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         %
+%   GNU General Public License for more details.                          %
+%                                                                         %
+%   You should have received a copy of the GNU General Public License     %
+%   along with this program; if not, write to the                         %
+%   Free Software Foundation, Inc.,                                       %
+%   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-define(LOG_INFO(Msg),      logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, info,     Msg)).
+-define(LOG_WARNING(Msg),   logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, warning,  Msg)).
+-define(LOG_ERROR(Msg),     logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, error,    Msg)).
+-define(LOG_DEBUG(Msg),     logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, debug,    Msg)).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ project (tests)
 if (NOT "${CMAKE_GENERATOR}" MATCHES "Xcode")
     add_subdirectory(erlang_tests)
     add_subdirectory(libs/estdlib)
+    add_subdirectory(libs/eavmlib)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)

--- a/tests/libs/eavmlib/CMakeLists.txt
+++ b/tests/libs/eavmlib/CMakeLists.txt
@@ -1,0 +1,14 @@
+##
+## Copyright (c) 2018 Fred Dushin <fred@dushin.net>
+##
+
+project(test_eavmlib)
+
+include(BuildErlang)
+
+set(ERLANG_MODULES
+    test_logger
+)
+
+pack_archive(test_eavmlib_lib ${ERLANG_MODULES})
+pack_test(test_eavmlib eavmlib estdlib etest)

--- a/tests/libs/eavmlib/test_logger.erl
+++ b/tests/libs/eavmlib/test_logger.erl
@@ -1,0 +1,13 @@
+-module(test_logger).
+
+-export([test/0]).
+
+-include("logger.hrl").
+
+test() ->
+    ok = ?LOG_INFO(ok),
+    ok = ?LOG_WARNING(ok),
+    ok = ?LOG_ERROR(ok),
+    ok = ?LOG_DEBUG(ok),
+
+    ok.

--- a/tests/libs/eavmlib/tests.erl
+++ b/tests/libs/eavmlib/tests.erl
@@ -1,0 +1,8 @@
+-module(tests).
+
+-export([start/0]).
+
+start() ->
+    etest:test([
+        test_logger
+    ]).

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -7,9 +7,11 @@ project(test_estdlib)
 include(BuildErlang)
 
 set(ERLANG_MODULES
-    test_timer
+    test_gen_server
     test_lists
+    test_proplists
+    test_timer
 )
 
 pack_archive(test_estdlib_lib ${ERLANG_MODULES})
-pack_test(test_estdlib estdlib etest)
+pack_test(test_estdlib estdlib eavmlib etest)

--- a/tests/libs/estdlib/test_gen_server.erl
+++ b/tests/libs/estdlib/test_gen_server.erl
@@ -1,0 +1,89 @@
+-module(test_gen_server).
+
+-export([test/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-record(state, {
+    num_casts=0,
+    num_infos=0
+}).
+
+test() ->
+    ok = test_call(),
+    ok = test_cast(),
+    ok = test_info(),
+    ok.
+
+test_call() ->
+    {ok, Pid} = gen_server:start(?MODULE, [], []),
+
+    pong = gen_server:call(Pid, ping),
+    pong = gen_server:call(Pid, reply_ping),
+    %pong = gen_server:call(Pid, async_ping),
+
+    gen_server:stop(Pid),
+    ok.
+
+test_cast() ->
+    {ok, Pid} = gen_server:start(?MODULE, [], []),
+
+    ok = gen_server:cast(Pid, ping),
+    ok = gen_server:cast(Pid, ping),
+    ok = gen_server:cast(Pid, ping),
+    ok = gen_server:cast(Pid, ping),
+    ok = gen_server:cast(Pid, ping),
+
+    5 = gen_server:call(Pid, get_num_casts),
+    0 = gen_server:call(Pid, get_num_casts),
+
+    gen_server:stop(Pid),
+    ok.
+
+test_info() ->
+    {ok, Pid} = gen_server:start(?MODULE, [], []),
+
+    Pid ! ping,
+    Pid ! ping,
+    Pid ! ping,
+
+    3 = gen_server:call(Pid, get_num_infos),
+    0 = gen_server:call(Pid, get_num_infos),
+
+    gen_server:stop(Pid),
+    ok.
+
+
+%%
+%% callbacks
+%%
+
+init(_) ->
+    {ok, #state{}}.
+
+handle_call(ping, _From, State) ->
+    {reply, pong, State};
+handle_call(reply_ping, From, State) ->
+    gen_server:reply(From, pong),
+    {noreply, State};
+handle_call(async_ping, From, State) ->
+    erlang:spawn(gen_server, reply, [{From, pong}]),
+    {noreply, State};
+handle_call(get_num_casts, From, #state{num_casts=NumCasts} = State) ->
+    gen_server:reply(From, NumCasts),
+    {noreply, State#state{num_casts=0}};
+handle_call(get_num_infos, From, #state{num_infos=NumInfos} = State) ->
+    gen_server:reply(From, NumInfos),
+    {noreply, State#state{num_infos=0}}.
+
+handle_cast(ping, #state{num_casts=NumCasts} = State) ->
+    {noreply, State#state{num_casts=NumCasts + 1}};
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(ping, #state{num_infos=NumInfos} = State) ->
+    {noreply, State#state{num_infos=NumInfos + 1}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -4,6 +4,7 @@
 
 test() ->
     ok = test_nth(),
+    ok = test_member(),
     ok.
 
 test_nth() ->
@@ -16,4 +17,11 @@ test_nth() ->
     % catch
     %     _:_ -> ok
     % end,
+    ok.
+
+test_member() ->
+    etest:assert_true(lists:member(a, [a,b,c])),
+    etest:assert_true(lists:member(b, [a,b,c])),
+    etest:assert_true(lists:member(c, [a,b,c])),
+    etest:assert_true(not lists:member(d, [a,b,c])),
     ok.

--- a/tests/libs/estdlib/test_proplists.erl
+++ b/tests/libs/estdlib/test_proplists.erl
@@ -1,0 +1,18 @@
+-module(test_proplists).
+
+-export([test/0]).
+
+test() ->
+    ok = test_get_value(),
+    ok.
+
+test_get_value() ->
+    ok = etest:assert_match(proplists:get_value(a, []), undefined),
+    ok = etest:assert_match(proplists:get_value(a, [a]), true),
+    ok = etest:assert_match(proplists:get_value(a, [{a, foo}]), foo),
+
+    ok = etest:assert_match(proplists:get_value(a, [], gnu), gnu),
+    ok = etest:assert_match(proplists:get_value(a, [a], gnu), true),
+    ok = etest:assert_match(proplists:get_value(a, [{a, foo}], gnu), foo),
+    ok = etest:assert_match(proplists:get_value(b, [{a, foo}], gnu), gnu),
+    ok.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -4,6 +4,8 @@
 
 start() ->
     etest:test([
-        test_lists,
-        test_timer
+        test_lists
+        , test_proplists
+        , test_gen_server
+        , test_timer
     ]).


### PR DESCRIPTION
This change set adds a gen_server module, as well as a few additional support modules.

Changes include the following:

* Added a gen_server module
* Added a logger module, for enhanced debugging/tracing of code
* Added a proplists module (currently only supports get_value/2,3)
* Added member/2 function to lists module
* Moved the console module to eavmlib
* Added tests for the same
* In order to prevent compilation errors with some erlang modules, each estdlib module must be built in its own directory, so CMakelists erlang rules had to change to accomodate that.
* Added travis rules for running erlang tests

These changes are made under the terms of the LGPLv2 and Apache2 licenses.