### PR TITLE
Fixes for gen_udp module (Erlang side only)

### DIFF
--- a/examples/erlang/esp32/udp_server_blink.erl
+++ b/examples/erlang/esp32/udp_server_blink.erl
@@ -9,21 +9,26 @@
 -define(OFF, 0).
 
 start() ->
-    Self = self(),
-    Config = [
-        {sta, [
-            {ssid, "myssid"},
-            {psk,  "mypsk"},
-            {connected, fun() -> Self ! connected end},
-            {got_ip, fun(IpInfo) -> Self ! {ok, IpInfo} end},
-            {disconnected, fun() -> Self ! disconnected end}
-        ]}
-    ],
-    case network_fsm:start(Config) of
-        ok ->
-            wait_for_message();
-        Error ->
-            erlang:display(Error)
+    try
+        Self = self(),
+        Config = [
+            {sta, [
+                {ssid, "myssid"},
+                {psk,  "mypsk"},
+                {connected, fun() -> Self ! connected end},
+                {got_ip, fun(IpInfo) -> Self ! {ok, IpInfo} end},
+                {disconnected, fun() -> Self ! disconnected end}
+            ]}
+        ],
+        case network_fsm:start(Config) of
+            ok ->
+                wait_for_message();
+            Error ->
+                erlang:display(Error)
+        end
+    catch
+        _:E ->
+            erlang:display(E)
     end.
 
 
@@ -44,29 +49,22 @@ wait_for_message() ->
 
 udp_server_start() ->
     console:puts("Opening socket 44444 ...\n"),
-    Socket = ?GEN_UDP:open(44444),
+    {ok, Socket} = ?GEN_UDP:open(44444, [{active, false}]),
     erlang:display(Socket),
     Gpio = gpio:open(),
     gpio:set_direction(Gpio, ?PIN, output),
-    udp_server_loop(Socket, Gpio, off).
-
-
-udp_server_loop(Socket, Gpio, PinState) ->
     console:puts("Waiting to receive data...\n"),
-    case ?GEN_UDP:recv(Socket, 1000) of
+    passive_loop(Socket, Gpio, 0).
+
+
+passive_loop(Socket, Gpio, PinState) ->
+    gpio:set_level(Gpio, ?PIN, PinState),
+    NewPinState = case ?GEN_UDP:recv(Socket, 128) of
         {ok, RecvData} ->
-            {Address, Port, Packet} = RecvData,
-            console:puts("Address: "),  erlang:display(Address),
-            console:puts("Port: "),     erlang:display(Port),
-            console:puts("Packet: "),   erlang:display(Packet),
-            case PinState of
-                on ->
-                    gpio:set_level(Gpio, ?PIN, ?OFF),
-                    udp_server_loop(Socket, Gpio, off);
-                off ->
-                    gpio:set_level(Gpio, ?PIN, ?ON),
-                    udp_server_loop(Socket, Gpio, on)
-            end;
-        {error, Reason} ->
-            console:puts("An error ocurred: "), erlang:display(Reason)
-    end.
+            erlang:display(RecvData),
+            1 - PinState;
+        ErrorReason ->
+            erlang:display(ErrorReason),
+            PinState
+    end,
+    passive_loop(Socket, Gpio, NewPinState).

