### PR TITLE
Added support for avm_inet:sockname/1 and avm_inet:peername/1.

### DIFF
--- a/examples/erlang/esp32/tcp_server_blink.erl
+++ b/examples/erlang/esp32/tcp_server_blink.erl
@@ -53,6 +53,7 @@ tcp_server_start() ->
     case ?GEN_TCP:listen(44404, []) of
         {ok, ListenSocket} ->
             console:puts("Listening on port 44404.\n"),
+            erlang:display(?INET:sockname(ListenSocket)),
             Gpio = gpio:open(),
             gpio:set_direction(Gpio, ?PIN, output),
             spawn(fun() -> accept(ListenSocket, Gpio) end);
@@ -63,8 +64,9 @@ tcp_server_start() ->
 accept(ListenSocket, Gpio) ->
     console:puts("Waiting to accept connection...\n"),
     case ?GEN_TCP:accept(ListenSocket) of
-        {ok, _Socket} ->
+        {ok, Socket} ->
             console:puts("Accepted connection.\n"),
+            erlang:display({?INET:peername(Socket), ?INET:sockname(Socket)}),
             spawn(fun() -> accept(ListenSocket, Gpio) end),
             echo(Gpio, 0);
         Error ->

--- a/examples/erlang/esp32/udp_server_blink.erl
+++ b/examples/erlang/esp32/udp_server_blink.erl
@@ -52,7 +52,7 @@ udp_server_start() ->
     console:puts("Opening socket 44444 ...\n"),
     case ?GEN_UDP:open(44444, [{active, true}]) of
         {ok, Socket} ->
-            erlang:display(Socket),
+            erlang:display({Socket, ?INET:sockname(Socket)}),
             Gpio = gpio:open(),
             gpio:set_direction(Gpio, ?PIN, output),
             console:puts("Waiting to receive data...\n"),

--- a/examples/erlang/tcp_server.erl
+++ b/examples/erlang/tcp_server.erl
@@ -8,6 +8,7 @@ start() ->
     case ?GEN_TCP:listen(44404, []) of
         {ok, ListenSocket} ->
             console:puts("Listening on port 44404.\n"),
+            erlang:display(?INET:sockname(ListenSocket)),
             spawn(fun() -> accept(ListenSocket) end);
         Error ->
             erlang:display(Error)
@@ -16,8 +17,9 @@ start() ->
 accept(ListenSocket) ->
     console:puts("Waiting to accept connection...\n"),
     case ?GEN_TCP:accept(ListenSocket) of
-        {ok, _Socket} ->
+        {ok, Socket} ->
             console:puts("Accepted connection.\n"),
+            erlang:display({?INET:peername(Socket), ?INET:sockname(Socket)}),
             spawn(fun() -> accept(ListenSocket) end),
             echo();
         Error ->

--- a/examples/erlang/udp_server.erl
+++ b/examples/erlang/udp_server.erl
@@ -9,7 +9,7 @@ start() ->
     Active = true,
     case ?GEN_UDP:open(44444, [{active, Active}]) of
         {ok, Socket} ->
-            erlang:display(Socket),
+            erlang:display({Socket, ?INET:sockname(Socket)}),
             console:puts("Waiting to receive data...\n"),
             case Active of
                 true -> active_loop();

--- a/libs/estdlib/avm_gen_tcp.erl
+++ b/libs/estdlib/avm_gen_tcp.erl
@@ -141,9 +141,9 @@ recv(Socket, Length, Timeout) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec listen(Port::avm_inet:port_number(), Options::avm_inet:opts()) -> {ok, ListeningSocket::avm_inet:socket()} | {error, Reason::term()}.
-listen(Port, Options0) ->
+listen(Port, Options) ->
     Socket = open_port({spawn, "socket"}, []),
