### PR TITLE
Adds support for select (for debugging only)

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -438,7 +438,7 @@ term make_fun(Context *ctx, const Module *mod, int fun_index)
     {
         for (int i = 0; i < arity; i++) {
             printf("DBG: <0.%i.0> -- arg%i: ", ctx->process_id, i);
-            term_display(ctx->x[i], ctx);
+            term_display(stdout, ctx->x[i], ctx);
             printf("\n");
         }
     }
@@ -486,7 +486,7 @@ term make_fun(Context *ctx, const Module *mod, int fun_index)
     {
         if (UNLIKELY(ctx->trace_returns)) {
             printf("DBG: <0.%i.0> - return, value: ", ctx->process_id);
-            term_display(ctx->x[0], ctx);
+            term_display(stdout, ctx->x[0], ctx);
             printf(".\n");
         }
     }
@@ -495,9 +495,9 @@ term make_fun(Context *ctx, const Module *mod, int fun_index)
     {
         if (UNLIKELY(ctx->trace_send)) {
             printf("DBG: <0.%i.0> - send, pid: ", ctx->process_id);
-            term_display(pid, ctx);
+            term_display(stdout, pid, ctx);
             printf(" message: ");
-            term_display(message, ctx);
+            term_display(stdout, message, ctx);
             printf(".\n");
         }
     }
@@ -506,7 +506,7 @@ term make_fun(Context *ctx, const Module *mod, int fun_index)
     {
         if (UNLIKELY(ctx->trace_send)) {
             printf("DBG: <0.%i.0> - receive, message: ", ctx->process_id);
-            term_display(message, ctx);
+            term_display(stdout, message, ctx);
             printf(".\n");
         }
     }

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -80,11 +80,11 @@ Context *scheduler_wait(GlobalContext *global, Context *c)
                 listener->data = global;
                 listener->handler = scheduler_timeout_callback;
 
-                sys_waitevents(global->listeners);
+                sys_waitevents(global);
             }
         } else if (list_is_empty(&global->ready_processes)) {
             if (LIKELY(global->listeners)) {
-                sys_waitevents(global->listeners);
+                sys_waitevents(global);
             } else {
                 fprintf(stderr, "Hang detected\n");
                 abort();

--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -55,7 +55,7 @@ typedef struct EventListener {
  * @details wait any of the specified events using a platform specific implementation, that might be poll on unix-like systems.
  * @param listeners_list a list of listeners that are waiting for some events, each listener waits an event and has a callback.
  */
-void sys_waitevents(struct ListHead *listeners_list);
+void sys_waitevents(GlobalContext *glb);
 
 /**
  * @brief sets the timestamp for a future event


### PR DESCRIPTION
In some cases it is nice to be able to debug on UNIX using select for checking the status of file descriptors (e.g., sockets).  This change adds support for select, with the addition of a compile time macro (defaults to using poll, for efficiency).  Select added to ESP32 port.

Also fixes two bugs:

* If the handler on an EventListener removes a listener from the global list of listeners, this has a side effect on the global->listeners pointer, so the check to exit the loop calling handlers may need to have the listeners value updated.  Without this change, we can end up in an infinite loop in some cases.

* Added the stdout to the calls to term_display that had been hidden in the ADAVANCED_TRACING macro.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
