### PR TITLE
Add support for process_info/2

### DIFF
--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -174,6 +174,28 @@ static inline unsigned long context_memory_size(const Context *ctx)
 }
 
 /**
+ * @brief Returns context heap size in term units
+ *
+ * @param ctx a valid context.
+ * @returns context heap size in term units
+ */
+static inline unsigned long context_heap_size(const Context *ctx)
+{
+    return ctx->heap_ptr - ctx->heap_start;
+}
+
+/**
+ * @brief Returns context heap size in term units
+ *
+ * @param ctx a valid context.
+ * @returns context heap size in term units
+ */
+static inline unsigned long context_stack_size(const Context *ctx)
+{
+    return ctx->stack_base - ctx->e;
+}
+
+/**
  * @brief Checks if a contex is waiting a timeout.
  *
  * @details Check if given context has a timeout timestamp set, regardless current timestamp.
@@ -199,5 +221,21 @@ static inline term context_make_atom(Context *ctx, AtomString string)
     int global_atom_index = globalcontext_insert_atom(ctx->global, string);
     return term_from_atom_index(global_atom_index);
 }
+
+/**
+ * @brief Returns number of messages in the process's mailbox
+ *
+ * @param ctx a valid context.
+ * @returns the number of messages in the process's mailbox
+ */
+size_t context_message_queue_len(Context *ctx);
+
+/**
+ * @brief Returns total amount of size (in byes) occuped by the process.
+ *
+ * @param ctx a valid context.
+ * @returns total amount of size (in byes) occuped by the process
+ */
+size_t context_size(Context *ctx);
 
 #endif

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -38,4 +38,5 @@ erlang:universaltime/0, &universaltime_nif
 erlang:timestamp/0, &timestamp_nif
 erlang:process_flag/3, &process_flag_nif
 erlang:processes/0, &processes_nif
+erlang:process_info/2, &process_info_nif
 erts_debug:flat_size/1, &flat_size_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -123,6 +123,7 @@ compile_erlang(test_recursion_and_try_catch)
 compile_erlang(test_func_info)
 compile_erlang(test_func_info2)
 compile_erlang(test_func_info3)
+compile_erlang(test_process_info)
 
 compile_erlang(test_funs0)
 compile_erlang(test_funs1)
@@ -315,6 +316,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_func_info.beam
     test_func_info2.beam
     test_func_info3.beam
+    test_process_info.beam
 
     test_funs0.beam
     test_funs1.beam

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -1,0 +1,39 @@
+-module(test_process_info).
+-export([start/0, loop/2]).
+
+start() ->
+    Self = self(),
+    Pid = spawn(?MODULE, loop, [Self, []]), receive ok -> ok end,
+    test_message_queue_len(Pid, Self),
+    Pid ! {Self, stop}, receive X -> erlang:display(X), 0 end.
+
+test_message_queue_len(Pid, Self) ->
+    {message_queue_len, MessageQueueLen} = process_info(Pid, message_queue_len),
+    {memory, Memory} = process_info(Pid, memory),
+    {heap_size, HeapSize} = process_info(Pid, heap_size),
+    Pid ! incr,
+    Pid ! incr,
+    Pid ! incr,
+    {message_queue_len, MessageQueueLen2} = process_info(Pid, message_queue_len),
+    {memory, Memory2} = process_info(Pid, memory),
+    Pid ! {Self, ping}, receive pong -> ok end,
+    {heap_size, HeapSize2} = process_info(Pid, heap_size),
+    assert(MessageQueueLen < MessageQueueLen2),
+    assert(Memory < Memory2),
+    assert(HeapSize < HeapSize2).
+
+loop(undefined, Accum) ->
+    receive
+        {Pid, stop} ->
+            Pid ! Accum;
+        incr ->
+            loop(undefined, [incr | Accum]);
+        {Pid, ping} ->
+            Pid ! pong,
+            loop(undefined, Accum)
+    end;
+loop(Pid, Accum) ->
+    Pid ! ok,
+    loop(undefined, Accum).
+
+assert(true) -> ok.

--- a/tests/test.c
+++ b/tests/test.c
@@ -155,6 +155,7 @@ struct Test tests[] =
     {"test_func_info.beam", 89},
     {"test_func_info2.beam", 1},
     {"test_func_info3.beam", 120},
+    {"test_process_info.beam", 0},
     {"test_funs0.beam", 20},
     {"test_funs1.beam", 517},
     {"test_funs2.beam", 52},


### PR DESCRIPTION
This change set adds support for process_info/2, where the first argument is a Pid, and the second argument is an atom.

The following statistics are available by specifying the following atoms as the second argument:

* heap_size: size in words of the heap of the process
* stack_size: stack size, in words, of the process
* message_queue_len: number of messages currently in the message queue of the process
* memory: size in bytes of the process. This includes call stack, heap, and internal structures.

The value returned is a tuple with the supplied atom as the first element and the integer value as the second element

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
