### PR TITLE
Add support for erlang:processes/0

### DIFF
--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -37,4 +37,5 @@ erlang:tuple_to_list/1, &tuple_to_list_nif
 erlang:universaltime/0, &universaltime_nif
 erlang:timestamp/0, &timestamp_nif
 erlang:process_flag/3, &process_flag_nif
+erlang:processes/0, &processes_nif
 erts_debug:flat_size/1, &flat_size_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -85,6 +85,7 @@ compile_erlang(test_tuple_to_list)
 compile_erlang(test_make_tuple)
 compile_erlang(test_make_list)
 compile_erlang(test_list_gc)
+compile_erlang(test_list_processes)
 compile_erlang(test_tl)
 compile_erlang(test_list_to_atom)
 compile_erlang(test_list_to_existing_atom)
@@ -276,6 +277,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_make_tuple.beam
     test_make_list.beam
     test_list_gc.beam
+    test_list_processes.beam
     test_tl.beam
     test_list_to_atom.beam
     test_list_to_existing_atom.beam

--- a/tests/erlang_tests/test_list_processes.erl
+++ b/tests/erlang_tests/test_list_processes.erl
@@ -1,0 +1,40 @@
+-module(test_list_processes).
+-export([start/0, loop/1]).
+
+start() ->
+    Self = self(),
+    IdList = [1,2,3],
+    Pids = [spawn(?MODULE, loop, [Self]) || _ <- IdList],
+    [receive ok -> ok end || _ <- IdList],
+    test_list_processes(Pids, 0, Self).
+
+test_list_processes([], Accum, _Self) ->
+    Accum;
+test_list_processes([Self | T], Accum, Self) ->
+    test_list_processes(T, Accum, Self);
+test_list_processes([Pid | T] = _PidList, Accum, Self) ->
+    assert(contains(erlang:processes(), Pid)),
+    Pid ! {Self, stop}, receive ok -> ok end,
+    assert(not contains(erlang:processes(), Pid)),
+    test_list_processes(T, Accum + 1, Self).
+
+loop(undefined) ->
+    receive
+        {Pid, stop} ->
+            Pid ! ok;
+        _ ->
+            loop(undefined)
+    end;
+loop(Pid) ->
+    Pid ! ok,
+    loop(undefined).
+
+
+contains([], _E) ->
+    false;
+contains([E|_T], E) ->
+    true;
+contains([_|T], E) ->
+    contains(T, E).
+
+assert(true) -> ok.

--- a/tests/test.c
+++ b/tests/test.c
@@ -122,6 +122,7 @@ struct Test tests[] =
     {"test_make_tuple.beam", 4},
     {"test_make_list.beam", 5},
     {"test_list_gc.beam", 2},
+    {"test_list_processes.beam", 3},
     {"test_tl.beam", 5},
     {"test_list_to_atom.beam", 9},
     {"test_list_to_existing_atom.beam", 9},


### PR DESCRIPTION
This change set adds support for the erlang:prcoesses/0 NIF.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
