### PR TITLE
Change the names of modules in the estdlib library.

### DIFF
--- a/examples/erlang/code_lock.erl
+++ b/examples/erlang/code_lock.erl
@@ -8,6 +8,8 @@
 -export([init/1,callback_mode/0,terminate/3]).
 -export([locked/3,open/3]).
 
+-include("estdlib.hrl").
+
 -record(state, {
     code, length, buttons
 }).
@@ -23,10 +25,10 @@ start() ->
     ok.
 
 start(Code) ->
-    gen_statem:start({local,?NAME}, ?MODULE, Code, []).
+    ?GEN_STATEM:start({local,?NAME}, ?MODULE, Code, []).
 
 button(Button) ->
-    gen_statem:cast(?NAME, {button,Button}).
+    ?GEN_STATEM:cast(?NAME, {button,Button}).
 
 init(Code) ->
     do_lock(),

--- a/examples/erlang/server.erl
+++ b/examples/erlang/server.erl
@@ -3,14 +3,16 @@
 -export([start/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
+-include("estdlib.hrl").
+
 -record(state, {
     %% fun stuff goes here
 }).
 
 
 start() ->
-    {ok, Pid} = gen_server:start(?MODULE, [], []),
-    Reply = gen_server:call(Pid, hello),
+    {ok, Pid} = ?GEN_SERVER:start(?MODULE, [], []),
+    Reply = ?GEN_SERVER:call(Pid, hello),
     erlang:display(Reply),
     ok.
 

--- a/examples/erlang/udp_client.erl
+++ b/examples/erlang/udp_client.erl
@@ -2,15 +2,17 @@
 
 -export([start/0]).
 
+-include("estdlib.hrl").
+
 start() ->
     Console = console:start(),
     console:puts(Console, "Opening socket...\n"),
-    Socket = gen_udp:open(0),
+    Socket = ?GEN_UDP:open(0),
     loop(Console, Socket).
 
 loop(Console, Socket) ->
     console:puts(Console, "Sending foo...\n"),
-    case gen_udp:send(Socket, {127,0,0,1}, 44444, "foo") of
+    case ?GEN_UDP:send(Socket, {127,0,0,1}, 44444, "foo") of
         ok ->
             ok;
         {error, Reason} ->

--- a/examples/erlang/udp_server.erl
+++ b/examples/erlang/udp_server.erl
@@ -2,17 +2,19 @@
 
 -export([start/0]).
 
+-include("estdlib.hrl").
+
 start() ->
     Console = console:start(),
     console:puts(Console, "Opening socket ...\n"),
-    Socket = gen_udp:open(44444),
+    Socket = ?GEN_UDP:open(44444),
     erlang:display(Socket),
     loop(Console, Socket).
 
 
 loop(Console, Socket) ->
     console:puts(Console, "Waiting to receive data...\n"),
-    case gen_udp:recv(Socket, 1000) of
+    case ?GEN_UDP:recv(Socket, 1000) of
         {ok, RecvData} ->
             {Address, Port, Packet} = RecvData,
             console:puts(Console, "Address: "), erlang:display(Address),

--- a/libs/estdlib/CMakeLists.txt
+++ b/libs/estdlib/CMakeLists.txt
@@ -7,14 +7,14 @@ project(estdlib)
 include(BuildErlang)
 
 set(ERLANG_MODULES
-    calendar
-    erlang
-    gen_server
-    gen_statem
-    gen_udp
-    lists
-    proplists
-    timer
+    avm_calendar
+    avm_gen_server
+    avm_gen_statem
+    avm_gen_udp
+    avm_lists
+    avm_proplists
+    avm_timer
+        erlang
 )
 
 pack_archive(estdlib ${ERLANG_MODULES})

--- a/libs/estdlib/avm_calendar.erl
+++ b/libs/estdlib/avm_calendar.erl
@@ -1,4 +1,4 @@
--module(calendar).
+-module(avm_calendar).
 
 -export([date_to_gregorian_days/1, date_to_gregorian_days/3, day_of_the_week/1, day_of_the_week/3]).
 

--- a/libs/estdlib/avm_gen_server.erl
+++ b/libs/estdlib/avm_gen_server.erl
@@ -38,10 +38,12 @@
 %% </ul>
 %% @end
 %%-----------------------------------------------------------------------------
--module(gen_server).
+-module(avm_gen_server).
 
 -export([start/3, start/4, stop/1, stop/3, call/2, call/3, cast/2, reply/2]).
 -export([loop/1]).
+
+-include("estdlib.hrl").
 
 -record(state, {
     name = undefined :: atom(),
@@ -108,7 +110,7 @@ start(Module, Args, Options) ->
     case Module:init(Args) of
         {ok, ModState} ->
             State = #state{
-                name = proplists:get_value(name, Options),
+                name = ?PROPLISTS:get_value(name, Options),
                 mod = Module,
                 mod_state = ModState
             },

--- a/libs/estdlib/avm_gen_udp.erl
+++ b/libs/estdlib/avm_gen_udp.erl
@@ -35,7 +35,7 @@
 %% on all AtomVM platforms.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--module(gen_udp).
+-module(avm_gen_udp).
 
 -export([open/1, open/2, send/4, recv/2, recv/3]).
 -export([get_port_num/1]).

--- a/libs/estdlib/avm_lists.erl
+++ b/libs/estdlib/avm_lists.erl
@@ -24,9 +24,9 @@
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
--module(lists).
+-module(avm_lists).
 
--export([nth/2, member/2, reverse/1, keydelete/3, keyfind/3]).
+-export([nth/2, member/2, delete/2, reverse/1, keydelete/3, keyfind/3]).
 
 %%-----------------------------------------------------------------------------
 %% @param   N the index in the list to get
@@ -60,6 +60,24 @@ member(E, [E | _]) ->
 member(E, [_ | T]) ->
     member(E, T).
 
+%%-----------------------------------------------------------------------------
+%% @param   E the member to delete
+%% @param   L the list from which to delete the value
+%% @returns the result of removing E from L, if it exists in L; otherwise, L.
+%% @doc     Remove E from L
+%% @end
+%%-----------------------------------------------------------------------------
+-spec delete(E::term(), L::list()) -> Result::list().
+delete(E, L) ->
+    delete(E, L, []).
+
+%% @private
+delete(_, [], Accum) ->
+    reverse(Accum);
+delete(E, [E|T], Accum) ->
+    reverse(Accum) ++ T;
+delete(E, [H|T], Accum) ->
+    delete(E, T, [H|Accum]).
 
 %%-----------------------------------------------------------------------------
 %% @param   L the list to reverse

--- a/libs/estdlib/avm_proplists.erl
+++ b/libs/estdlib/avm_proplists.erl
@@ -24,7 +24,7 @@
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
--module(proplists).
+-module(avm_proplists).
 
 -export([get_value/2, get_value/3]).
 

--- a/libs/estdlib/avm_timer.erl
+++ b/libs/estdlib/avm_timer.erl
@@ -1,4 +1,4 @@
--module(timer).
+-module(avm_timer).
 
 -export([sleep/1]).
 

--- a/libs/include/estdlib.hrl
+++ b/libs/include/estdlib.hrl
@@ -1,0 +1,27 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%   Copyright 2019 by Fred Dushin <fred@dushin.net>                       %
+%                                                                         %
+%   This program is free software; you can redistribute it and/or modify  %
+%   it under the terms of the GNU Lesser General Public License as        %
+%   published by the Free Software Foundation; either version 2 of the    %
+%   License, or (at your option) any later version.                       %
+%                                                                         %
+%   This program is distributed in the hope that it will be useful,       %
+%   but WITHOUT ANY WARRANTY; without even the implied warranty of        %
+%   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         %
+%   GNU General Public License for more details.                          %
+%                                                                         %
+%   You should have received a copy of the GNU General Public License     %
+%   along with this program; if not, write to the                         %
+%   Free Software Foundation, Inc.,                                       %
+%   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-define(CALENDAR,       avm_calendar).
+-define(ERLANG,             erlang).
+-define(GEN_SERVER,     avm_gen_server).
+-define(GEN_STATEM,     avm_gen_statem).
+-define(GEN_UDP,        avm_gen_udp).
+-define(LISTS,          avm_lists).
+-define(PROPLISTS,      avm_proplists).
+-define(TIMER,          avm_timer).

--- a/tests/libs/estdlib/test_gen_server.erl
+++ b/tests/libs/estdlib/test_gen_server.erl
@@ -3,6 +3,8 @@
 -export([test/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
+-include("estdlib.hrl").
+
 -record(state, {
     num_casts=0,
     num_infos=0
@@ -15,41 +17,41 @@ test() ->
     ok.
 
 test_call() ->
-    {ok, Pid} = gen_server:start(?MODULE, [], []),
+    {ok, Pid} = ?GEN_SERVER:start(?MODULE, [], []),
 
-    pong = gen_server:call(Pid, ping),
-    pong = gen_server:call(Pid, reply_ping),
-    %pong = gen_server:call(Pid, async_ping),
+    pong = ?GEN_SERVER:call(Pid, ping),
+    pong = ?GEN_SERVER:call(Pid, reply_ping),
+    %pong = ?GEN_SERVER:call(Pid, async_ping),
 
-    gen_server:stop(Pid),
+    ?GEN_SERVER:stop(Pid),
     ok.
 
 test_cast() ->
-    {ok, Pid} = gen_server:start(?MODULE, [], []),
+    {ok, Pid} = ?GEN_SERVER:start(?MODULE, [], []),
 
-    ok = gen_server:cast(Pid, ping),
-    ok = gen_server:cast(Pid, ping),
-    ok = gen_server:cast(Pid, ping),
-    ok = gen_server:cast(Pid, ping),
-    ok = gen_server:cast(Pid, ping),
+    ok = ?GEN_SERVER:cast(Pid, ping),
+    ok = ?GEN_SERVER:cast(Pid, ping),
+    ok = ?GEN_SERVER:cast(Pid, ping),
+    ok = ?GEN_SERVER:cast(Pid, ping),
+    ok = ?GEN_SERVER:cast(Pid, ping),
 
-    5 = gen_server:call(Pid, get_num_casts),
-    0 = gen_server:call(Pid, get_num_casts),
+    5 = ?GEN_SERVER:call(Pid, get_num_casts),
+    0 = ?GEN_SERVER:call(Pid, get_num_casts),
 
-    gen_server:stop(Pid),
+    ?GEN_SERVER:stop(Pid),
     ok.
 
 test_info() ->
-    {ok, Pid} = gen_server:start(?MODULE, [], []),
+    {ok, Pid} = ?GEN_SERVER:start(?MODULE, [], []),
 
     Pid ! ping,
     Pid ! ping,
     Pid ! ping,
 
-    3 = gen_server:call(Pid, get_num_infos),
-    0 = gen_server:call(Pid, get_num_infos),
+    3 = ?GEN_SERVER:call(Pid, get_num_infos),
+    0 = ?GEN_SERVER:call(Pid, get_num_infos),
 
-    gen_server:stop(Pid),
+    ?GEN_SERVER:stop(Pid),
     ok.
 
 
@@ -63,16 +65,16 @@ init(_) ->
 handle_call(ping, _From, State) ->
     {reply, pong, State};
 handle_call(reply_ping, From, State) ->
-    gen_server:reply(From, pong),
+    ?GEN_SERVER:reply(From, pong),
     {noreply, State};
 handle_call(async_ping, From, State) ->
     erlang:spawn(gen_server, reply, [{From, pong}]),
     {noreply, State};
 handle_call(get_num_casts, From, #state{num_casts=NumCasts} = State) ->
-    gen_server:reply(From, NumCasts),
+    ?GEN_SERVER:reply(From, NumCasts),
     {noreply, State#state{num_casts=0}};
 handle_call(get_num_infos, From, #state{num_infos=NumInfos} = State) ->
-    gen_server:reply(From, NumInfos),
+    ?GEN_SERVER:reply(From, NumInfos),
     {noreply, State#state{num_infos=0}}.
 
 handle_cast(ping, #state{num_casts=NumCasts} = State) ->

--- a/tests/libs/estdlib/test_gen_statem.erl
+++ b/tests/libs/estdlib/test_gen_statem.erl
@@ -3,6 +3,8 @@
 -export([test/0]).
 -export([init/1, initial/3, terminate/3]).
 
+-include("estdlib.hrl").
+
 -record(data, {
     num_casts=0,
     num_infos=0
@@ -16,37 +18,37 @@ test() ->
 
 
 test_call() ->
-    {ok, Pid} = gen_statem:start(?MODULE, [], []),
-    pong = gen_statem:call(Pid, ping),
-    gen_statem:stop(Pid),
+    {ok, Pid} = ?GEN_STATEM:start(?MODULE, [], []),
+    pong = ?GEN_STATEM:call(Pid, ping),
+    ?GEN_STATEM:stop(Pid),
     ok.
 
 test_cast() ->
-    {ok, Pid} = gen_statem:start(?MODULE, [], []),
+    {ok, Pid} = ?GEN_STATEM:start(?MODULE, [], []),
 
-    ok = gen_statem:cast(Pid, ping),
-    ok = gen_statem:cast(Pid, ping),
-    ok = gen_statem:cast(Pid, ping),
-    ok = gen_statem:cast(Pid, ping),
-    ok = gen_statem:cast(Pid, ping),
+    ok = ?GEN_STATEM:cast(Pid, ping),
+    ok = ?GEN_STATEM:cast(Pid, ping),
+    ok = ?GEN_STATEM:cast(Pid, ping),
+    ok = ?GEN_STATEM:cast(Pid, ping),
+    ok = ?GEN_STATEM:cast(Pid, ping),
 
-    5 = gen_statem:call(Pid, get_num_casts),
-    0 = gen_statem:call(Pid, get_num_casts),
+    5 = ?GEN_STATEM:call(Pid, get_num_casts),
+    0 = ?GEN_STATEM:call(Pid, get_num_casts),
 
-    gen_statem:stop(Pid),
+    ?GEN_STATEM:stop(Pid),
     ok.
 
 test_info() ->
-    {ok, Pid} = gen_statem:start(?MODULE, [], []),
+    {ok, Pid} = ?GEN_STATEM:start(?MODULE, [], []),
 
     Pid ! ping,
     Pid ! ping,
     Pid ! ping,
 
-    3 = gen_statem:call(Pid, get_num_infos),
-    0 = gen_statem:call(Pid, get_num_infos),
+    3 = ?GEN_STATEM:call(Pid, get_num_infos),
+    0 = ?GEN_STATEM:call(Pid, get_num_infos),
 
-    gen_statem:stop(Pid),
+    ?GEN_STATEM:stop(Pid),
     ok.
 
 %%

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -3,6 +3,7 @@
 -export([test/0, id/1]).
 
 -include("etest.hrl").
+-include("estdlib.hrl").
 
 test() ->
     ok = test_nth(),
@@ -14,11 +15,11 @@ test() ->
     ok.
 
 test_nth() ->
-    ?ASSERT_MATCH(lists:nth(1, [a,b,c]), a),
-    ?ASSERT_MATCH(lists:nth(2, [a,b,c]), b),
-    ?ASSERT_MATCH(lists:nth(3, [a,b,c]), c),
+    ?ASSERT_MATCH(?LISTS:nth(1, [a,b,c]), a),
+    ?ASSERT_MATCH(?LISTS:nth(2, [a,b,c]), b),
+    ?ASSERT_MATCH(?LISTS:nth(3, [a,b,c]), c),
     % try
-    %     lists:nth(-1, [a,b,c]),
+    %     ?LISTS:nth(-1, [a,b,c]),
     %     throw(failure)
     % catch
     %     _:_ -> ok
@@ -26,35 +27,42 @@ test_nth() ->
     ok.
 
 test_reverse() ->
-    ?ASSERT_MATCH(lists:reverse([]), []),
-    ?ASSERT_MATCH(lists:reverse([a]), [a]),
-    ?ASSERT_MATCH(lists:reverse([a, b]), [b,a]),
-
+    ?ASSERT_MATCH(?LISTS:reverse([]), []),
+    ?ASSERT_MATCH(?LISTS:reverse([a]), [a]),
+    ?ASSERT_MATCH(?LISTS:reverse([a, b]), [b,a]),
     ok.
 
 test_member() ->
-    ?ASSERT_TRUE(lists:member(a, [a,b,c])),
-    ?ASSERT_TRUE(lists:member(b, [a,b,c])),
-    ?ASSERT_TRUE(lists:member(c, [a,b,c])),
-    ?ASSERT_TRUE(not lists:member(d, [a,b,c])),
-    ?ASSERT_TRUE(not lists:member(x, [])),
+    ?ASSERT_TRUE(?LISTS:member(a, [a,b,c])),
+    ?ASSERT_TRUE(?LISTS:member(b, [a,b,c])),
+    ?ASSERT_TRUE(?LISTS:member(c, [a,b,c])),
+    ?ASSERT_TRUE(not ?LISTS:member(d, [a,b,c])),
+    ?ASSERT_TRUE(not ?LISTS:member(x, [])),
+    ok.
+
+test_delete() ->
+    ?ASSERT_MATCH(?LISTS:delete(a, []), []),
+    ?ASSERT_MATCH(?LISTS:delete(a, [a]), []),
+    ?ASSERT_MATCH(?LISTS:delete(a, [a,b,c]), [b,c]),
+    ?ASSERT_MATCH(?LISTS:delete(a, [a,a,b,c]), [a,b,c]),
+    ?ASSERT_MATCH(?LISTS:delete(d, [a,b,c]), [a,b,c]),
     ok.
 
 test_keyfind() ->
-    ?ASSERT_MATCH(lists:keyfind(a, 1, [{a, x}, b, []]), {a, x}),
-    ?ASSERT_MATCH(lists:keyfind(x, 2, [{a, x}, b, []]), {a, x}),
-    ?ASSERT_MATCH(lists:keyfind(x, 3, [{a, x}, b, []]), false),
-    ?ASSERT_MATCH(lists:keyfind(b, 1, [{a, 1}, b, []]), false),
+    ?ASSERT_MATCH(?LISTS:keyfind(a, 1, [{a, x}, b, []]), {a, x}),
+    ?ASSERT_MATCH(?LISTS:keyfind(x, 2, [{a, x}, b, []]), {a, x}),
+    ?ASSERT_MATCH(?LISTS:keyfind(x, 3, [{a, x}, b, []]), false),
+    ?ASSERT_MATCH(?LISTS:keyfind(b, 1, [{a, 1}, b, []]), false),
 
-    ?ASSERT_MATCH(lists:keyfind(b, 1, [{a, x}, {b, foo, bar}, []]), {b, foo, bar}),
-    ?ASSERT_MATCH(lists:keyfind(nope, 2, [{a, x}, {b, foo, bar}, []]), false),
+    ?ASSERT_MATCH(?LISTS:keyfind(b, 1, [{a, x}, {b, foo, bar}, []]), {b, foo, bar}),
+    ?ASSERT_MATCH(?LISTS:keyfind(nope, 2, [{a, x}, {b, foo, bar}, []]), false),
     ok.
 
 test_keydelete() ->
-    ?ASSERT_MATCH(lists:keydelete(a, 1, []), []),
-    ?ASSERT_MATCH(lists:keydelete(a, 1, [{a, x}, b, []]), [b, []]),
-    ?ASSERT_MATCH(lists:keydelete(a, 1, [b, {a, x}, []]), [b, []]),
-    ?ASSERT_MATCH(lists:keydelete(a, 1, [b, {a, x}, {a, x}, {a, x}, []]), [b, {a, x}, {a, x}, []]),
+    ?ASSERT_MATCH(?LISTS:keydelete(a, 1, []), []),
+    ?ASSERT_MATCH(?LISTS:keydelete(a, 1, [{a, x}, b, []]), [b, []]),
+    ?ASSERT_MATCH(?LISTS:keydelete(a, 1, [b, {a, x}, []]), [b, []]),
+    ?ASSERT_MATCH(?LISTS:keydelete(a, 1, [b, {a, x}, {a, x}, {a, x}, []]), [b, {a, x}, {a, x}, []]),
     ok.
 
 test_list_match() ->

--- a/tests/libs/estdlib/test_proplists.erl
+++ b/tests/libs/estdlib/test_proplists.erl
@@ -2,17 +2,19 @@
 
 -export([test/0]).
 
+-include("estdlib.hrl").
+
 test() ->
     ok = test_get_value(),
     ok.
 
 test_get_value() ->
-    ok = etest:assert_match(proplists:get_value(a, []), undefined),
-    ok = etest:assert_match(proplists:get_value(a, [a]), true),
-    ok = etest:assert_match(proplists:get_value(a, [{a, foo}]), foo),
+    ok = etest:assert_match(?PROPLISTS:get_value(a, []), undefined),
+    ok = etest:assert_match(?PROPLISTS:get_value(a, [a]), true),
+    ok = etest:assert_match(?PROPLISTS:get_value(a, [{a, foo}]), foo),
 
-    ok = etest:assert_match(proplists:get_value(a, [], gnu), gnu),
-    ok = etest:assert_match(proplists:get_value(a, [a], gnu), true),
-    ok = etest:assert_match(proplists:get_value(a, [{a, foo}], gnu), foo),
-    ok = etest:assert_match(proplists:get_value(b, [{a, foo}], gnu), gnu),
+    ok = etest:assert_match(?PROPLISTS:get_value(a, [], gnu), gnu),
+    ok = etest:assert_match(?PROPLISTS:get_value(a, [a], gnu), true),
+    ok = etest:assert_match(?PROPLISTS:get_value(a, [{a, foo}], gnu), foo),
+    ok = etest:assert_match(?PROPLISTS:get_value(b, [{a, foo}], gnu), gnu),
     ok.

--- a/tests/libs/estdlib/test_timer.erl
+++ b/tests/libs/estdlib/test_timer.erl
@@ -2,6 +2,8 @@
 
 -export([test/0]).
 
+-include("estdlib.hrl").
+
 test() ->
     ok = test_start_timer(),
     ok = test_cancel_timer(),
@@ -13,15 +15,15 @@ test() ->
 test_start_timer() ->
     timer_manager:start(),
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
-    erlang:start_timer(100, self(), test_start_timer),
+    ?ERLANG:start_timer(100, self(), test_start_timer),
     wait_for_timeout(test_start_timer, 5000).
 
 test_cancel_timer() ->
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
-    TimerRef = erlang:start_timer(60000, self(), test_cancel_timer),
+    TimerRef = ?ERLANG:start_timer(60000, self(), test_cancel_timer),
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), [TimerRef]),
-    erlang:cancel_timer(TimerRef),
-    timer:sleep(100),
+    ?ERLANG:cancel_timer(TimerRef),
+    ?TIMER:sleep(100),
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
     ok.
 
@@ -29,7 +31,7 @@ test_timer() ->
     %% hack. until we can convert an erlang timestamp to a big integer
     %% this will fail if run when UNIX epoch divides 1m secs
     {_M0, S0, _Mi0} = erlang:timestamp(),
-    ok = timer:sleep(1001),
+    ok = ?TIMER:sleep(1001),
     {_M1, S1, _Mi1} = erlang:timestamp(),
     ok = etest:assert_true(S1 > S0),
     ok.


### PR DESCRIPTION
This change set changes the names of the estdlib library to use names that are not the same
as their OTP equivalents.  All modules in this library are prefixed with 'avm_'.  For
convenience, macros are provided that can be used to insulate the user from these names.

In addition, a few bug fixes and enhancements were made to the logger and avm_lists modules.

This change is made under the terms of the LGPLv2 and Apache2 licenses.