### PR TITLE
Add support for apply_last opcode

### DIFF
--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -104,6 +104,7 @@ compile_erlang(test_bif_badargument2)
 compile_erlang(test_bif_badargument3)
 compile_erlang(test_tuple_nifs_badargs)
 compile_erlang(test_apply)
+compile_erlang(test_apply_last)
 compile_erlang(test_timestamp)
 compile_erlang(long_atoms)
 compile_erlang(test_concat_badarg)
@@ -291,6 +292,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_bif_badargument3.beam
     test_tuple_nifs_badargs.beam
     test_apply.beam
+    test_apply_last.beam
     test_timestamp.beam
     long_atoms.beam
     test_concat_badarg.beam

--- a/tests/erlang_tests/test_apply_last.erl
+++ b/tests/erlang_tests/test_apply_last.erl
@@ -1,0 +1,44 @@
+-module(test_apply_last).
+
+-export([start/0, add/2, do_apply0/2, do_apply1/3, do_apply2/4]).
+
+start() ->
+    NoModule = try_apply_last(list_to_atom("foo"), list_to_atom("bar")),
+    NoFunction = try_apply_last(?MODULE, no_such_function),
+    Initial = NoModule + NoFunction,
+    do_apply_last({?MODULE, add}, {erlang, list_to_integer}, ["1","2","3","4","5"], Initial).
+
+do_apply_last(_, _, [], Sum) ->
+    Sum;
+do_apply_last({M1, F1} = MF1, {M2, F2} = MF2, [H|T], Sum) ->
+    NewSum = ?MODULE:do_apply2(M1, F1, ?MODULE:do_apply1(M2, F2, H), Sum),
+    do_apply_last(MF1, MF2, T, NewSum).
+
+do_apply0(M, F) ->
+    pad_some_calls(),
+    M:F().
+
+do_apply1(M, F, A) ->
+    pad_some_calls(),
+    M:F(A).
+
+do_apply2(M, F, A, B) ->
+    pad_some_calls(),
+    M:F(A, B).
+
+add(A, B) ->
+    A + B.
+
+
+try_apply_last(M, F) ->
+    try
+        ?MODULE:do_apply0(M, F)
+    catch
+        _Class:_Reason -> 1
+    end.
+
+pad_some_calls() ->
+    X = 1,
+    Y = 2,
+    Z = X + Y,
+    Z.

--- a/tests/test.c
+++ b/tests/test.c
@@ -229,6 +229,7 @@ struct Test tests[] =
     {"copy_terms18.beam", -19},
 
     {"test_apply.beam", 17},
+    {"test_apply_last.beam", 17},
     {"test_timestamp.beam", 1},
 
     //TEST CRASHES HERE: {"memlimit.beam", 0},


### PR DESCRIPTION
This is a followup to the addition of support for the apply instruction, adding support for the related apply_last opcode.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.