--- a/libs/estdlib/CMakeLists.txt
+++ b/libs/estdlib/CMakeLists.txt
@@ -11,6 +11,7 @@ set(ERLANG_MODULES
     avm_gen_server
     avm_gen_statem
     avm_gen_udp
+    avm_inet
     avm_lists
     avm_proplists
     avm_timer

--- a/libs/estdlib/avm_gen_udp.erl
+++ b/libs/estdlib/avm_gen_udp.erl
@@ -20,15 +20,18 @@
 %%-----------------------------------------------------------------------------
 %% @doc An implementation of the Erlang/OTP gen_udp interface.
 %%
-%% This module provides an implementation of the Erlang/OTP gen_udp interface.
-%% It is designed to be API-compatible with gen_udp, with exceptions noted
-%% below.
+%% This module provides an implementation of a subset of the functionality of
+%% the Erlang/OTP gen_udp interface.  It is designed to be API-compatible with 
+%% gen_udp, with exceptions noted below.
+%%
+%% This interface may be used to send and receive UDP packets, as either
+%% binaries or strings.  Active and passive modes are supported for receiving data.
 %%
 %% Caveats:
 %% <ul>
 %%     <li>Currently no support for IPv6</li>
-%%     <li>Currently no support for socket tuning parameters</li>
-%%     <li>Receive packet size limited to 128 bytes</li>
+%%     <li>Currently limited support for socket tuning parameters</li>
+%%     <li>Currently no support for closing sockets</li>
 %% </ul>
 %%
 %% <em><b>Note.</b>  Port drivers for this interface are not supported
@@ -37,18 +40,9 @@
 %%-----------------------------------------------------------------------------
 -module(avm_gen_udp).
 
--export([open/1, open/2, send/4, recv/2, recv/3]).
--export([get_port_num/1]).
+-export([open/1, open/2, send/4, recv/2, recv/3, close/1]).
+-export([start_recv_loop/1]).
 
--record(
-    socket, {
-        pid,
-        port
-    }
-).
-
--type port_num() :: 0..65535.
--opaque socket() :: #socket{}.
 -type proplist() :: [{atom(), any()}].
 -type address() :: ipv4_address().
 -type ipv4_address() :: {octet(), octet(), octet(), octet()}.
@@ -56,28 +50,36 @@
 -type packet() :: string() | binary().
 -type reason() :: term().
 
--export_type([socket/0]).
+-record(
+    data, {
+        driver_pid      :: pid(),
+        controlling_pid :: pid() | undefined,
+        receiving_pid   :: pid() 
+    }
+).
+
+-include("estdlib.hrl").
+
+-define(DEFAULT_PARAMS, [{active, true}, {buffer, 128}, binary, {timeout, infinity}]).
 
 %%-----------------------------------------------------------------------------
 %% @doc     Create a UDP socket.  This function will instatiate a UDP socket
 %%          that may be used to
 %%          send or receive UDP messages.
-%% @equiv   open(Port, [])
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(port_num()) -> socket().
-open(Port) ->
-    open(Port, []).
+-spec open(avm_inet:port_number()) -> {ok, avm_inet:socket()} | {error, Reason::reason()}.
+open(PortNum) ->
+    open(PortNum, []).
 
 %%-----------------------------------------------------------------------------
 %% @param   Port the port number to bind to.  Specify 0 to use an OS-assigned
-%%          port number, which can then be retrieved via the get_port_num
+%%          port number, which can then be retrieved via the inet:port/1
 %%          function.
 %% @param   Params A list of configuration parameters.
 %% @returns an opaque reference to the socket instance, used in subsequent
 %%          commands.
 %% @throws  bad_arg
-%% @see     get_port_num/1
 %% @doc     Create a UDP socket.  This function will instatiate a UDP socket
 %%          that may be used to send or receive UDP messages.
 %%          This function will raise an exception with the bad_arg atom if
@@ -86,12 +88,15 @@ open(Port) ->
 %%          <em><b>Note.</b>  The Params argument is currently ignored.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(port_num(), proplist()) -> socket().
-open(Port, _Params) ->
-    Pid = open_port({spawn, "socket"}, []),
-    ok = init(Pid, [{proto, udp}]),
-    {ok, ActualPort} = bind(Pid, {127, 0, 0, 1}, Port),
-    #socket{pid=Pid, port=ActualPort}.
+-spec open(avm_inet:port_number(), proplist()) -> {ok, avm_inet:socket()} | {error, Reason::reason()}.
+open(PortNum, Params0) ->
+    Params = merge(Params0, ?DEFAULT_PARAMS),
+    DriverPid = open_port({spawn, "socket"}, []),
+    try_init(
+        init(DriverPid, [{proto, udp}, {binary, ?PROPLISTS:get_value(binary, Params)}]), 
+        DriverPid, PortNum, Params
+    ).
+
 
 %%-----------------------------------------------------------------------------
 %% @param   Socket the socket over which to send a packet
@@ -104,9 +109,10 @@ open(Port, _Params) ->
 %%          <em><b>Note.</b> Currently only ipv4 addresses are supported.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec send(socket(), address(), port_num(), packet()) -> ok | {error, reason()}.
-send(#socket{pid=Pid} = _Socket, Address, Port, Packet) ->
-    case call(Pid, {send, Address, Port, Packet}) of
+-spec send(avm_inet:socket(), address(), avm_inet:port_number(), packet()) -> ok | {error, reason()}.
+send(Socket, Address, PortNum, Packet) ->
+    #data{driver_pid=DriverPid} = avm_inet:data(Socket),
+    case call(DriverPid, {send, Address, PortNum, Packet}) of
         {ok, _Sent} ->
             ok;
         Else -> Else
@@ -117,8 +123,8 @@ send(#socket{pid=Pid} = _Socket, Address, Port, Packet) ->
 %% @doc     Receive a packet over a UDP socket from a source address/port.
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(socket(), non_neg_integer()) ->
-    {ok, {address(), port_num(), packet()}} | {error, reason()}.
+-spec recv(avm_inet:socket(), non_neg_integer()) ->
+    {ok, {address(), avm_inet:port_number(), packet()}} | {error, reason()}.
 recv(Socket, Length) ->
     recv(Socket, Length, infinity).
 
@@ -139,42 +145,127 @@ recv(Socket, Length) ->
 %%          is limited to 128 bytes.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(socket(), non_neg_integer(), non_neg_integer()) ->
-    {ok, {address(), port_num(), packet()}} | {error, reason()}.
-recv(#socket{pid=Pid} = _Socket, Length, Timeout) ->
-    call(Pid, {recvfrom, Length, Timeout}).
+-spec recv(avm_inet:socket(), non_neg_integer(), non_neg_integer()) ->
+    {ok, {address(), avm_inet:port_number(), packet()}} | {error, reason()}.
+recv(Socket, Length, Timeout) ->
+    #data{driver_pid=DriverPid} = avm_inet:data(Socket),
+    internal_recv(DriverPid, Length, Timeout).
 
 
 %%-----------------------------------------------------------------------------
-%% @param   Socket the socket from which to obtain the bound port number
-%% @returns the port number to which the socket is bound
-%% @doc     Retrieve the actual port number to which the socket is bound.
-%%          This function is useful if the port assignment is done by the
-%%          operating system.
-%%
-%%          <em><b>Note.</b>  This function is not a part of the Erlang/OTP
-%%          gen_udp interface.</em>
+%% @param   Socket the socket to close
+%% @returns ok, if closing the socket succeeded, or {error, Reason}, if
+%%          closing the socket failed for any reason.
+%% @doc     Close the socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_port_num(socket()) -> port_num().
-get_port_num(#socket{port=Port}) ->
-    Port.
+-spec close(avm_inet:socket()) -> ok | {error, Reason::reason()}.
+close(Socket) ->
+    #data{driver_pid=DriverPid, receiving_pid=ReceivingPid} = avm_inet:data(Socket),
+    case ReceivingPid of
+        undefined -> ok;
+        _ ->
+            ReceivingPid ! stop
+    end,
+    call(DriverPid, {close}).
+
 
 %% internal operations
 
 %% @private
-init(Pid, Params) ->
-    call(Pid, {init, Params}).
+try_init(ok, DriverPid, PortNum, Params) ->
+    try_bind(bind(DriverPid, {127, 0, 0, 1}, PortNum), DriverPid, Params);
+try_init(ErrorReason, _DriverPid, _PortNum, _Params) ->
+    ErrorReason.
 
 %% @private
-bind(Pid, Address, Port) ->
-    call(Pid, {bind, Address, Port}).
+try_bind({ok, ActualPortNum}, DriverPid, Params) ->
+    Self = self(),
+    ReceivingPid = case ?PROPLISTS:get_value(active, Params) of
+        true ->
+            erlang:spawn(?MODULE, start_recv_loop, [Params]);
+        _ ->
+            undefined
+    end,
+    Data = #data{
+        driver_pid=DriverPid, 
+        controlling_pid=Self, 
+        receiving_pid=ReceivingPid
+    },
+    Socket = avm_inet:create(ActualPortNum, Data),
+    case ReceivingPid of
+        undefined -> ok;
+        _ ->
+            ReceivingPid ! Socket
+    end,
+    {ok, Socket};
+try_bind(ErrorReason, _DriverPid, _Params) ->
+    ErrorReason.
+
+% @private
+internal_recv(DriverPid, Length, Timeout) ->
+    call(DriverPid, {recvfrom, Length, Timeout}).
 
 %% @private
-call(Pid, Msg) ->
+init(DriverPid, Params) ->
+    call(DriverPid, {init, Params}).
+
+%% @private
+bind(DriverPid, Address, PortNum) ->
+    call(DriverPid, {bind, Address, PortNum}).
+
+%% @private
+call(DriverPid, Msg) ->
     Ref = erlang:make_ref(),
-    Pid ! {self(),  Ref, Msg},
+    DriverPid ! {self(), Ref, Msg},
     receive
         {Ref, Ret} ->
             Ret
+    end.
+
+%% @hidden
+start_recv_loop(Params) ->
+    receive
+        Socket -> recv_loop(Socket, Params)
+    end.
+
+%% @private
+recv_loop(Socket, Params) ->
+    #data{controlling_pid=ControllingPid, driver_pid=DriverPid} = avm_inet:data(Socket),
+    Length = ?PROPLISTS:get_value(buffer, Params),
+    Timeout = ?PROPLISTS:get_value(timeout, Params),
+    case internal_recv(DriverPid, Length, Timeout) of
+        {ok, {Address, Port, Packet}} ->
+            ControllingPid ! {udp, Socket, Address, Port, Packet};
+        ErrorReason ->
+            %% TODO is this right?  Docs don't say
+            ControllingPid ! {udp, Socket, ErrorReason}
+    end,
+    receive
+        stop ->
+            ok
+    after 1 ->
+        recv_loop(Socket, Params)
+    end.
+
+
+%% TODO implement this in lists
+
+%% @private
+merge(Config, Defaults) ->
+    merge(Config, Defaults, []).
+
+%% @private
+merge(_Config, [], Accum) ->
+    Accum;
+merge(Config, [H | T], Accum) ->
+    Key = case H of
+        {K, _V} -> K;
+        K -> K
+    end,
+    case ?PROPLISTS:get_value(Key, Config) of
+        undefined ->
+            merge(Config, T, [H | Accum]);
+        Value ->
+            merge(Config, T, [{Key, Value}|Accum])
     end.

--- a/libs/estdlib/avm_inet.erl
+++ b/libs/estdlib/avm_inet.erl
@@ -16,13 +16,42 @@
 %   Free Software Foundation, Inc.,                                       %
 %   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-module(avm_inet).
 
--define(CALENDAR,       avm_calendar).
--define(ERLANG,             erlang).
--define(GEN_SERVER,     avm_gen_server).
--define(GEN_STATEM,     avm_gen_statem).
--define(INET,           avm_inet).
--define(GEN_UDP,        avm_gen_udp).
--define(LISTS,          avm_lists).
--define(PROPLISTS,      avm_proplists).
--define(TIMER,          avm_timer).
+-export([port/1]).
+-export([create/2, data/1]).
+
+-type port_number() :: 0..65535.
+
+-record(
+    socket, {
+        port :: port_number(),
+        data :: term()
+    }
+).
+
+-type socket() :: #socket{}.
+
+-export_type([socket/0, port_number/0]).
+
+%% @hidden
+-spec create(Port::port_number(), Data::term()) -> socket().
+create(Port, Data) ->
+    #socket{port=Port, data=Data}.
+
+%%-----------------------------------------------------------------------------
+%% @param   Socket the socket from which to obtain the port number
+%% @returns the port number associated with the local socket
+%% @doc     Retrieve the actual port number to which the socket is bound.
+%%          This function is useful if the port assignment is done by the
+%%          operating system.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec port(Socket::socket()) -> port_number().
+port(#socket{port=Port}) ->
+    Port.
+
+%% @hidden
+-spec data(Socket::socket()) -> term().
+data(#socket{data=Data}) ->
+    Data.


### PR DESCRIPTION
This set of changes makes improvements to the gen_udp module to align it more closely with the OTP gen_udp interface.

These changes are only on the Erlang side.  Another set of changes will be made on the driver side.

Changes include:

* Fixed signature of open to return {ok, Socket}
* added avm_inet module to support extraction of port from a Socket, and removed the non-standard get_port_num function
* Added support for active and passive mode
* Added close operation (unsupported until changes on driver side)
* Added ability to specify binary or string on receive (unsupported until changes on driver side)
* Added ability to specify buffer size (unsupported until changes on driver side)

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
