### PR TITLE
Workaround for race condition in logger test failure.

### DIFF
--- a/tests/libs/eavmlib/test_logger.erl
+++ b/tests/libs/eavmlib/test_logger.erl
@@ -74,6 +74,7 @@ increment_counter(Level) ->
     Pid ! {increment, Level}.
 
 get_counter(Level) ->
+    ?TIMER:sleep(50),
     Pid = erlang:whereis(counter),
     Ref = erlang:make_ref(),
     Pid ! {self(), Ref, get_counter, Level},


### PR DESCRIPTION
The AVM logger module is by design asynchronous.  This change adds a sleep to the retrieval of the counted logs to wait for the logger sink to be invoked, and hence the counter to be updated.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
