### PR TITLE
Update main.c

### DIFF
--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -66,10 +66,18 @@ void app_main()
 
     printf("Starting: %s...\n", startup_module_name);
     printf("---\n");
-    context_execute_loop(ctx, mod, "start", 0);
-    printf("Return value: %lx\n", (long) term_to_int32(ctx->x[0]));
-
-    while(1);
+    context_execute_loop(ctx, mod, "start", 0);    
+    term ret_value = ctx->x[0];
+    fprintf(stderr, "AtomVM finished with return value = ");
+    term_display(stderr, ret_value, ctx);
+    fprintf(stderr, "\n");
+    
+    fprintf(stderr, "going to sleep forever..\n");
+    while(1) {
+        // avoid task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time
+        // ..
+        vTaskDelay(5000 / portTICK_PERIOD_MS);
+    }
 }
 
 const void *avm_partition(int *size)


### PR DESCRIPTION
- fixed display of AtomVM's exit value
- modified forever-loop at the end of main to avoid avoid console messages like
task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time
messages

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
