### PR TITLE
Rename cleanup

### DIFF
--- a/libs/estdlib/erlang.erl
+++ b/libs/estdlib/erlang.erl
@@ -24,10 +24,7 @@
 %%-----------------------------------------------------------------------------
 -module(erlang).
 
--export([
-    start_timer/3, start_timer/4, cancel_timer/1, send_after/3
-]).
--export([send_after_timer/3]).
+-export([start_timer/3, start_timer/4, cancel_timer/1, send_after/3]).
 
 
 %%-----------------------------------------------------------------------------
@@ -58,7 +55,6 @@ start_timer(Time, Dest, Msg) ->
 %%-----------------------------------------------------------------------------
 -spec start_timer(non_neg_integer(), pid() | atom(), term(), list()) -> reference().
 start_timer(Time, Dest, Msg, _Options) ->
-    timer_manager:start(),
     timer_manager:start_timer(Time, Dest, Msg).
 
 
@@ -76,7 +72,6 @@ start_timer(Time, Dest, Msg, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec cancel_timer(TimerRef::reference()) -> ok.
 cancel_timer(TimerRef) ->
-    timer_manager:start(),
     timer_manager:cancel_timer(TimerRef).
 
 %%-----------------------------------------------------------------------------
@@ -89,18 +84,4 @@ cancel_timer(TimerRef) ->
 %%-----------------------------------------------------------------------------
 -spec send_after(non_neg_integer(), pid() | atom(), term()) -> reference().
 send_after(Time, Dest, Msg) ->
-    TimerRef = erlang:make_ref(),
-    spawn(?MODULE, send_after_timer, [Time, Dest, Msg]),
-    TimerRef.
-
-
-%%=============================================================================
-%% internal functions
-
-%% @private
-send_after_timer(Time, Dest, Msg) ->
-    TimerRef = start_timer(Time, self(), Msg),
-    receive
-        {timeout, TimerRef, Msg} ->
-            Dest ! Msg
-    end.
+    timer_manager:send_after(Time, Dest, Msg).

--- a/libs/include/etest.hrl
+++ b/libs/include/etest.hrl
@@ -21,7 +21,7 @@
     case etest:assert_match(A, B) of 
         ok -> ok; 
         fail -> 
-            erlang:display({failed_assert_match, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}, A, B}), 
+            erlang:display({failed_assert_match, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, A, B}), 
             fail 
     end
 ).
@@ -29,7 +29,7 @@
     case etest:assert_true(C) of 
         ok -> ok; 
         fail -> 
