### PR TITLE
Replaces error strings with terms

### DIFF
--- a/src/libAtomVM/network.c
+++ b/src/libAtomVM/network.c
@@ -53,10 +53,10 @@ static void network_consume_mailbox(Context *ctx)
             if (cmd_name == context_make_atom(ctx, setup_a)) {
                 network_driver_setup(ctx, pid, ref, config);
             } else {
-                port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, "unrecognized tuple command"));
+                port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, BADARG_ATOM));
             }
         } else {
-            port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, "unrecognized command"));
+            port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, BADARG_ATOM));
         }
     } else {
         fprintf(stderr, "WARNING: Invalid port command.  Unable to send reply");

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -441,7 +441,7 @@ static void process_console_mailbox(Context *ctx)
     Message *message = mailbox_dequeue(ctx);
     term msg = message->message;
 
-    port_ensure_available(ctx, 64);
+    port_ensure_available(ctx, 12);
 
     if (port_is_standard_port_command(msg)) {
 
@@ -451,25 +451,25 @@ static void process_console_mailbox(Context *ctx)
 
         if (term_is_atom(cmd) && cmd == FLUSH_ATOM) {
             fflush(stdout);
-            port_send_reply(ctx, pid, ref, port_make_ok_atom(ctx));
+            port_send_reply(ctx, pid, ref, OK_ATOM);
         } else if (term_is_tuple(cmd) && term_get_tuple_arity(cmd) == 2) {
             term cmd_name = term_get_tuple_element(cmd, 0);
             if (cmd_name == PUTS_ATOM) {
                 char *str = interop_term_to_string(term_get_tuple_element(cmd, 1));
                 if (IS_NULL_PTR(str)) {
-                    term error = port_create_error_tuple(ctx, "Unable to convert term to string");
+                    term error = port_create_error_tuple(ctx, BADARG_ATOM);
                     port_send_reply(ctx, pid, ref, error);
                 } else {
                     printf("%s", str);
-                    port_send_reply(ctx, pid, ref, port_make_ok_atom(ctx));
+                    port_send_reply(ctx, pid, ref, OK_ATOM);
                 }
                 free(str);
             } else {
-                term error = port_create_error_tuple(ctx, "Expected puts command");
+                term error = port_create_error_tuple(ctx, BADARG_ATOM);
                 port_send_reply(ctx, pid, ref, error);
             }
         } else {
-            port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, "unrecognized command"));
+            port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, BADARG_ATOM));
         }
     } else {
         fprintf(stderr, "WARNING: Invalid port command.  Unable to send reply");

--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -21,9 +21,7 @@
 #include "context.h"
 #include "globalcontext.h"
 #include "mailbox.h"
-
-const char *const port_ok_a     = "\x2" "ok";
-const char *const port_error_a  = "\x5" "error";
+#include "defaultatoms.h"
 
 
 term port_create_tuple2(Context *ctx, term a, term b)
@@ -56,18 +54,20 @@ term port_create_tuple_n(Context *ctx, size_t num_terms, term *terms)
     return ret;
 }
 
-term port_create_error_tuple(Context *ctx, const char *reason)
+term port_create_error_tuple(Context *ctx, term reason)
 {
-    int len = strnlen(reason, 424);
-    term error_atom = context_make_atom(ctx, port_error_a);
-    term error_reason = term_from_string((const uint8_t*) reason, len, ctx);
-    return port_create_tuple2(ctx, error_atom, error_reason);
+    return port_create_tuple2(ctx, ERROR_ATOM, reason);
+}
+
+term port_create_sys_error_tuple(Context *ctx, AtomString syscall, int errno)
+{
+    term reason = port_create_tuple2(ctx, context_make_atom(ctx, syscall), term_from_int32(errno));
+    return port_create_error_tuple(ctx, reason);
 }
 
 term port_create_ok_tuple(Context *ctx, term t)
 {
-    term ok_atom = context_make_atom(ctx, port_ok_a);
-    return port_create_tuple2(ctx, ok_atom, t);
+    return port_create_tuple2(ctx, OK_ATOM, t);
 }
 
 void port_send_reply(Context *ctx, term pid, term ref, term reply)

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -23,19 +23,13 @@
 #include "globalcontext.h"
 #include "context.h"
 #include "term.h"
-
-extern const char *const port_ok_a;
-extern const char *const port_error_a;
-
-static inline term port_make_ok_atom(Context *ctx)
-{
-    return context_make_atom(ctx, port_ok_a);
-}
+#include "defaultatoms.h"
 
 term port_create_tuple2(Context *ctx, term a, term b);
 term port_create_tuple3(Context *ctx, term a, term b, term c);
 term port_create_tuple_n(Context *ctx, size_t num_terms, term *terms);
