### PR TITLE
CMake: fix `make install` for out-of-tree builds

### DIFF
--- a/libs/eavmlib/CMakeLists.txt
+++ b/libs/eavmlib/CMakeLists.txt
@@ -24,4 +24,4 @@ set(ERLANG_MODULES
 
 pack_archive(eavmlib ${ERLANG_MODULES})
 
-install(FILES eavmlib.avm DESTINATION lib/AtomVM/ebin)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eavmlib.avm DESTINATION lib/AtomVM/ebin)

--- a/libs/estdlib/CMakeLists.txt
+++ b/libs/estdlib/CMakeLists.txt
@@ -24,4 +24,4 @@ set(ERLANG_MODULES
 
 pack_archive(estdlib ${ERLANG_MODULES})
 
-install(FILES estdlib.avm DESTINATION lib/AtomVM/ebin)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/estdlib.avm DESTINATION lib/AtomVM/ebin)

--- a/libs/etest/CMakeLists.txt
+++ b/libs/etest/CMakeLists.txt
@@ -12,4 +12,4 @@ set(ERLANG_MODULES
 
 pack_archive(etest ${ERLANG_MODULES})
 
-install(FILES etest.avm DESTINATION lib/AtomVM/ebin)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/etest.avm DESTINATION lib/AtomVM/ebin)

--- a/libs/exavmlib/CMakeLists.txt
+++ b/libs/exavmlib/CMakeLists.txt
@@ -13,4 +13,4 @@ set(ELIXIR_MODULES
 
 pack_archive(exavmlib ${ELIXIR_MODULES})
 
-install(FILES exavmlib.avm DESTINATION lib/AtomVM/ebin)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/exavmlib.avm DESTINATION lib/AtomVM/ebin)

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -97,7 +97,7 @@ gperf_generate(${CMAKE_CURRENT_SOURCE_DIR}/nifs.gperf nifs_hash.h)
 add_custom_target(generated DEPENDS bifs_hash.h)
 add_custom_target(generated-nifs-hash DEPENDS nifs_hash.h)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in version.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(


### PR DESCRIPTION
These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
