### PR TITLE
Add support for the set_tuple_element opcode.

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -379,6 +379,7 @@
 #define OP_MOVE 64
 #define OP_GET_LIST 65
 #define OP_GET_TUPLE_ELEMENT 66
+#define OP_SET_TUPLE_ELEMENT 67
 #define OP_PUT_LIST 69
 #define OP_PUT_TUPLE 70
 #define OP_PUT 71
@@ -2052,6 +2053,30 @@ static const char *const try_clause_atom = "\xA" "try_clause";
                     UNUSED(src_value)
                 #endif
 
+                NEXT_INSTRUCTION(next_off);
+                break;
+            }
+
+            case OP_SET_TUPLE_ELEMENT: {
+                int next_off = 1;
+                term new_element;
+                DECODE_COMPACT_TERM(new_element, code, i, next_off, next_off);
+                term tuple;
+                DECODE_COMPACT_TERM(tuple, code, i, next_off, next_off);
+                int position;
+                DECODE_INTEGER(position, code, i, next_off, next_off);
+
+                TRACE("set_tuple_element/2\n");
+
+#ifdef IMPL_EXECUTE_LOOP
+                term_put_tuple_element(tuple, position, new_element);
+#endif
+
+#ifdef IMPL_CODE_LOADER
+                UNUSED(tuple);
+                UNUSED(position);
+                UNUSED(new_element);
+#endif
                 NEXT_INSTRUCTION(next_off);
                 break;
             }

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -105,6 +105,7 @@ compile_erlang(test_bif_badargument3)
 compile_erlang(test_tuple_nifs_badargs)
 compile_erlang(test_apply)
 compile_erlang(test_apply_last)
+compile_erlang(test_set_tuple_element)
 compile_erlang(test_timestamp)
 compile_erlang(long_atoms)
 compile_erlang(test_concat_badarg)
@@ -293,6 +294,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_tuple_nifs_badargs.beam
     test_apply.beam
     test_apply_last.beam
+    test_set_tuple_element.beam
     test_timestamp.beam
     long_atoms.beam
     test_concat_badarg.beam

--- a/tests/erlang_tests/test_set_tuple_element.erl
+++ b/tests/erlang_tests/test_set_tuple_element.erl
@@ -1,0 +1,32 @@
+-module(test_set_tuple_element).
+
+-export([start/0, test/2]).
+
+-record(
+    big, {
+        a = foo,
+        b = 1,
+        c = {e, f},
+        e = [3,1,4,1,5,2,6,9,5],
+        f = [],
+        g = undefined,
+        h = [have, i ,created, enough, elements, yet],
+        i = [und, now, for, something, completely, different],
+        j = {ha, ha}
+    }
+).
+
+
+start() ->
+    test(thing1, {lets, try_this}).
+
+test(G, J) ->
+    Big = make_a_change(#big{}, G, J),
+    case {Big#big.g, Big#big.j} of
+        {G, J} ->
+            0;
+        X -> erlang:display(X), 1
+    end.
+
+make_a_change(Big, Thing1, Thing2) ->
+    Big#big{g=Thing1, j=Thing2}.

--- a/tests/test.c
+++ b/tests/test.c
@@ -231,6 +231,7 @@ struct Test tests[] =
     {"test_apply.beam", 17},
     {"test_apply_last.beam", 17},
     {"test_timestamp.beam", 1},
+    {"test_set_tuple_element.beam", 0},
 
     //TEST CRASHES HERE: {"memlimit.beam", 0},
 


### PR DESCRIPTION
This change adds support for the set_tuple_element (67) opcode.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.