-term port_create_error_tuple(Context *ctx, const char *reason);
+term port_create_error_tuple(Context *ctx, term reason);
+term port_create_sys_error_tuple(Context *ctx, AtomString syscall, int errno);
 term port_create_ok_tuple(Context *ctx, term t);
 void port_send_reply(Context *ctx, term pid, term ref, term reply);
 void port_ensure_available(Context *ctx, size_t size);

--- a/src/libAtomVM/socket.c
+++ b/src/libAtomVM/socket.c
@@ -97,7 +97,7 @@ static void socket_consume_mailbox(Context *ctx)
     } else if (cmd_name == context_make_atom(ctx, recvfrom_a)) {
         socket_driver_do_recvfrom(ctx, pid, ref);
     } else {
-        port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, "unrecognized command"));
+        port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, BADARG_ATOM));
     }
 
     free(message);

--- a/src/platforms/esp32/main/network_driver.c
+++ b/src/platforms/esp32/main/network_driver.c
@@ -81,7 +81,7 @@ void network_driver_setup(Context *ctx, term_ref pid, term_ref ref, term config)
             if (psk != NULL) {
                 free(psk);
             }
-            term reply = port_create_error_tuple(ctx, "cannot allocate memory for ssid or psk");
+            term reply = port_create_error_tuple(ctx, OUT_OF_MEMORY_ATOM);
             port_send_reply(ctx, pid, ref, reply);
             return;
         }
@@ -97,7 +97,7 @@ void network_driver_setup(Context *ctx, term_ref pid, term_ref ref, term config)
             TRACE("ssid or psk is too long\n");
             free(ssid);
             free(psk);
-            term reply = port_create_error_tuple(ctx, "ssid or psk is too long");
+            term reply = port_create_error_tuple(ctx, BADARG_ATOM);
             port_send_reply(ctx, pid, ref, reply);
             return;
         }
@@ -122,11 +122,9 @@ void network_driver_setup(Context *ctx, term_ref pid, term_ref ref, term config)
                 sntp_init();
             }
         }
-        // TODO make this async
-        term reply = context_make_atom(ctx, port_ok_a);
-        port_send_reply(ctx, pid, ref, reply);
+        port_send_reply(ctx, pid, ref, OK_ATOM);
     } else {
-        term reply = port_create_error_tuple(ctx, "unsupported config");
+        term reply = port_create_error_tuple(ctx, BADARG_ATOM);
         port_send_reply(ctx, pid, ref, reply);
     }
 }

--- a/src/platforms/generic_unix/network_driver.c
+++ b/src/platforms/generic_unix/network_driver.c
@@ -24,10 +24,10 @@
 void network_driver_setup(Context *ctx, term pid, term ref, term config)
 {
     UNUSED(config);
-    port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, "unimplemented"));
+    port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, UNDEFINED_ATOM));
 }
 
 term network_driver_ifconfig(Context *ctx)
 {
-    return port_create_error_tuple(ctx, "unimplemented");
+    return port_create_error_tuple(ctx, UNDEFINED_ATOM);
 }

--- a/src/platforms/generic_unix/socket_driver.c
+++ b/src/platforms/generic_unix/socket_driver.c
@@ -47,6 +47,12 @@
 static const char *const tag_proto_a = "\x5" "proto";
 static const char *const proto_udp_a = "\x3" "udp";
 static const char *const proto_tcp_a = "\x3" "tcp";
