### PR TITLE
Remove use of CContext in port drivers.

### DIFF
--- a/src/libAtomVM/network_driver.h
+++ b/src/libAtomVM/network_driver.h
@@ -24,7 +24,7 @@
 #include "ccontext.h"
 #include "term.h"
 
-void network_driver_setup(CContext *cc, term pid, term_ref ref, term config);
-term_ref network_driver_ifconfig(CContext *cc);
+void network_driver_setup(Context *ctx, term pid, term_ref ref, term config);
+term network_driver_ifconfig(Context *ctx);
 
 #endif

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -21,28 +21,23 @@
 #define _PORT_H_
 
 #include "globalcontext.h"
-#include "ccontext.h"
+#include "context.h"
 #include "term.h"
 
 extern const char *const port_ok_a;
 extern const char *const port_error_a;
 
-static inline term_ref port_make_atom(CContext *cc, AtomString atom)
+static inline term port_make_ok_atom(Context *ctx)
 {
-    return ccontext_make_term_ref(cc, context_make_atom(cc->ctx, atom));
+    return context_make_atom(ctx, port_ok_a);
 }
 
-static inline term_ref port_make_ok_atom(CContext *cc)
-{
-    return ccontext_make_term_ref(cc, context_make_atom(cc->ctx, port_ok_a));
-}
-
-term_ref port_create_tuple2(CContext *cc, term_ref a, term_ref b);
-term_ref port_create_tuple3(CContext *cc, term_ref a, term_ref b, term_ref c);
-term_ref port_create_tuple_n(CContext *cc, size_t num_terms, term_ref *terms);
-term_ref port_create_error_tuple(CContext *cc, const char *reason);
-term_ref port_create_ok_tuple(CContext *cc, term_ref t);
-void port_send_reply(CContext *cc, term_ref pid, term_ref ref, term_ref reply);
+term port_create_tuple2(Context *ctx, term a, term b);
+term port_create_tuple3(Context *ctx, term a, term b, term c);
+term port_create_tuple_n(Context *ctx, size_t num_terms, term *terms);
+term port_create_error_tuple(Context *ctx, const char *reason);
+term port_create_ok_tuple(Context *ctx, term t);
+void port_send_reply(Context *ctx, term pid, term ref, term reply);
 void port_ensure_available(Context *ctx, size_t size);
 int port_is_standard_port_command(term msg);
 

--- a/src/libAtomVM/socket.h
+++ b/src/libAtomVM/socket.h
@@ -20,14 +20,14 @@
 #ifndef _SOCKET_H_
 #define _SOCKET_H_
 
-#include "ccontext.h"
+#include "context.h"
 #include "term.h"
 
 
 void socket_init(Context *ctx, term params);
 
 uint32_t socket_tuple_to_addr(term addr_tuple);
-term_ref socket_tuple_from_addr(CContext *cc, uint32_t addr);
-term_ref socket_create_packet_term(CContext *cc, const char *buf, ssize_t len);
+term socket_tuple_from_addr(Context *ctx, uint32_t addr);
+term socket_create_packet_term(Context *ctx, const char *buf, ssize_t len);
 
 #endif

--- a/src/libAtomVM/socket_driver.h
+++ b/src/libAtomVM/socket_driver.h
@@ -20,15 +20,15 @@
 #ifndef _SOCKET_DRIVER_H_
 #define _SOCKET_DRIVER_H_
 
-#include "ccontext.h"
+#include "context.h"
 #include "term.h"
 
 void *socket_driver_create_data();
 void socket_driver_delete_data(void *data);
 
-term_ref socket_driver_do_init(CContext *cc, term params);
-term_ref socket_driver_do_bind(CContext *cc, term address, term port);
-term_ref socket_driver_do_send(CContext *cc, term dest_address, term dest_port, term buffer);
-void socket_driver_do_recvfrom(CContext *cc, term_ref pid, term_ref ref);
+term socket_driver_do_init(Context *ctx, term params);
+term socket_driver_do_bind(Context *ctx, term address, term port);
+term socket_driver_do_send(Context *ctx, term dest_address, term dest_port, term buffer);
+void socket_driver_do_recvfrom(Context *ctx, term pid, term ref);
 
 #endif

