### PR TITLE
Fixed calculation of boxed size of binaries.

### DIFF
--- a/src/libAtomVM/socket.c
+++ b/src/libAtomVM/socket.c
@@ -60,7 +60,7 @@ term_ref socket_tuple_from_addr(CContext *cc, uint32_t addr)
 
 term_ref socket_create_packet_term(CContext *cc, const char *buf, ssize_t len)
 {
-    return ccontext_make_term_ref(cc, term_from_string((const uint8_t *)buf, len, cc->ctx));
+    return ccontext_make_term_ref(cc, term_from_literal_binary((void *)buf, len, cc->ctx));
 }
 
 static void socket_consume_mailbox(Context *ctx)

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -524,14 +524,14 @@ static inline term term_from_local_process_id(uint32_t local_process_id)
 static inline term term_from_literal_binary(void *data, uint32_t size, Context *ctx)
 {
 #if TERM_BYTES == 4
-    int size_in_terms = ((size + 4 - 1) >> 2);
+    int size_in_terms = ((size + 4 - 1) >> 2) + 1;
 #elif TERM_BYTES == 8
-    int size_in_terms = ((size + 8 - 1) >> 3);
+    int size_in_terms = ((size + 8 - 1) >> 3) + 1;
 #else
     #error
 #endif
 
-    term *boxed_value = memory_heap_alloc(ctx, size_in_terms + 2);
+    term *boxed_value = memory_heap_alloc(ctx, size_in_terms + 1);
     boxed_value[0] = (size_in_terms << 6) | 0x24; // heap binary
     boxed_value[1] = size;
 


### PR DESCRIPTION
The calculation of the boxed size of a binary is off by 1, which causes the binary to not be properly (shallow) copied during GC and in message passing.

Also modified socket to use binaries and calculate correct heap size.

This fix is made under the terms of the LGPLv2 and Apache2 licenses.