### PR TITLE
Fix support for funs in AVM files

### DIFF
--- a/libs/eavmlib/logger.erl
+++ b/libs/eavmlib/logger.erl
@@ -69,7 +69,7 @@ start(Config) ->
             State = #state{pid=self(), config=Config},
             Pid = spawn(?MODULE, loop, [State]),
             receive
-                started -> 
+                started ->
                     ok
             end,
             erlang:register(?MODULE, Pid),

--- a/libs/estdlib/avm_lists.erl
+++ b/libs/estdlib/avm_lists.erl
@@ -26,7 +26,7 @@
 %%-----------------------------------------------------------------------------
 -module(avm_lists).
 
--export([nth/2, member/2, delete/2, reverse/1, keydelete/3, keyfind/3]).
+-export([nth/2, member/2, delete/2, reverse/1, keydelete/3, keyfind/3, foldl/3, foldr/3, all/2, any/2]).
 
 %%-----------------------------------------------------------------------------
 %% @param   N the index in the list to get
@@ -152,3 +152,58 @@ keyfind(K, I, [H|T]) when is_tuple(H) ->
     end;
 keyfind(K, I, [_H|T]) ->
     keyfind(K, I, T).
+
+%%-----------------------------------------------------------------------------
+%% @param   Fun the function to apply
+%% @param   Accum0 the initial accumulator
+%% @param   List the list over which to fold
+%% @returns the result of folding Fun over L
+%% @doc     Fold over a list of terms, from left to right, applying Fun(E, Accum)
+%%          to each successive element in List
+%% @end
+%%-----------------------------------------------------------------------------
+-spec foldl(Fun::fun((Elem::term(), AccIn::term()) -> AccOut::term()), Acc0::term(), List::list()) -> Acc1::term().
+foldl(_Fun, Acc0, []) ->
+    Acc0;
+foldl(Fun, Acc0, [H|T]) ->
+    Acc1 = Fun(H, Acc0),
+    foldl(Fun, Acc1, T).
+
+%%-----------------------------------------------------------------------------
+%% @equiv   foldl(Fun, Acc0, reverse(List))
+%% @doc     Fold over a list of terms, from right to left, applying Fun(E, Accum)
+%%          to each successive element in List
+%% @end
+%%-----------------------------------------------------------------------------
+-spec foldr(Fun::fun((Elem::term(), AccIn::term()) -> AccOut::term()), Acc0::term(), List::list()) -> Acc1::term().
+foldr(Fun, Acc0, List) ->
+    foldl(Fun, Acc0, reverse(List)).
+
+%%-----------------------------------------------------------------------------
+%% @param   Fun the predicate to evaluate
+%% @param   List the list over which to evaluate elements
+%% @returns true if Fun(E) evaluates to true, for all elements in List
+%% @doc     Evaluates to true iff Fun(E) =:= true, for all E in List
+%% @end
+%%-----------------------------------------------------------------------------
+-spec all(Fun::fun((Elem::term()) -> boolean()), List::list()) -> boolean().
+all(_Fun, []) ->
+    true;
+all(Fun, [H|T]) ->
+    case Fun(H) of
+        true ->
+            all(Fun, T);
+        _ ->
+            false
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Fun the predicate to evaluate
+%% @param   List the list over which to evaluate elements
+%% @returns true if Fun(E) evaluates to true, for at least one in List
+%% @doc     Evaluates to true iff Fun(E) =:= true, for some E in List
+%% @end
+%%-----------------------------------------------------------------------------
+-spec any(Fun::fun((Elem::term()) -> boolean()), List::list()) -> boolean().
+any(Fun, L) ->
+    not all(fun(E) -> not Fun(E) end, L).

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -2275,7 +2275,7 @@ static const char *const try_clause_atom = "\xA" "try_clause";
                     uint32_t label;
                     uint32_t arity;
                     uint32_t n_freeze;
-                    module_get_fun(mod, fun_index, &label, &arity, &n_freeze);
+                    module_get_fun(fun_module, fun_index, &label, &arity, &n_freeze);
 
                     if (UNLIKELY(args_count != arity - n_freeze)) {
                         int target_label = get_catch_label_and_change_module(ctx, &mod);
@@ -2290,15 +2290,15 @@ static const char *const try_clause_atom = "\xA" "try_clause";
                         }
                     }
 
