### PR TITLE
Added support for formatted logging in logger interface.

### DIFF
--- a/libs/include/logger.hrl
+++ b/libs/include/logger.hrl
@@ -17,7 +17,7 @@
 %   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--define(LOG_INFO(Msg),      logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, info,     Msg)).
--define(LOG_WARNING(Msg),   logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, warning,  Msg)).
--define(LOG_ERROR(Msg),     logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, error,    Msg)).
--define(LOG_DEBUG(Msg),     logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, debug,    Msg)).
+-define(LOG_INFO(Format, Args),      logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, info,     {Format, Args})).
+-define(LOG_WARNING(Format, Args),   logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, warning,  {Format, Args})).
+-define(LOG_ERROR(Format, Args),     logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, error,    {Format, Args})).
+-define(LOG_DEBUG(Format, Args),     logger:log({?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, debug,    {Format, Args})).

--- a/tests/libs/eavmlib/test_logger.erl
+++ b/tests/libs/eavmlib/test_logger.erl
@@ -8,46 +8,49 @@
 
 test() ->
     start_counter(),
-    logger:start([{sink, {?MODULE, do_log}}]),
+    logger:start([{sinks, [{?MODULE, do_log}]}]),
 
     ?ASSERT_MATCH(get_counter(info), 0),
     ?ASSERT_MATCH(get_counter(warning), 0),
     ?ASSERT_MATCH(get_counter(error), 0),
     ?ASSERT_MATCH(get_counter(debug), 0),
 
-    ok = ?LOG_INFO(ok),
+    ok = ?LOG_INFO("This is an info", []),
     ?ASSERT_MATCH(get_counter(info), 1),
     ?ASSERT_MATCH(get_counter(warning), 0),
     ?ASSERT_MATCH(get_counter(error), 0),
     ?ASSERT_MATCH(get_counter(debug), 0),
 
-    ok = ?LOG_WARNING(ok),
+    ok = ?LOG_WARNING("This is a warning", []),
     ?ASSERT_MATCH(get_counter(info), 1),
     ?ASSERT_MATCH(get_counter(warning), 1),
     ?ASSERT_MATCH(get_counter(error), 0),
     ?ASSERT_MATCH(get_counter(debug), 0),
 
-    ok = ?LOG_ERROR(ok),
+    ok = ?LOG_ERROR("This is an error", []),
     ?ASSERT_MATCH(get_counter(info), 1),
     ?ASSERT_MATCH(get_counter(warning), 1),
     ?ASSERT_MATCH(get_counter(error), 1),
     ?ASSERT_MATCH(get_counter(debug), 0),
 
-    ok = ?LOG_DEBUG(ok),
+    ok = ?LOG_DEBUG("This is a debug", []),
     ?ASSERT_MATCH(get_counter(info), 1),
     ?ASSERT_MATCH(get_counter(warning), 1),
     ?ASSERT_MATCH(get_counter(error), 1),
     ?ASSERT_MATCH(get_counter(debug), 0),
 
     logger:set_levels([debug, info]),
-    ok = ?LOG_INFO(ok),
-    ok = ?LOG_WARNING(ok),
-    ok = ?LOG_ERROR(ok),
-    ok = ?LOG_DEBUG(ok),
+    ok = ?LOG_INFO("Another info ~p", [info]),
+    ok = ?LOG_WARNING("Another warning ~p", [warning]),
+    ok = ?LOG_ERROR("Another error ~p", [error]),
+    ok = ?LOG_DEBUG("Another debug ~p", [debug]),
     ?ASSERT_MATCH(get_counter(info), 2),
     ?ASSERT_MATCH(get_counter(warning), 1),
     ?ASSERT_MATCH(get_counter(error), 1),
     ?ASSERT_MATCH(get_counter(debug), 1),
+
+    % logger:set_sinks([{logger, console_log}]),
+    % ok = ?LOG_INFO("Some sample ~p logging to print to the console.", [info]),
 
     ok.
 


### PR DESCRIPTION
This change set makes some improvements to the avmlib logger interface, mostly to support formatted logging when using the logging macros.  The macro arity has changed to 2, to allow specification of a format string and argument list.

Because the interface has changed, the uses of the LOG_DEBUG macro have been removed from modules in the estdlib library.

The longer interface also now supported multiple sinks, so that logs can be directed to more than one output channel.  In the future, we can add sinks for protocols like syslog or mqtt.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