-    Params = merge(Options0, ?DEFAULT_PARAMS),
+    Params = merge(Options, ?DEFAULT_PARAMS),
     InitParams = [
         {proto, tcp},
         {listen, true},
@@ -244,7 +244,7 @@ call(DriverPid, Msg) ->
 
 %% @private
 merge(Config, Defaults) ->
-    merge(Config, Defaults, []).
+    merge(Config, Defaults, []) ++ Config.
 
 %% @private
 merge(_Config, [], Accum) ->

--- a/libs/estdlib/avm_gen_udp.erl
+++ b/libs/estdlib/avm_gen_udp.erl
@@ -43,15 +43,12 @@
 -export([open/1, open/2, send/4, recv/2, recv/3, close/1]).
 
 -type proplist() :: [{atom(), any()}].
--type address() :: ipv4_address().
--type ipv4_address() :: {octet(), octet(), octet(), octet()}.
--type octet() :: 0..255.
 -type packet() :: string() | binary().
 -type reason() :: term().
 
 -include("estdlib.hrl").
 
--define(DEFAULT_PARAMS, [{active, false}, {buffer, 128}, {binary, true}, {address, {127, 0, 0, 1}}, {timeout, infinity}]).
+-define(DEFAULT_PARAMS, [{active, false}, {buffer, 128}, {binary, true}, {timeout, infinity}]).
 
 %%-----------------------------------------------------------------------------
 %% @doc     Create a UDP socket.  This function will instatiate a UDP socket
@@ -96,7 +93,7 @@ open(PortNum, Params0) ->
 %%          <em><b>Note.</b> Currently only ipv4 addresses are supported.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec send(avm_inet:socket(), address(), avm_inet:port_number(), packet()) -> ok | {error, reason()}.
+-spec send(avm_inet:socket(), avm_inet:address(), avm_inet:port_number(), packet()) -> ok | {error, reason()}.
 send(Socket, Address, PortNum, Packet) ->
     case call(Socket, {sendto, Address, PortNum, Packet}) of
         {ok, _Sent} ->
@@ -111,7 +108,7 @@ send(Socket, Address, PortNum, Packet) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec recv(avm_inet:socket(), non_neg_integer()) ->
-    {ok, {address(), avm_inet:port_number(), packet()}} | {error, reason()}.
+    {ok, {avm_inet:address(), avm_inet:port_number(), packet()}} | {error, reason()}.
 recv(Socket, Length) ->
     recv(Socket, Length, infinity).
 
@@ -134,7 +131,7 @@ recv(Socket, Length) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec recv(avm_inet:socket(), non_neg_integer(), non_neg_integer()) ->
-    {ok, {address(), avm_inet:port_number(), packet()}} | {error, reason()}.
+    {ok, {avm_inet:address(), avm_inet:port_number(), packet()}} | {error, reason()}.
 recv(Socket, Length, Timeout) ->
     call(Socket, {recvfrom, Length, Timeout}).
 
@@ -181,7 +178,7 @@ call(DriverPid, Msg) ->
 
 %% @private
 merge(Config, Defaults) ->
-    merge(Config, Defaults, []).
+    merge(Config, Defaults, []) ++ Config.
 
 %% @private
 merge(_Config, [], Accum) ->

--- a/libs/estdlib/avm_inet.erl
+++ b/libs/estdlib/avm_inet.erl
@@ -18,12 +18,15 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 -module(avm_inet).
 
--export([port/1, close/1]).
+-export([port/1, close/1, sockname/1, peername/1]).
 
 -type port_number() :: 0..65535.
 -type socket() :: pid().
+-type address() :: ipv4_address().
+-type ipv4_address() :: {octet(), octet(), octet(), octet()}.
+-type octet() :: 0..255.
 
--export_type([socket/0, port_number/0]).
+-export_type([socket/0, port_number/0, address/0, ipv4_address/0, octet/0]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Socket the socket from which to obtain the port number
@@ -46,6 +49,28 @@ port(Socket) ->
 -spec close(Socket::socket()) -> ok.
 close(Socket) ->
     call(Socket, {close}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Socket the socket
+%% @returns The address and port of the local end of an established connection.
+%% @doc     The address and port representing the "local" end of a connection.
+%%          This function should be called on a running socket instance.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec sockname(Socket::socket()) -> {address(), port_number()} | {error, Reason::term()}.
+sockname(Socket) ->
+    call(Socket, {sockname}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Socket the socket
+%% @returns The address and port of the remote end of an established connection.
+%% @doc     The address and port representing the "remote" end of a connection.
+%%          This function should be called on a running socket instance.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec peername(Socket::socket()) -> {address(), port_number()} | {error, Reason::term()}.
+peername(Socket) ->
+    call(Socket, {peername}).
 
 %%
 %% Internal operations

--- a/src/libAtomVM/socket.c
+++ b/src/libAtomVM/socket.c
@@ -43,6 +43,8 @@ const char *const recv_a = "\x4" "recv";
 const char *const close_a = "\x5" "close";
 const char *const get_port_a = "\x8" "get_port";
 const char *const accept_a = "\x6" "accept";
+const char *const sockname_a = "\x8" "sockname";
+const char *const peername_a = "\x8" "peername";
 
 
 uint32_t socket_tuple_to_addr(term addr_tuple)
@@ -125,6 +127,12 @@ static void socket_consume_mailbox(Context *ctx)
         // TODO handle shutdown
         // socket_driver_delete_data(ctx->platform_data);
         // context_destroy(ctx);
+    } else if (cmd_name == context_make_atom(ctx, sockname_a)) {
+        term reply = socket_driver_sockname(ctx);
+        port_send_reply(ctx, pid, ref, reply);
+    } else if (cmd_name == context_make_atom(ctx, peername_a)) {
+        term reply = socket_driver_peername(ctx);
+        port_send_reply(ctx, pid, ref, reply);
     } else if (cmd_name == context_make_atom(ctx, get_port_a)) {
         term reply = socket_driver_get_port(ctx);
         port_send_reply(ctx, pid, ref, reply);

--- a/src/libAtomVM/socket_driver.h
+++ b/src/libAtomVM/socket_driver.h
@@ -34,5 +34,7 @@ void socket_driver_do_recvfrom(Context *ctx, term pid, term ref, term length, te
 void socket_driver_do_close(Context *ctx);
 term socket_driver_get_port(Context *ctx);
 void socket_driver_do_accept(Context *ctx, term pid, term ref, term timeout);
+term socket_driver_sockname(Context *ctx);
+term socket_driver_peername(Context *ctx);
 
 #endif


### PR DESCRIPTION
Also added ability to specify address on which to bind (for UDP and TCP services).  By not specifying an address (default), application will bind to any (0.0.0.0) interface.

sockname and peername are used to retrieve the address and port of local and remote endpoints of connected sockets.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
