### PR TITLE
Update socket_driver.c in order to make it compilable

### DIFF
--- a/src/platforms/esp32/main/socket_driver.c
+++ b/src/platforms/esp32/main/socket_driver.c
@@ -47,10 +47,12 @@ static const char *const proto_udp_a = "\x3" "udp";
 static const char *const proto_tcp_a = "\x3" "tcp";
 static const char *const socket_a    = "\x6" "socket";
 static const char *const fcntl_a     = "\x5" "fcntl";
-static const char *const bind_a      = "\x4" "bind";
-static const char *const getsockname_a = "\xB" "getsockname";
+
+// 3 unused variables -> won't compile using esp-idf v 3.2
+// static const char *const bind_a      = "\x4" "bind";
+// static const char *const getsockname_a = "\xB" "getsockname";
+// static const char *const recvfrom_a    = "\x8" "recvfrom"; 
 static const char *const sendto_a      = "\x6" "sendto";
-static const char *const recvfrom_a    = "\x8" "recvfrom";
 
 // TODO use net_conn instead of BSD Sockets
 


### PR DESCRIPTION
commented out unused static var declarations (bind_a, getsockname_a,  recvfrom_a) because otherwise it won't be comilable using esp-idf 3.2 which defines -Werror=unused-const-variable - i did not delete because i feel there is missing some code which should use these vars.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
