### PR TITLE
Document requirement for an Erlang compiler.

### DIFF
--- a/README.Md
+++ b/README.Md
@@ -10,6 +10,7 @@ Dependencies
 
 * CMake ([CMake build system](https://cmake.org/)) is required to build AtomVM.
 * gperf ([GNU Perfect Hash Function Generator](https://www.gnu.org/software/gperf/manual/gperf.html)) is required to build AtomVM.
+* erlc ([erlang compiler](https://www.erlang.org/)) is required to build AtomVM
 * zlib ([zlib compression and decompression library](https://zlib.net/)) is optionally needed to run standard BEAM files (without uncompressed literals extension).
 
 * gcov and lcov are optionally required to generate coverage report (make coverage).


### PR DESCRIPTION
Probably just an obvious documentation change but I installed all the dependencies from the `README` and didn't get a build because you also need to have an Erlang compiler (or I'm really dumb and missed something).

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
