### PR TITLE
Add support for spawn/1 and spawn_opt/2

### DIFF
--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -28,7 +28,9 @@ erlang:is_process_alive/1, &is_process_alive_nif
 erlang:register/2, &register_nif
 erlang:send/2, &send_nif
 erlang:setelement/3, &setelement_nif
+erlang:spawn/1, &spawn_fun_nif
 erlang:spawn/3, &spawn_nif
+erlang:spawn_opt/2, &spawn_fun_opt_nif
 erlang:spawn_opt/4, &spawn_opt_nif
 erlang:whereis/1, &whereis_nif
 erlang:++/2, &concat_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -201,6 +201,9 @@ compile_erlang(copy_terms18)
 
 compile_erlang(memlimit)
 
+compile_erlang(spawn_fun1)
+compile_erlang(spawn_fun2)
+compile_erlang(spawn_fun3)
 
 add_custom_target(erlang_test_modules DEPENDS
     add.beam
@@ -394,4 +397,8 @@ add_custom_target(erlang_test_modules DEPENDS
     copy_terms18.beam
 
     memlimit.beam
+
+    spawn_fun1.beam
+    spawn_fun2.beam
+    spawn_fun3.beam
 )

--- a/tests/erlang_tests/spawn_fun1.erl
+++ b/tests/erlang_tests/spawn_fun1.erl
@@ -1,0 +1,31 @@
+-module(spawn_fun1).
+-export([start/0, loop/0]).
+
+start() ->
+    Pid = spawn(fun loop/0),
+    Pid ! {self(), 21},
+    Double =
+        receive
+            Any -> Any
+        end,
+    Pid ! terminate,
+    Double.
+
+loop() ->
+    case handle_request() of
+        ok ->
+            loop();
+
+        terminate ->
+            terminate
+    end.
+
+handle_request() ->
+    receive
+        {Pid, N} ->
+            Pid ! N * 2,
+            ok;
+
+        terminate ->
+            terminate
+    end.

--- a/tests/erlang_tests/spawn_fun2.erl
+++ b/tests/erlang_tests/spawn_fun2.erl
@@ -1,0 +1,12 @@
+-module(spawn_fun2).
+-export([start/0]).
+
+start() ->
+    Father = self(),
+    Fun = fun() -> Father ! 33 end,
+    spawn(Fun),
+    Result =
+        receive
+            Any -> Any
+        end,
+    Result.

--- a/tests/erlang_tests/spawn_fun3.erl
+++ b/tests/erlang_tests/spawn_fun3.erl
@@ -1,0 +1,22 @@
+-module(spawn_fun3).
+-export([start/0]).
+
+start() ->
+    L = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+    Fun = fun() ->
+            receive
+                {Pid, sum} ->
+                    Pid ! sum(L)
+            end
+          end,
+    Pid = spawn(Fun),
+    Pid ! {self(), sum},
+    receive
+        N -> N
+    end.
+
+sum([]) ->
+    0;
+
+sum([H | T]) ->
+    H + sum(T).

--- a/tests/test.c
+++ b/tests/test.c
@@ -237,6 +237,10 @@ struct Test tests[] =
     {"test_timestamp.beam", 1},
     {"test_set_tuple_element.beam", 0},
 
+    {"spawn_fun1.beam", 42},
+    {"spawn_fun2.beam", 33},
+    {"spawn_fun3.beam", 10},
+
     //TEST CRASHES HERE: {"memlimit.beam", 0},
 
     {NULL, 0}


### PR DESCRIPTION
This makes it possible to spawn a process using a fun.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
