### PR TITLE
Add support for string tables in beam files

### DIFF
--- a/src/libAtomVM/iff.c
+++ b/src/libAtomVM/iff.c
@@ -88,6 +88,9 @@ void scan_iff(const void *iff_binary, int buf_size, unsigned long *offsets, unsi
         } else if (!memcmp(current_record->name, "FunT", 4)) {
             offsets[FUNT] = current_pos;
             sizes[FUNT] = ENDIAN_SWAP_32(current_record->size);
+        } else if (!memcmp(current_record->name, "StrT", 4)) {
+            offsets[STRT] = current_pos;
+            sizes[STRT] = ENDIAN_SWAP_32(current_record->size);
         }
 
         current_pos += iff_align(ENDIAN_SWAP_32(current_record->size) + 8);

--- a/src/libAtomVM/iff.h
+++ b/src/libAtomVM/iff.h
@@ -46,12 +46,14 @@
 #define LITU 6
 /** Funs table section */
 #define FUNT 7
+/** Str table section */
+#define STRT 8
 
 
 /** Required size for offsets array */
-#define MAX_OFFS 8
+#define MAX_OFFS 9
 /** Required size for sizes array */
-#define MAX_SIZES 8
+#define MAX_SIZES 9
 
 /** sizeof IFF section header in bytes */
 #define IFF_SECTION_HEADER_SIZE 8

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -196,6 +196,8 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
     mod->export_table = beam_file + offsets[EXPT];
     mod->atom_table = beam_file + offsets[AT8U];
     mod->fun_table = beam_file + offsets[FUNT];
+    mod->str_table = beam_file + offsets[STRT];
+    mod->str_table_len = sizes[STRT];
     mod->labels = calloc(ENDIAN_SWAP_32(mod->code->labels), sizeof(void *));
     if (IS_NULL_PTR(mod->labels)) {
         module_destroy(mod);

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -61,6 +61,8 @@ struct Module
     void *export_table;
     void *atom_table;
     void *fun_table;
+    void *str_table;
+    size_t str_table_len;
 
     union imported_func *imported_funcs;
     void *local_labels;
@@ -225,6 +227,14 @@ static inline void module_get_fun(const Module *this_module, int fun_index, uint
     // index
     *n_freeze = READ_32_ALIGNED(table_data + fun_index * 24 + 16 + 12);
     // ouniq
+}
+
+static inline uint8_t *module_get_str(Module *mod, size_t offset, size_t *remaining) {
+    if (offset >= mod->str_table_len) {
+        return NULL;
+    }
+    *remaining = mod->str_table_len - offset;
+    return mod->str_table + 8 + offset;
 }
 
 #endif

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -298,6 +298,10 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
         fwrite(data + offsets[FUNT], sizeof(uint8_t), sizes[FUNT] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
+    if (offsets[STRT]) {
+        fwrite(data + offsets[STRT], sizeof(uint8_t), sizes[STRT] + IFF_SECTION_HEADER_SIZE, pack);
+        pad_and_align(pack);
+    }
 
     if (offsets[LITT]) {
         size_t u_size;


### PR DESCRIPTION
This PR adds support for parsing out string tables in BEAM files, and for including them in packed BEAM files.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
