### PR TITLE
Added console:print/1 NIF, now used by logger

### DIFF
--- a/libs/eavmlib/src/console.erl
+++ b/libs/eavmlib/src/console.erl
@@ -23,7 +23,7 @@
 %%-----------------------------------------------------------------------------
 -module(console).
 
--export([start/0, puts/1, puts/2, flush/0, flush/1]).
+-export([start/0, puts/1, puts/2, flush/0, flush/1, print/1]).
 
 %%-----------------------------------------------------------------------------
 %% @param   String the string data to write to the console
@@ -60,6 +60,19 @@ flush() ->
 -spec flush(pid()) -> ok.
 flush(Console) ->
     call(Console, flush).
+    
+%%-----------------------------------------------------------------------------
+%% @param   String the string data to write to the console
+%% @returns ok if the data was written, or {error, Reason}, if there was
+%%          an error.
+%% @see     erlang:display/1
+%% @doc     Write a string to the console.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec print(string()) -> ok | error.
+print(String) ->
+    throw(nif_error).
+
 
 %% Internal operations
 

--- a/libs/eavmlib/src/logger.erl
+++ b/libs/eavmlib/src/logger.erl
@@ -225,13 +225,13 @@ console_log(Request) ->
 
 make_timestamp(Timestamp) ->
     {{Year, Month, Day}, {Hour, Minute, Second}} = Timestamp,
-    io_lib:format("~p:~p:~pT~p:~p:~p", [
+    io:format("~p-~p-~pT~p:~p:~p.000", [
         Year, Month, Day, Hour, Minute, Second
     ]).
 
 make_location(Location) ->
     {Module, Function, Arity, Line} = Location,
-    io_lib:format("~p:~p/~p:~p", [
+    io:format("[~p:~p/~p:~p]", [
         Module, Function, Arity, Line
     ]).
 

--- a/libs/estdlib/src/io.erl
+++ b/libs/estdlib/src/io.erl
@@ -46,4 +46,4 @@ format(Format, Args) when is_list(Format) andalso is_list(Args) ->
             _:_ ->
                 io_lib:format("Bad format!  Format: ~p Args: ~p~n", [Format, Args])
         end,
-    console:puts(Msg).
+    console:print(Msg).

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -73,3 +73,4 @@ erlang:fun_to_list/1, &fun_to_list_nif
 erlang:!/2, &send_nif
 erts_debug:flat_size/1, &flat_size_nif
 atomvm:read_priv/2, &atomvm_read_priv_nif
+console:print/1, &console_print_nif


### PR DESCRIPTION
This change set makes printing to the console more immediate and more efficient, as no message passing is required.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