-            erlang:display({failed_assert_true, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}, C}),
+            erlang:display({failed_assert_true, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, C}),
             fail 
     end
 ).

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -2186,9 +2186,6 @@ static const char *const try_clause_atom = "\xA" "try_clause";
             }
 
             case OP_PUT_LIST: {
-                #ifdef IMPL_EXECUTE_LOOP
-                    term *list_elem = term_list_alloc(ctx);
-                #endif
 
                 int next_off = 1;
                 term head;
@@ -2198,6 +2195,10 @@ static const char *const try_clause_atom = "\xA" "try_clause";
                 int dreg;
                 uint8_t dreg_type;
                 DECODE_DEST_REGISTER(dreg, dreg_type, code, i, next_off, next_off);
+
+#ifdef IMPL_EXECUTE_LOOP
+                term *list_elem = term_list_alloc(ctx);
+#endif
 
                 TRACE("op_put_list/3\n");
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -83,6 +83,7 @@ compile_erlang(test_insert_element)
 compile_erlang(test_delete_element)
 compile_erlang(test_tuple_to_list)
 compile_erlang(test_make_tuple)
+compile_erlang(test_make_list)
 compile_erlang(test_tl)
 compile_erlang(test_list_to_atom)
 compile_erlang(test_list_to_existing_atom)
@@ -272,6 +273,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_delete_element.beam
     test_tuple_to_list.beam
     test_make_tuple.beam
+    test_make_list.beam
     test_tl.beam
     test_list_to_atom.beam
     test_list_to_existing_atom.beam

--- a/tests/erlang_tests/test_make_list.erl
+++ b/tests/erlang_tests/test_make_list.erl
@@ -1,0 +1,10 @@
+-module(test_make_list).
+
+-export([start/0]).
+
+start() ->
+    length(make_list(a,b,c)).
+
+
+make_list(A, B, C) ->
+    [{foo, "bar"}, {gnu, "gnat"}, {a, A}, {b, B}, {c, C}].

--- a/tests/libs/eavmlib/CMakeLists.txt
+++ b/tests/libs/eavmlib/CMakeLists.txt
@@ -8,6 +8,7 @@ include(BuildErlang)
 
 set(ERLANG_MODULES
     test_logger
+    test_timer_manager
 )
 
 pack_archive(test_eavmlib_lib ${ERLANG_MODULES})

--- a/tests/libs/eavmlib/test_logger.erl
+++ b/tests/libs/eavmlib/test_logger.erl
@@ -1,13 +1,93 @@
 -module(test_logger).
 
--export([test/0]).
+-export([test/0, do_log/1, counter/1]).
 
+-include("estdlib.hrl").
+-include("etest.hrl").
 -include("logger.hrl").
 
 test() ->
+    start_counter(),
+    logger:start([{sink, {?MODULE, do_log}}]),
+
+    ?ASSERT_MATCH(get_counter(info), 0),
+    ?ASSERT_MATCH(get_counter(warning), 0),
+    ?ASSERT_MATCH(get_counter(error), 0),
+    ?ASSERT_MATCH(get_counter(debug), 0),
+
+    ok = ?LOG_INFO(ok),
+    ?ASSERT_MATCH(get_counter(info), 1),
+    ?ASSERT_MATCH(get_counter(warning), 0),
+    ?ASSERT_MATCH(get_counter(error), 0),
+    ?ASSERT_MATCH(get_counter(debug), 0),
+
+    ok = ?LOG_WARNING(ok),
+    ?ASSERT_MATCH(get_counter(info), 1),
+    ?ASSERT_MATCH(get_counter(warning), 1),
+    ?ASSERT_MATCH(get_counter(error), 0),
+    ?ASSERT_MATCH(get_counter(debug), 0),
+
+    ok = ?LOG_ERROR(ok),
+    ?ASSERT_MATCH(get_counter(info), 1),
+    ?ASSERT_MATCH(get_counter(warning), 1),
+    ?ASSERT_MATCH(get_counter(error), 1),
+    ?ASSERT_MATCH(get_counter(debug), 0),
+
+    ok = ?LOG_DEBUG(ok),
+    ?ASSERT_MATCH(get_counter(info), 1),
+    ?ASSERT_MATCH(get_counter(warning), 1),
+    ?ASSERT_MATCH(get_counter(error), 1),
+    ?ASSERT_MATCH(get_counter(debug), 0),
+
+    logger:set_levels([debug, info]),
     ok = ?LOG_INFO(ok),
     ok = ?LOG_WARNING(ok),
     ok = ?LOG_ERROR(ok),
     ok = ?LOG_DEBUG(ok),
+    ?ASSERT_MATCH(get_counter(info), 2),
+    ?ASSERT_MATCH(get_counter(warning), 1),
+    ?ASSERT_MATCH(get_counter(error), 1),
+    ?ASSERT_MATCH(get_counter(debug), 1),
 
     ok.
+
+
+do_log({_Location, _Time, _Pid, Level, _Msg} = _LogRequest) ->
+    increment_counter(Level).
+
+
+-record(state, {
+    counters = [
+        {info, 0},
+        {warning, 0},
+        {error, 0},
+        {debug, 0}
+    ]
+}).
+
+start_counter() ->
+    Pid = spawn(?MODULE, counter, [#state{}]),
+    erlang:register(counter, Pid).
+
+increment_counter(Level) ->
+    Pid = erlang:whereis(counter),
+    Pid ! {increment, Level}.
+
+get_counter(Level) ->
+    Pid = erlang:whereis(counter),
+    Ref = erlang:make_ref(),
+    Pid ! {self(), Ref, get_counter, Level},
+    receive
+        {Ref, Counter} -> Counter
+    end.
+
+counter(#state{counters=Counters} = State) ->
+    NewState = receive
+        {increment, Level} ->
+            Value = ?PROPLISTS:get_value(Level, Counters),
+            State#state{counters=[{Level, Value + 1} | ?LISTS:keydelete(Level, 1, Counters)]};
+        {Pid, Ref, get_counter, Level} ->
+            Pid ! {Ref, ?PROPLISTS:get_value(Level, Counters)},
+            State
+    end,
+    counter(NewState).

--- a/tests/libs/eavmlib/test_timer_manager.erl
+++ b/tests/libs/eavmlib/test_timer_manager.erl
@@ -1,0 +1,41 @@
+-module(test_timer_manager).
+
+-export([test/0]).
+
+-include("estdlib.hrl").
+
+test() ->
+    ok = test_start_timer(),
+    ok = test_cancel_timer(),
+    ok.
+
+-include("etest.hrl").
+
+test_start_timer() ->
+    ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
+    timer_manager:start_timer(100, self(), test_start_timer),
+    wait_for_timeout(test_start_timer, 5000).
+
+test_cancel_timer() ->
+    ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
+    TimerRef = timer_manager:start_timer(60000, self(), test_cancel_timer),
+    ?ASSERT_MATCH(timer_manager:get_timer_refs(), [TimerRef]),
+    timer_manager:cancel_timer(TimerRef),
+    %?TIMER:sleep(100),
+    ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
+    ok.
+
+test_send_after() ->
+    timer_manager:send_after(100, self(), ping),
+    pong = wait_for_timeout(ping, 5000).
+
+
+wait_for_timeout(Msg, Timeout) ->
+    receive
+        {timeout, _TimerRef, Msg} ->
+            ok;
+        Msg ->
+            pong
+    after Timeout ->
+        fail
+    end.

--- a/tests/libs/eavmlib/tests.erl
+++ b/tests/libs/eavmlib/tests.erl
@@ -4,5 +4,6 @@
 
 start() ->
     etest:test([
-        test_logger
+        test_logger,
+        test_timer_manager
     ]).

--- a/tests/libs/estdlib/test_timer.erl
+++ b/tests/libs/estdlib/test_timer.erl
@@ -5,27 +5,10 @@
 -include("estdlib.hrl").
 
 test() ->
-    ok = test_start_timer(),
-    ok = test_cancel_timer(),
     ok = test_timer(),
     ok.
 
 -include("etest.hrl").
-
-test_start_timer() ->
-    timer_manager:start(),
-    ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
-    ?ERLANG:start_timer(100, self(), test_start_timer),
-    wait_for_timeout(test_start_timer, 5000).
-
-test_cancel_timer() ->
-    ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
-    TimerRef = ?ERLANG:start_timer(60000, self(), test_cancel_timer),
-    ?ASSERT_MATCH(timer_manager:get_timer_refs(), [TimerRef]),
-    ?ERLANG:cancel_timer(TimerRef),
-    ?TIMER:sleep(100),
-    ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
-    ok.
 
 test_timer() ->
     %% hack. until we can convert an erlang timestamp to a big integer
@@ -35,18 +18,3 @@ test_timer() ->
     {_M1, S1, _Mi1} = erlang:timestamp(),
     ok = etest:assert_true(S1 > S0),
     ok.
-
-%% TODO Add support for opcode 96
-% current_ms() ->
-%     {MegaSecs, Secs, MicroSecs} = erlang:timestamp(),
-%     MegaSecs * 1000000 + Secs * 1000 + MicroSecs / 1000.
-
-
-
-wait_for_timeout(Msg, Timeout) ->
-    receive
-        {timeout, _TimerRef, Msg} ->
-            ok
-    after Timeout ->
-        fail
-    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -120,6 +120,7 @@ struct Test tests[] =
     {"test_delete_element.beam", 421},
     {"test_tuple_to_list.beam", 300},
     {"test_make_tuple.beam", 4},
+    {"test_make_list.beam", 5},
     {"test_tl.beam", 5},
     {"test_list_to_atom.beam", 9},
     {"test_list_to_existing_atom.beam", 9},


### PR DESCRIPTION
This change set makes some minor changes to the previous name change PR.

* Erlang module functionality now delegates to the timer_manager module, and internal calls to these functions now call timer_manager directory, which makes testing of applications on OTP/20 easier
* Added a test for the timer_manager module
* Added sink functionality to the logger module, which makes testing easier
* Improved testing of logger module
* Improved assertion macros to include line number
* Added handling of stop and stop_and_reply from gen_statem state handlers
* Added support for actions from gen_statem init calls

These changes are made under the terms of the LGPLv2 and Apache2 licenses.