### PR TITLE
gen_udp test and fixes

### DIFF
--- a/libs/estdlib/avm_inet.erl
+++ b/libs/estdlib/avm_inet.erl
@@ -35,5 +35,13 @@
 %%-----------------------------------------------------------------------------
 -spec port(Socket::socket()) -> port_number().
 port(Socket) ->
-    %% TODO implement a call to the port to get the actual port
-    undefined.
+    call(Socket, {get_port}).
+
+%% @private
+call(Socket, Msg) ->
+    Ref = erlang:make_ref(),
+    Socket ! {self(), Ref, Msg},
+    receive
+        {Ref, Ret} ->
+            Ret
+    end.

--- a/src/libAtomVM/socket_driver.h
+++ b/src/libAtomVM/socket_driver.h
@@ -29,5 +29,7 @@ void socket_driver_delete_data(void *data);
 term socket_driver_do_init(Context *ctx, term params);
 term socket_driver_do_send(Context *ctx, term dest_address, term dest_port, term buffer);
 void socket_driver_do_recvfrom(Context *ctx, term pid, term ref);
+void socket_driver_do_close(Context *ctx);
+term socket_driver_get_port(Context *ctx);
 
 #endif

--- a/src/platforms/generic_unix/sys.c
+++ b/src/platforms/generic_unix/sys.c
@@ -111,9 +111,9 @@ extern void sys_waitevents(GlobalContext *glb)
                 fds[poll_fd_index].fd = listener->fd;
                 fds[poll_fd_index].events = POLLIN;
                 fds[poll_fd_index].revents = 0;
+                poll_fd_index++;
             }
 
-            poll_fd_index++;
 
             listener = GET_LIST_ENTRY(listener->listeners_list_head.next, EventListener, listeners_list_head);
         } while (listener != listeners);

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -9,6 +9,7 @@ include(BuildErlang)
 set(ERLANG_MODULES
     test_gen_server
     test_gen_statem
+    test_gen_udp
     test_lists
     test_proplists
     test_timer

--- a/tests/libs/estdlib/test_gen_udp.erl
+++ b/tests/libs/estdlib/test_gen_udp.erl
@@ -1,0 +1,50 @@
+-module(test_gen_udp).
+
+-export([test/0, start_sender/3]).
+
+-include("estdlib.hrl").
+-include("etest.hrl").
+
+test() ->
+    ok = test_send_receive_active(),
+    ok.
+
+test_send_receive_active() ->
+    {ok, Socket} = ?GEN_UDP:open(0, [{active, true}]),
+    {ok, Port} = ?INET:port(Socket),
+    NumToSend = 10,
+    Sender = erlang:spawn(?MODULE, start_sender, [Socket, Port, make_messages(NumToSend)]),
+    NumReceived = count_received(),
+    Sender ! stop,
+    ?ASSERT_TRUE((0 < NumReceived) and (NumReceived =< NumToSend)),
+    ok = ?GEN_UDP:close(Socket),
+    ok.
+
+
+make_messages(0) ->
+    [];
+make_messages(N) ->
+    [<<"foo">> | make_messages(N - 1)].
+
+start_sender(Socket, Port, Msgs) ->
+    send(Socket, Port, Msgs),
+    receive stop -> 
+        ok 
+    end.
+
+send(_Socket, _Port, []) ->
+    ok;
+send(Socket, Port, [Msg | Rest]) ->
+    ?GEN_UDP:send(Socket, {127,0,0,1}, Port, Msg),
+    send(Socket, Port, Rest).
+
+count_received() ->
+    count_received(0).
+
+count_received(I) ->
+    receive
+        _Msg ->
+            count_received(I + 1)
+    after 100 ->
+        I
+    end.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -7,6 +7,7 @@ start() ->
         test_lists
         , test_gen_server
         , test_gen_statem
+        , test_gen_udp
         , test_proplists
         , test_timer
     ]).

--- a/tools/dev/clean-whitespace.sh
+++ b/tools/dev/clean-whitespace.sh
@@ -14,8 +14,15 @@ function clean_file {
     rm ${file}.cleaned
 }
 
+nargs=$#
+if [ "${nargs}" -gt 0 ]; then
+    files=$@
+else
+    files=$(git ls-files)
+fi
+
 cd ${ROOT_DIR}
-for f in $(git ls-files); do
+for f in $@; do
     case $f in
         *.sh | *.erl | *.c | *.h | *.txt)
             clean_file $f


### PR DESCRIPTION
Add test for gen_udp, fixed close functionality, and added ability to get the actual port number, if a port is dynamically assigend.  

Also fixed a bug in generic_unix sys_waitevents, so that poll_fd_index is incremented only if the event listener has a file descriptor.  Otherwise, we run the risk of passing the wrong count into poll, which can SEGV.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.