### PR TITLE
Fix UDP Socket server

### DIFF
--- a/src/platforms/generic_unix/socket_driver.c
+++ b/src/platforms/generic_unix/socket_driver.c
@@ -199,13 +199,14 @@ static void recvfrom_callback(void *data)
         term ref = term_from_ref_ticks(recvfrom_data->ref_ticks, ctx);
         port_send_reply(ctx, pid, ref, port_create_sys_error_tuple(ctx, sendto_a, errno));
     } else {
-        // {Ref, {{int,int,int,int}, int, binary}}
+        // {Ref, {ok, {{int,int,int,int}, int, binary}}}
         // tuple arity 2:       3
         // tuple arity 3:       4
         // tuple arity 4:       5
+        // tuple arity 2:       3
         // ref:                 3 (max)
         // binary:              2 + len(binary)/WORD_SIZE + 1
-        port_ensure_available(ctx, 18 + len/(TERM_BITS/8));
+        port_ensure_available(ctx, 20 + len/(TERM_BITS/8) + 1);
         term pid = recvfrom_data->pid;
         term ref = term_from_ref_ticks(recvfrom_data->ref_ticks, ctx);
         term addr = socket_tuple_from_addr(ctx, htonl(clientaddr.sin_addr.s_addr));

--- a/src/platforms/generic_unix/sys.c
+++ b/src/platforms/generic_unix/sys.c
@@ -144,7 +144,7 @@ extern void sys_waitevents(GlobalContext *glb)
 #endif
             listener = next_listener;
             listeners = GET_LIST_ENTRY(glb->listeners, EventListener, listeners_list_head);
-        } while (listener != listeners);
+        } while (listeners != NULL && listener != listeners);
 
 #ifndef USE_SELECT
         free(fds);
@@ -179,7 +179,7 @@ extern void sys_waitevents(GlobalContext *glb)
 
             listener = next_listener;
             listeners = GET_LIST_ENTRY(glb->listeners, EventListener, listeners_list_head);
-        } while (listener != last_listener);
+        } while (listeners != NULL && listener != last_listener);
     }
 }
 


### PR DESCRIPTION
This change set fixes the UDP Socket server code, so that:

1. The correct estimated heap size is calculated
2. The in-flight update to listeners checks against the possibility of a NULL value after the update

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