-                    mod = fun_module;
-                    code = mod->code->code;
-
                     for (unsigned int j = arity - n_freeze; j < arity + n_freeze; j++) {
                         ctx->x[j] = boxed_value[j - (arity - n_freeze) + 3];
                     }
 
                     NEXT_INSTRUCTION(next_off);
                     ctx->cp = module_address(mod->module_index, i);
+
+                    mod = fun_module;
+                    code = mod->code->code;
 
                     remaining_reductions--;
                     if (LIKELY(remaining_reductions)) {

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -9,8 +9,13 @@ test() ->
     ok = test_nth(),
     ok = test_member(),
     ok = test_reverse(),
+    ok = test_delete(),
     ok = test_keyfind(),
     ok = test_keydelete(),
+    ok = test_foldl(),
+    ok = test_foldr(),
+    ok = test_all(),
+    ok = test_any(),
     ok = test_list_match(),
     ok.
 
@@ -63,6 +68,36 @@ test_keydelete() ->
     ?ASSERT_MATCH(?LISTS:keydelete(a, 1, [{a, x}, b, []]), [b, []]),
     ?ASSERT_MATCH(?LISTS:keydelete(a, 1, [b, {a, x}, []]), [b, []]),
     ?ASSERT_MATCH(?LISTS:keydelete(a, 1, [b, {a, x}, {a, x}, {a, x}, []]), [b, {a, x}, {a, x}, []]),
+    ok.
+
+test_foldl() ->
+    ?ASSERT_MATCH(?LISTS:foldl(fun(I, Accum) -> Accum + I end, 0, [1,2,3,4,5]), 15),
+    ?ASSERT_MATCH(?LISTS:foldl(fun(I, Accum) -> Accum + I end, 0, []), 0),
+    ok.
+
+test_foldr() ->
+    ?ASSERT_MATCH(?LISTS:foldr(fun(I, Accum) -> Accum + I end, 0, [1,2,3,4,5]), 15),
+    ?ASSERT_MATCH(?LISTS:foldr(fun(I, Accum) -> Accum + I end, 0, []), 0),
+    ok.
+
+test_all() ->
+    ?ASSERT_MATCH(?LISTS:all(fun(_E) -> false end, []), true),
+    ?ASSERT_MATCH(?LISTS:all(fun(_E) -> false end, [a]), false),
+    ?ASSERT_MATCH(?LISTS:all(fun(_E) -> true end, [a]), true),
+    ?ASSERT_MATCH(?LISTS:all(fun(E) -> is_atom(E) end, [a,b,c,d]), true),
+    ?ASSERT_MATCH(?LISTS:all(fun(E) -> is_atom(E) end, [a, []]), false),
+    ?ASSERT_MATCH(?LISTS:all(fun(E) -> is_atom(E) end, [[], a]), false),
+    ok.
+
+test_any() ->
+    ?ASSERT_MATCH(?LISTS:any(fun(_E) -> false end, []), false),
+    ?ASSERT_MATCH(?LISTS:any(fun(_E) -> false end, [a]), false),
+    ?ASSERT_MATCH(?LISTS:any(fun(_E) -> true end, []), false),
+    ?ASSERT_MATCH(?LISTS:any(fun(_E) -> true end, [a]), true),
+    ?ASSERT_MATCH(?LISTS:any(fun(E) -> is_atom(E) end, [a,b,c,d]), true),
+    ?ASSERT_MATCH(?LISTS:any(fun(E) -> is_atom(E) end, [a, []]), true),
+    ?ASSERT_MATCH(?LISTS:any(fun(E) -> is_atom(E) end, [[], a]), true),
+    ?ASSERT_MATCH(?LISTS:any(fun(E) -> is_atom(E) end, [[], {a}]), false),
     ok.
 
 test_list_match() ->

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -290,6 +290,14 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
         fwrite(data + offsets[IMPT], sizeof(uint8_t), sizes[IMPT] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
+    if (offsets[LITU]) {
+        fwrite(data + offsets[LITU], sizeof(uint8_t), sizes[LITU] + IFF_SECTION_HEADER_SIZE, pack);
+        pad_and_align(pack);
+    }
+    if (offsets[FUNT]) {
+        fwrite(data + offsets[FUNT], sizeof(uint8_t), sizes[FUNT] + IFF_SECTION_HEADER_SIZE, pack);
+        pad_and_align(pack);
+    }
 
     if (offsets[LITT]) {
         size_t u_size;


### PR DESCRIPTION
This change set fixes support for funs in AVM (packed beam) files.  In addition, it fixes some minor issues with calling funs defined in other modules, and add functions and tests in the avm_lists module for using funs.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.