### PR TITLE
send/2 improvements

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1238,8 +1238,10 @@ static const char *const out_of_memory_atom = "\xD" "out_of_memory";
                     TRACE("send/0 target_pid=%i\n", local_process_id);
                     TRACE_SEND(ctx, ctx->x[0], ctx->x[1]);
                     Context *target = globalcontext_get_process(ctx->global, local_process_id);
+                    if (!IS_NULL_PTR(target)) {
+                        mailbox_send(target, ctx->x[1]);
+                    }
 
-                    mailbox_send(target, ctx->x[1]);
                 #endif
 
                 NEXT_INSTRUCTION(1);

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1242,6 +1242,7 @@ static const char *const out_of_memory_atom = "\xD" "out_of_memory";
                         mailbox_send(target, ctx->x[1]);
                     }
 
+                    ctx->x[0] = ctx->x[1];
                 #endif
 
                 NEXT_INSTRUCTION(1);

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -18,6 +18,7 @@ compile_erlang(biggerintegers)
 compile_erlang(biggerdifference)
 compile_erlang(moreintegertests)
 compile_erlang(send_receive)
+compile_erlang(send_to_dead_process)
 compile_erlang(selval)
 compile_erlang(byte_size_test)
 compile_erlang(tuple)
@@ -211,6 +212,7 @@ add_custom_target(erlang_test_modules DEPENDS
     biggerdifference.beam
     moreintegertests.beam
     send_receive.beam
+    send_to_dead_process.beam
     selval.beam
     byte_size_test.beam
     tuple.beam

--- a/tests/erlang_tests/send_to_dead_process.erl
+++ b/tests/erlang_tests/send_to_dead_process.erl
@@ -1,0 +1,22 @@
+-module(send_to_dead_process).
+-export([start/0, double_and_terminate/0]).
+
+start() ->
+    Pid = spawn(?MODULE, double_and_terminate, []),
+    Pid ! {self(), 10},
+    Result =
+        receive
+            Any -> Any
+        end,
+    case Pid ! ping of
+        ping ->
+            Result;
+
+        _Other ->
+            0
+    end.
+
+double_and_terminate() ->
+    receive
+        {Pid, N} -> Pid ! N * 2
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -50,6 +50,7 @@ struct Test tests[] =
     {"biggerdifference.beam", 250},
     {"moreintegertests.beam", 32},
     {"send_receive.beam", 18},
+    {"send_to_dead_process.beam", 20},
     {"byte_size_test.beam", 10},
     {"tuple.beam", 6},
     {"len_test.beam", 5},


### PR DESCRIPTION
* Fix a segfault when sending a message to a dead process
* Fix the return of `send/2`, now it correctly returns the message

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