--- a/src/platforms/esp32/main/network_driver.c
+++ b/src/platforms/esp32/main/network_driver.c
@@ -55,18 +55,16 @@
 
 static esp_err_t wifi_event_handler(void *ctx, system_event_t *event);
 
-static const char *const sta_a = "\x3" "sta";
+static const char *const sta_a  = "\x3" "sta";
 static const char *const ssid_a = "\x4" "ssid";
-static const char *const psk_a = "\x3" "psk";
+static const char *const psk_a  = "\x3" "psk";
 static const char *const sntp_a = "\x4" "sntp";
 
 static EventGroupHandle_t wifi_event_group;
 
 
-void network_driver_setup(CContext *cc, term_ref pid, term_ref ref, term config)
+void network_driver_setup(Context *ctx, term_ref pid, term_ref ref, term config)
 {
-    Context *ctx = cc->ctx;
-
     term sta_config = interop_proplist_get_value(config, context_make_atom(ctx, sta_a));
     if (!term_is_nil(sta_config)) {
         term ssid_value = interop_proplist_get_value(sta_config, context_make_atom(ctx, ssid_a));
@@ -83,8 +81,8 @@ void network_driver_setup(CContext *cc, term_ref pid, term_ref ref, term config)
             if (psk != NULL) {
                 free(psk);
             }
-            term_ref reply = port_create_error_tuple(cc, "cannot allocate memory for ssid or psk");
-            port_send_reply(cc, pid, ref, reply);
+            term reply = port_create_error_tuple(ctx, "cannot allocate memory for ssid or psk");
+            port_send_reply(ctx, pid, ref, reply);
             return;
         }
 
@@ -99,8 +97,8 @@ void network_driver_setup(CContext *cc, term_ref pid, term_ref ref, term config)
             TRACE("ssid or psk is too long\n");
             free(ssid);
             free(psk);
-            term_ref reply = port_create_error_tuple(cc, "ssid or psk is too long");
-            port_send_reply(cc, pid, ref, reply);
+            term reply = port_create_error_tuple(ctx, "ssid or psk is too long");
+            port_send_reply(ctx, pid, ref, reply);
             return;
         }
 
@@ -125,17 +123,17 @@ void network_driver_setup(CContext *cc, term_ref pid, term_ref ref, term config)
             }
         }
         // TODO make this async
-        term_ref reply = port_make_atom(cc, port_ok_a);
-        port_send_reply(cc, pid, ref, reply);
+        term reply = context_make_atom(ctx, port_ok_a);
+        port_send_reply(ctx, pid, ref, reply);
     } else {
-        term_ref reply = port_create_error_tuple(cc, "unsupported config");
-        port_send_reply(cc, pid, ref, reply);
+        term reply = port_create_error_tuple(ctx, "unsupported config");
+        port_send_reply(ctx, pid, ref, reply);
     }
 }
 
-term_ref network_driver_ifconfig(CContext *cc)
+term network_driver_ifconfig(Context *ctx)
 {
-    return port_create_error_tuple(cc, "unimplemented");
+    return port_create_error_tuple(ctx, "unimplemented");
 }
 
 static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)

--- a/src/platforms/generic_unix/network_driver.c
+++ b/src/platforms/generic_unix/network_driver.c
@@ -21,13 +21,13 @@
 #include "network_driver.h"
 #include "port.h"
 
-void network_driver_setup(CContext *cc, term_ref pid, term_ref ref, term config)
+void network_driver_setup(Context *ctx, term pid, term ref, term config)
 {
     UNUSED(config);
-    port_send_reply(cc, pid, ref, port_create_error_tuple(cc, "unimplemented"));
+    port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, "unimplemented"));
 }
 
-term_ref network_driver_ifconfig(CContext *cc)
+term network_driver_ifconfig(Context *ctx)
 {
-    return port_create_error_tuple(cc, "unimplemented");
+    return port_create_error_tuple(ctx, "unimplemented");
 }


### PR DESCRIPTION
This change set makes a broad set of changes across the network and socket drivers, replacing uses of CContext with the more simple Context structure.

The use of CContext in this code adds unnecessary complexity to the code, while proving no tangible benefit.  All of the gains are via preventing the GC from running inside the execution context of the port.

These changes are made under the terms of the LGPLv2 and Apache2 licenses.