+static const char *const socket_a    = "\x6" "socket";
+static const char *const fcntl_a     = "\x5" "fcntl";
+static const char *const bind_a      = "\x4" "bind";
+static const char *const getsockname_a = "\xB" "getsockname";
+static const char *const sendto_a      = "\x6" "sendto";
+static const char *const recvfrom_a    = "\x8" "recvfrom";
 
 typedef struct SocketDriverData
 {
@@ -72,32 +78,30 @@ term socket_driver_do_init(Context *ctx, term params)
     SocketDriverData *socket_data = (SocketDriverData *) ctx->platform_data;
 
     if (!term_is_list(params)) {
-        return port_create_error_tuple(ctx, "badarg: params is not a list");
+        return port_create_error_tuple(ctx, BADARG_ATOM);
     }
     term proto = interop_proplist_get_value(params, context_make_atom(ctx, tag_proto_a));
 
     if (term_is_nil(proto)) {
-        return port_create_error_tuple(ctx, "badarg: no proto in params");
+        return port_create_error_tuple(ctx, BADARG_ATOM);
     }
 
     if (proto == context_make_atom(ctx, proto_udp_a)) {
         int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
         if (sockfd == -1) {
-            const char *error_string = strerror(errno);
-            return port_create_error_tuple(ctx, error_string);
+            return port_create_sys_error_tuple(ctx, socket_a, errno);
         }
         socket_data->sockfd = sockfd;
     } else if (proto == context_make_atom(ctx, proto_tcp_a)) {
         socket_data->sockfd = socket(AF_INET, SOCK_STREAM, 0);
     } else {
-        return port_create_error_tuple(ctx, "badarg: unsupported protocol");
+        return port_create_error_tuple(ctx, BADARG_ATOM);
     }
     if (fcntl(socket_data->sockfd, F_SETFL, O_NONBLOCK) == -1){
-        const char *error_string = strerror(errno);
-        return port_create_error_tuple(ctx, error_string);
+        return port_create_sys_error_tuple(ctx, fcntl_a, errno);
     }
 
-    return context_make_atom(ctx, port_ok_a);
+    return OK_ATOM;
 }
 
 
@@ -115,12 +119,10 @@ term socket_driver_do_bind(Context *ctx, term address, term port)
 
     socklen_t address_len = sizeof(serveraddr);
     if (bind(socket_data->sockfd, (struct sockaddr *) &serveraddr, address_len) == -1) {
-        const char *error_string = strerror(errno);
-        return port_create_error_tuple(ctx, error_string);
+        return port_create_sys_error_tuple(ctx, bind_a, errno);
     } else {
         if (getsockname(socket_data->sockfd, (struct sockaddr *) &serveraddr, &address_len) == -1) {
-            const char *error_string = strerror(errno);
-            return port_create_error_tuple(ctx, error_string);
+            return port_create_sys_error_tuple(ctx, getsockname_a, errno);
         } else {
             term port_atom = term_from_int32(ntohs(serveraddr.sin_port));
             return port_create_ok_tuple(ctx, port_atom);
@@ -147,15 +149,14 @@ term socket_driver_do_send(Context *ctx, term dest_address, term dest_port, term
         buf = interop_list_to_string(buffer);
         len = strlen(buf);
     } else {
-        return port_create_error_tuple(ctx, "unsupported type for send");
+        return port_create_error_tuple(ctx, BADARG_ATOM);
     }
 
     TRACE("send: data with len: %i, to: %i, port: %i\n", len, ntohl(addr.sin_addr.s_addr), ntohs(addr.sin_port));
 
     int sent_data = sendto(socket_data->sockfd, buf, len, 0, (struct sockaddr *) &addr, sizeof(addr));
     if (sent_data == -1) {
-        const char *error_string = strerror(errno);
-        return port_create_error_tuple(ctx, error_string);
+        return port_create_sys_error_tuple(ctx, sendto_a, errno);
     } else {
         term sent_atom = term_from_int32(sent_data);
         return port_create_ok_tuple(ctx, sent_atom);
@@ -186,21 +187,17 @@ static void recvfrom_callback(void *data)
         abort();
     }
 
-    term pid = recvfrom_data->pid;
-    term ref = term_from_ref_ticks(recvfrom_data->ref_ticks, ctx);
-
     ssize_t len = recvfrom(socket_data->sockfd, buf, BUFSIZE, 0, (struct sockaddr *) &clientaddr, &clientlen);
     if (len == -1) {
-        // {Ref, {error, string}}
+        // {Ref, {error, {SysCall, Errno}}}
+        // tuple arity 2:       3
         // tuple arity 2:       3
         // tuple arity 2:       3
         // ref:                 3 (max)
-        // string               2*strlen(string)
-        const char *error_string = strerror(errno);
-        port_ensure_available(ctx, 9 + 2*strlen(error_string) + 1);
+        port_ensure_available(ctx, 12);
         term pid = recvfrom_data->pid;
         term ref = term_from_ref_ticks(recvfrom_data->ref_ticks, ctx);
-        port_send_reply(ctx, pid, ref, port_create_error_tuple(ctx, error_string));
+        port_send_reply(ctx, pid, ref, port_create_sys_error_tuple(ctx, sendto_a, errno));
     } else {
         // {Ref, {{int,int,int,int}, int, binary}}
         // tuple arity 2:       3


### PR DESCRIPTION
This changeset fixes messages of the form {error, Reason} returned from port drivers, so that atoms or tuples are bound to the Reason in an error tuple, instead of arbitrary strings.  Doing this prevents potential crashes due to dynamic memory allocation in port drivers..

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
