### PR TITLE
Fix for memory allocation failure in console port.

### DIFF
--- a/src/libAtomVM/ccontext.h
+++ b/src/libAtomVM/ccontext.h
@@ -84,7 +84,18 @@ static inline term_ref ccontext_make_term_ref(struct CContext *ccontext, term t)
     Context *ctx = ccontext->ctx;
 
     if (ctx->heap_ptr > ctx->e - 1) {
-        memory_ensure_free(ctx, 1);
+        switch (memory_ensure_free(ctx, 1)) {
+            case MEMORY_GC_OK:
+                break;
+            case MEMORY_GC_ERROR_FAILED_ALLOCATION:
+                // TODO Improve error handling
+                fprintf(stderr, "Failed to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
+                abort();
+            case MEMORY_GC_DENIED_ALLOCATION:
+                // TODO Improve error handling
+                fprintf(stderr, "Not permitted to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
+                abort();
+        }
     }
 
     ctx->e--;

--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -51,7 +51,18 @@ term externalterm_to_term(const void *external_term, Context *ctx)
 
     int eterm_size;
     int heap_usage = calculate_heap_usage(external_term_buf + 1, &eterm_size, ctx);
-    memory_ensure_free(ctx, heap_usage);
+    switch (memory_ensure_free(ctx, heap_usage)) {
+        case MEMORY_GC_OK:
+            break;
+        case MEMORY_GC_ERROR_FAILED_ALLOCATION:
+            // TODO Improve error handling
+            fprintf(stderr, "Failed to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
+            abort();
+        case MEMORY_GC_DENIED_ALLOCATION:
+            // TODO Improve error handling
+            fprintf(stderr, "Not permitted to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
+            abort();
+    }
 
     return parse_external_terms(external_term_buf + 1, &eterm_size, ctx);
 }

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -408,6 +408,8 @@ static void process_console_mailbox(Context *ctx)
     Message *message = mailbox_dequeue(ctx);
     term msg = message->message;
 
+    port_ensure_available(ctx, 64);
+
     if (port_is_standard_port_command(msg)) {
         CContext ccontext;
         CContext *cc = &ccontext;

--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -84,7 +84,18 @@ void port_send_reply(CContext *cc, term_ref pid, term_ref ref, term_ref reply)
 void port_ensure_available(Context *ctx, size_t size)
 {
     if (context_avail_free_memory(ctx) < size) {
-        memory_ensure_free(ctx, size);
+        switch (memory_ensure_free(ctx, size)) {
+            case MEMORY_GC_OK:
+                break;
+            case MEMORY_GC_ERROR_FAILED_ALLOCATION:
+                // TODO Improve error handling
+                fprintf(stderr, "Failed to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
+                abort();
+            case MEMORY_GC_DENIED_ALLOCATION:
+                // TODO Improve error handling
+                fprintf(stderr, "Not permitted to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
+                abort();
+        }
     }
 }
 


### PR DESCRIPTION
The console port does not ensure adequate memory to run, with the new memlimit change.  This change ensures sufficient memory to run console process messages.

This change is made under the terms of the LGPLv2 and Apache2 licenses.