### PR TITLE
Fixed OP_PUT_LIST opcode

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -2186,9 +2186,6 @@ static const char *const try_clause_atom = "\xA" "try_clause";
             }
 
             case OP_PUT_LIST: {
-                #ifdef IMPL_EXECUTE_LOOP
-                    term *list_elem = term_list_alloc(ctx);
-                #endif
 
                 int next_off = 1;
                 term head;
@@ -2198,6 +2195,10 @@ static const char *const try_clause_atom = "\xA" "try_clause";
                 int dreg;
                 uint8_t dreg_type;
                 DECODE_DEST_REGISTER(dreg, dreg_type, code, i, next_off, next_off);
+
+#ifdef IMPL_EXECUTE_LOOP
+                term *list_elem = term_list_alloc(ctx);
+#endif
 
                 TRACE("op_put_list/3\n");
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -83,6 +83,7 @@ compile_erlang(test_insert_element)
 compile_erlang(test_delete_element)
 compile_erlang(test_tuple_to_list)
 compile_erlang(test_make_tuple)
+compile_erlang(test_make_list)
 compile_erlang(test_tl)
 compile_erlang(test_list_to_atom)
 compile_erlang(test_list_to_existing_atom)
@@ -272,6 +273,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_delete_element.beam
     test_tuple_to_list.beam
     test_make_tuple.beam
+    test_make_list.beam
     test_tl.beam
     test_list_to_atom.beam
     test_list_to_existing_atom.beam

--- a/tests/erlang_tests/test_make_list.erl
+++ b/tests/erlang_tests/test_make_list.erl
@@ -1,0 +1,10 @@
+-module(test_make_list).
+
+-export([start/0]).
+
+start() ->
+    length(make_list(a,b,c)).
+
+
+make_list(A, B, C) ->
+    [{foo, "bar"}, {gnu, "gnat"}, {a, A}, {b, B}, {c, C}].

--- a/tests/test.c
+++ b/tests/test.c
@@ -120,6 +120,7 @@ struct Test tests[] =
     {"test_delete_element.beam", 421},
     {"test_tuple_to_list.beam", 300},
     {"test_make_tuple.beam", 4},
+    {"test_make_list.beam", 5},
     {"test_tl.beam", 5},
     {"test_list_to_atom.beam", 9},
     {"test_list_to_existing_atom.beam", 9},


### PR DESCRIPTION
This change set moves the allocation of a list element in the OP_PUT_LIST handling code after the decoding of terms, which may trigger the garbage collector, and could otherwise invalidate the allocated list element in the heap.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.