### PR TITLE
Removed avm_ prefix from erlang estdlib modules

### DIFF
--- a/examples/elixir/stm32/MultiBlink.ex
+++ b/examples/elixir/stm32/MultiBlink.ex
@@ -22,7 +22,7 @@ defmodule MultiBlink do
   def blink_loop(gpio_driver, gpio, interval_ms, level) do
     GPIO.set_level(gpio_driver, gpio, level)
 
-    :avm_timer.sleep(interval_ms)
+    :timer.sleep(interval_ms)
 
     blink_loop(gpio_driver, gpio, interval_ms, 1 - level)
   end

--- a/examples/erlang/esp32/blink.erl
+++ b/examples/erlang/esp32/blink.erl
@@ -8,9 +8,9 @@ start() ->
 
 loop(GPIO, off) ->
     gpio:set_level(GPIO, 2, 0),
-    avm_timer:sleep(1000),
+    timer:sleep(1000),
     loop(GPIO, on);
 loop(GPIO, on) ->
     gpio:set_level(GPIO, 2, 1),
-    avm_timer:sleep(1000),
+    timer:sleep(1000),
     loop(GPIO, off).

--- a/examples/erlang/esp32/morse_server.erl
+++ b/examples/erlang/esp32/morse_server.erl
@@ -36,13 +36,13 @@ handle_req("GET", [], Conn) ->
     http_server:reply(200, Body, Conn);
 
 handle_req("POST", [], Conn) ->
-    ParamsBody = avm_proplists:get_value(body_chunk, Conn),
+    ParamsBody = proplists:get_value(body_chunk, Conn),
     Params = http_server:parse_query_string(ParamsBody),
 
-    GPIOString = avm_proplists:get_value("gpio", Params),
+    GPIOString = proplists:get_value("gpio", Params),
     GPIONum = safe_list_to_integer(GPIOString),
 
-    Text = avm_proplists:get_value("text", Params, "off"),
+    Text = proplists:get_value("text", Params, "off"),
     MorseText = morse_encode(Text),
 
     spawn(fun() -> blink_led(GPIONum, MorseText) end),
@@ -111,19 +111,19 @@ blink_led(GPIO, GPIONum, [H | T]) ->
     case H of
         $\s ->
             gpio:set_level(GPIO, GPIONum, 0),
-            avm_timer:sleep(120);
+            timer:sleep(120);
 
         $. ->
             gpio:set_level(GPIO, GPIONum, 1),
-            avm_timer:sleep(120),
+            timer:sleep(120),
             gpio:set_level(GPIO, GPIONum, 0),
-            avm_timer:sleep(120);
+            timer:sleep(120);
 
         $- ->
             gpio:set_level(GPIO, GPIONum, 1),
-            avm_timer:sleep(120 * 3),
+            timer:sleep(120 * 3),
             gpio:set_level(GPIO, GPIONum, 0),
-            avm_timer:sleep(120)
+            timer:sleep(120)
     end,
     blink_led(GPIO, GPIONum, T).
 
@@ -134,7 +134,7 @@ morse_encode([], Acc) ->
     Acc;
 
 morse_encode([H | L], Acc) ->
-    M = to_morse(avm_string:to_upper(H)),
+    M = to_morse(string:to_upper(H)),
     morse_encode(L, Acc ++ M).
 
 to_morse(C) ->

--- a/examples/erlang/esp32/sht31.erl
+++ b/examples/erlang/esp32/sht31.erl
@@ -11,7 +11,7 @@ start() ->
 loop(I2C) ->
     Val = read(I2C),
     erlang:display(Val),
-    avm_timer:sleep(10000),
+    timer:sleep(10000),
     loop(I2C).
 
 read(I2C) ->
@@ -33,7 +33,7 @@ float_hum(IntHum, S) ->
 
 read_sensor(I2C) ->
     send_command(I2C, ?SHT31_MEAS_HIGH_REP),
-    avm_timer:sleep(20),
+    timer:sleep(20),
     i2c:read_bytes(I2C, ?SHT31_BASE_ADDR, 6).
 
 send_command(I2C, Command) ->

--- a/examples/erlang/esp32/sx127x.erl
+++ b/examples/erlang/esp32/sx127x.erl
@@ -60,15 +60,15 @@
     ]).
 
 start() ->
-    {ok, P} = avm_gen_server:start(?MODULE, [], []),
-    avm_gen_server:call(P, init),
+    {ok, P} = gen_server:start(?MODULE, [], []),
+    gen_server:call(P, init),
     loop(P).
 
 loop(P) ->
-    avm_timer:sleep(1000),
+    timer:sleep(1000),
     TheList = "AVM",
-    avm_gen_server:call(P, {send, TheList}),
-    avm_io:format("Sending: ~s~n", [TheList]),
+    gen_server:call(P, {send, TheList}),
+    io:format("Sending: ~s~n", [TheList]),
     loop(P).
 
 init(_) ->
@@ -114,9 +114,9 @@ init_hw(GPIO, SPISettings) ->
 
     % Reset
     gpio:set_level(GPIO, 14, 0),
-    avm_timer:sleep(20),
+    timer:sleep(20),
     gpio:set_level(GPIO, 14, 1),
-    avm_timer:sleep(50),
+    timer:sleep(50),
 
     SPI = spi:open(SPISettings),
 
@@ -221,15 +221,15 @@ handle_irq(SPI) ->
             {ok, CurrentAddr} = read_register(SPI, ?REG_FIFO_RX_CURRENT_ADDR),
 
             write_register(SPI, ?REG_FIFO_ADDR_PTR, CurrentAddr),
-            avm_io:format("Received data: ~s~n", [read(SPI, PacketLength)]),
+            io:format("Received data: ~s~n", [read(SPI, PacketLength)]),
 
             write_register(SPI, ?REG_FIFO_ADDR_PTR, 0);
 
         (IRQFlags band ?IRQ_RX_DONE_MASK) /= 0 ->
-            avm_io:format("CRC error");
+            io:format("CRC error");
 
         true ->
-            avm_io:format("Unexpected IRQ")
+            io:format("Unexpected IRQ")
     end.
 
 read(_SPI, 0) ->

--- a/libs/estdlib/CMakeLists.txt
+++ b/libs/estdlib/CMakeLists.txt
@@ -7,18 +7,18 @@ project(estdlib)
 include(BuildErlang)
 
 set(ERLANG_MODULES
-    avm_calendar
-    avm_gen_server
-    avm_gen_statem
-    avm_gen_udp
-    avm_gen_tcp
-    avm_inet
-    avm_io_lib
-    avm_io
-    avm_lists
-    avm_proplists
-    avm_string
-    avm_timer
+    calendar
+    gen_server
+    gen_statem
+    gen_udp
+    gen_tcp
+    inet
+    io_lib
+    io
+    lists
+    proplists
+    string
+    timer
     erlang
 )
 

--- a/libs/estdlib/calendar.erl
+++ b/libs/estdlib/calendar.erl
@@ -1,4 +1,4 @@
--module(avm_calendar).
+-module(calendar).
 
 -export([date_to_gregorian_days/1, date_to_gregorian_days/3, day_of_the_week/1, day_of_the_week/3]).
 

--- a/libs/estdlib/gen_server.erl
+++ b/libs/estdlib/gen_server.erl
@@ -38,7 +38,7 @@
 %% </ul>
 %% @end
 %%-----------------------------------------------------------------------------
--module(avm_gen_server).
+-module(gen_server).
 
 -export([start/3, start/4, stop/1, stop/3, call/2, call/3, cast/2, reply/2]).
 -export([loop/1]).

--- a/libs/estdlib/gen_statem.erl
+++ b/libs/estdlib/gen_statem.erl
@@ -39,7 +39,7 @@
 %% </ul>
 %% @end
 %%-----------------------------------------------------------------------------
--module(avm_gen_statem).
+-module(gen_statem).
 
 -export([start/3, start/4, stop/1, stop/3, call/2, call/3, cast/2, reply/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).

--- a/libs/estdlib/gen_tcp.erl
+++ b/libs/estdlib/gen_tcp.erl
@@ -37,7 +37,7 @@
 %% on all AtomVM platforms.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--module(avm_gen_tcp).
+-module(gen_tcp).
 
 -export([connect/3, send/2, recv/2, recv/3, close/1, listen/2, accept/1, accept/2]).
 
@@ -69,8 +69,8 @@
 %%          in order to receive data on the socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec connect(avm_inet:address(), avm_inet:port_number(), Options::avm_inet:opts()) ->
-    {ok, Socket::avm_inet:socket()} | {error, Reason::term()}.
+-spec connect(inet:address(), inet:port_number(), Options::inet:opts()) ->
+    {ok, Socket::inet:socket()} | {error, Reason::term()}.
 connect(Address, Port, Params0) ->
     Socket = open_port({spawn, "socket"}, []),
     Params = merge(Params0, ?DEFAULT_PARAMS),
@@ -86,7 +86,7 @@ connect(Address, Port, Params0) ->
 %%          otherwise, an error with a reason.
 %% @end
 %%-----------------------------------------------------------------------------
--spec send(avm_inet:socket(), avm_inet:packet()) -> ok | {error, Reason::term()}.
+-spec send(inet:socket(), inet:packet()) -> ok | {error, Reason::term()}.
 send(Socket, Packet) ->
     case call(Socket, {send, Packet}) of
         {ok, _Len} ->
@@ -100,8 +100,8 @@ send(Socket, Packet) ->
 %% @doc     Receive a packet over a TCP socket from a source address/port.
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(avm_inet:socket(), non_neg_integer()) ->
-    {ok,avm_inet:packet()} | {error, Reason::term()}.
+-spec recv(inet:socket(), non_neg_integer()) ->
+    {ok,inet:packet()} | {error, Reason::term()}.
 recv(Socket, Length) ->
     recv(Socket, Length, infinity).
 
@@ -124,8 +124,8 @@ recv(Socket, Length) ->
 %%          ignored.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(avm_inet:socket(), non_neg_integer(), non_neg_integer()) ->
-    {ok,avm_inet:packet()} | {error, Reason::term()}.
+-spec recv(inet:socket(), non_neg_integer(), non_neg_integer()) ->
+    {ok,inet:packet()} | {error, Reason::term()}.
 recv(Socket, Length, Timeout) ->
     call(Socket, {recv, Length, Timeout}).
 
@@ -140,7 +140,7 @@ recv(Socket, Length, Timeout) ->
 %%          This function is currently unimplemented
 %% @end
 %%-----------------------------------------------------------------------------
--spec listen(Port::avm_inet:port_number(), Options::avm_inet:opts()) -> {ok, ListeningSocket::avm_inet:socket()} | {error, Reason::term()}.
+-spec listen(Port::inet:port_number(), Options::inet:opts()) -> {ok, ListeningSocket::inet:socket()} | {error, Reason::term()}.
 listen(Port, Options) ->
     Socket = open_port({spawn, "socket"}, []),
     Params = merge(Options, ?DEFAULT_PARAMS),
@@ -165,7 +165,7 @@ listen(Port, Options) ->
 %% @doc     Accept a connection on a listening socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec accept(avm_inet:socket()) -> {ok, Socket::avm_inet:socket()} | {error, Reason::term()}.
+-spec accept(inet:socket()) -> {ok, Socket::inet:socket()} | {error, Reason::term()}.
 accept(ListenSocket) ->
     accept(ListenSocket, infinity).
 
@@ -176,7 +176,7 @@ accept(ListenSocket) ->
 %% @doc     Accept a connection on a listening socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec accept(avm_inet:socket(), Timeout::non_neg_integer()) -> {ok, Socket::avm_inet:socket()} | {error, Reason::term()}.
+-spec accept(inet:socket(), Timeout::non_neg_integer()) -> {ok, Socket::inet:socket()} | {error, Reason::term()}.
 accept(ListenSocket, Timeout) ->
     case call(ListenSocket, {accept, Timeout}) of
         {ok, FD} when is_integer(FD) ->
@@ -207,9 +207,9 @@ accept(ListenSocket, Timeout) ->
 %% @doc     Close the socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec close(avm_inet:socket()) -> ok.
+-spec close(inet:socket()) -> ok.
 close(Socket) ->
-    avm_inet:close(Socket).
+    inet:close(Socket).
 
 
 

--- a/libs/estdlib/gen_udp.erl
+++ b/libs/estdlib/gen_udp.erl
@@ -38,7 +38,7 @@
 %% on all AtomVM platforms.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--module(avm_gen_udp).
+-module(gen_udp).
 
 -export([open/1, open/2, send/4, recv/2, recv/3, close/1]).
 
@@ -56,7 +56,7 @@
 %%          send or receive UDP messages.
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(avm_inet:port_number()) -> {ok, avm_inet:socket()} | {error, Reason::reason()}.
+-spec open(inet:port_number()) -> {ok, inet:socket()} | {error, Reason::reason()}.
 open(PortNum) ->
     open(PortNum, []).
 
@@ -76,7 +76,7 @@ open(PortNum) ->
 %%          <em><b>Note.</b>  The Params argument is currently ignored.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(avm_inet:port_number(), proplist()) -> {ok, avm_inet:socket()} | {error, Reason::reason()}.
+-spec open(inet:port_number(), proplist()) -> {ok, inet:socket()} | {error, Reason::reason()}.
 open(PortNum, Params0) ->
     DriverPid = open_port({spawn, "socket"}, []),
     Params = merge(Params0, ?DEFAULT_PARAMS),
@@ -93,7 +93,7 @@ open(PortNum, Params0) ->
 %%          <em><b>Note.</b> Currently only ipv4 addresses are supported.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec send(avm_inet:socket(), avm_inet:address(), avm_inet:port_number(), packet()) -> ok | {error, reason()}.
+-spec send(inet:socket(), inet:address(), inet:port_number(), packet()) -> ok | {error, reason()}.
 send(Socket, Address, PortNum, Packet) ->
     case call(Socket, {sendto, Address, PortNum, Packet}) of
         {ok, _Sent} ->
@@ -107,8 +107,8 @@ send(Socket, Address, PortNum, Packet) ->
 %% @doc     Receive a packet over a UDP socket from a source address/port.
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(avm_inet:socket(), non_neg_integer()) ->
-    {ok, {avm_inet:address(), avm_inet:port_number(), packet()}} | {error, reason()}.
+-spec recv(inet:socket(), non_neg_integer()) ->
+    {ok, {inet:address(), inet:port_number(), packet()}} | {error, reason()}.
 recv(Socket, Length) ->
     recv(Socket, Length, infinity).
 
@@ -130,8 +130,8 @@ recv(Socket, Length) ->
 %%          is limited to 128 bytes.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(avm_inet:socket(), non_neg_integer(), non_neg_integer()) ->
-    {ok, {avm_inet:address(), avm_inet:port_number(), packet()}} | {error, reason()}.
+-spec recv(inet:socket(), non_neg_integer(), non_neg_integer()) ->
+    {ok, {inet:address(), inet:port_number(), packet()}} | {error, reason()}.
 recv(Socket, Length, Timeout) ->
     call(Socket, {recvfrom, Length, Timeout}).
 
@@ -143,7 +143,7 @@ recv(Socket, Length, Timeout) ->
 %% @doc     Close the socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec close(avm_inet:socket()) -> ok | {error, Reason::reason()}.
+-spec close(inet:socket()) -> ok | {error, Reason::reason()}.
 close(Socket) ->
     call(Socket, {close}).
 

--- a/libs/estdlib/inet.erl
+++ b/libs/estdlib/inet.erl
@@ -16,7 +16,7 @@
 %   Free Software Foundation, Inc.,                                       %
 %   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--module(avm_inet).
+-module(inet).
 
 -export([port/1, close/1, sockname/1, peername/1]).
 

--- a/libs/estdlib/io.erl
+++ b/libs/estdlib/io.erl
@@ -16,7 +16,7 @@
 %   Free Software Foundation, Inc.,                                       %
 %   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--module(avm_io).
+-module(io).
 
 -export([format/1, format/2]).
 
@@ -35,7 +35,7 @@ format(Format) when is_list(Format) ->
 %% @param   Args format argument
 %% @returns string
 %% @doc     Format string and data to console.
-%%          See avm_io_lib:format/2 for information about
+%%          See io_lib:format/2 for information about
 %%          formatting capabilities.
 %% @end
 %%-----------------------------------------------------------------------------

--- a/libs/estdlib/io_lib.erl
+++ b/libs/estdlib/io_lib.erl
@@ -16,7 +16,7 @@
 %   Free Software Foundation, Inc.,                                       %
 %   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--module(avm_io_lib).
+-module(io_lib).
 
 -export([format/2]).
 

--- a/libs/estdlib/lists.erl
+++ b/libs/estdlib/lists.erl
@@ -24,7 +24,7 @@
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
--module(avm_lists).
+-module(lists).
 
 -export([nth/2, member/2, delete/2, reverse/1, foreach/2, keydelete/3, keyfind/3, keymember/3, foldl/3, foldr/3, all/2, any/2, flatten/1]).
 

--- a/libs/estdlib/proplists.erl
+++ b/libs/estdlib/proplists.erl
@@ -24,7 +24,7 @@
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
--module(avm_proplists).
+-module(proplists).
 
 -export([get_value/2, get_value/3]).
 

--- a/libs/estdlib/string.erl
+++ b/libs/estdlib/string.erl
@@ -24,7 +24,7 @@
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
--module(avm_string).
+-module(string).
 
 -export([to_upper/1]).
 

--- a/libs/estdlib/timer.erl
+++ b/libs/estdlib/timer.erl
@@ -1,4 +1,4 @@
--module(avm_timer).
+-module(timer).
 
 -export([sleep/1]).
 

--- a/libs/exavmlib/Access.ex
+++ b/libs/exavmlib/Access.ex
@@ -3,7 +3,7 @@ defmodule Access do
   @compile {:autoload, false}
 
   def fetch(list, key) when is_list(list) and is_atom(key) do
-    case :avm_lists.keyfind(key, 1, list) do
+    case :lists.keyfind(key, 1, list) do
       {_, value} -> {:ok, value}
       false -> :error
     end
@@ -26,7 +26,7 @@ defmodule Access do
   end
 
   def get(list, key, default) when is_list(list) and is_atom(key) do
-    case :avm_lists.keyfind(key, 1, list) do
+    case :lists.keyfind(key, 1, list) do
       {_, value} -> value
       false -> default
     end

--- a/libs/exavmlib/Enum.ex
+++ b/libs/exavmlib/Enum.ex
@@ -3,7 +3,7 @@ defmodule Enum do
   @compile {:autoload, false}
 
   def reduce(enumerable, acc, fun) when is_list(enumerable) do
-    :avm_lists.foldl(fun, acc, enumerable)
+    :lists.foldl(fun, acc, enumerable)
   end
 
   def all?(enumerable, fun) when is_list(enumerable) do
@@ -19,7 +19,7 @@ defmodule Enum do
   end
 
   def each(enumerable, fun) when is_list(enumerable) do
-    :avm_lists.foreach(fun, enumerable)
+    :lists.foreach(fun, enumerable)
     :ok
   end
 
@@ -40,11 +40,11 @@ defmodule Enum do
   end
 
   def map(enumerable, fun) when is_list(enumerable) do
-    :avm_lists.map(fun, enumerable)
+    :lists.map(fun, enumerable)
   end
 
   def member?(enumerable, element) when is_list(enumerable) do
-    :avm_lists.member(element, enumerable)
+    :lists.member(element, enumerable)
   end
 
   def reject(enumerable, fun) when is_list(enumerable) do

--- a/libs/exavmlib/Keyword.ex
+++ b/libs/exavmlib/Keyword.ex
@@ -3,21 +3,21 @@ defmodule Keyword do
   @compile {:autoload, false}
 
   def fetch(keywords, key) when is_list(keywords) and is_atom(key) do
-    case :avm_lists.keyfind(key, 1, keywords) do
+    case :lists.keyfind(key, 1, keywords) do
       {^key, value} -> {:ok, value}
       false -> :error
     end
   end
 
   def fetch!(keywords, key) when is_list(keywords) and is_atom(key) do
-    case :avm_lists.keyfind(key, 1, keywords) do
+    case :lists.keyfind(key, 1, keywords) do
       {^key, value} -> value
       false -> raise(KeyError, key: key, term: keywords)
     end
   end
 
   def get(keywords, key, default \\ nil) when is_list(keywords) and is_atom(key) do
-    case :avm_lists.keyfind(key, 1, keywords) do
+    case :lists.keyfind(key, 1, keywords) do
       {^key, value} -> value
       false -> default
     end
@@ -25,7 +25,7 @@ defmodule Keyword do
 
   def get_lazy(keywords, key, fun)
       when is_list(keywords) and is_atom(key) and is_function(fun, 0) do
-    case :avm_lists.keyfind(key, 1, keywords) do
+    case :lists.keyfind(key, 1, keywords) do
       {^key, value} -> value
       false -> fun.()
     end
@@ -36,7 +36,7 @@ defmodule Keyword do
   end
 
   def delete(keywords, key) when is_list(keywords) and is_atom(key) do
-    case :avm_lists.keymember(key, 1, keywords) do
+    case :lists.keymember(key, 1, keywords) do
       true -> delete_key(keywords, key)
       _ -> keywords
     end

--- a/libs/exavmlib/List.ex
+++ b/libs/exavmlib/List.ex
@@ -171,7 +171,7 @@ defmodule List do
   """
   @spec flatten(deep_list) :: list when deep_list: [any | deep_list]
   def flatten(list) do
-    :avm_lists.flatten(list)
+    :lists.flatten(list)
   end
 
   @doc """
@@ -189,7 +189,7 @@ defmodule List do
   """
   @spec foldl([elem], acc, (elem, acc -> acc)) :: acc when elem: var, acc: var
   def foldl(list, acc, fun) when is_list(list) and is_function(fun) do
-    :avm_lists.foldl(fun, acc, list)
+    :lists.foldl(fun, acc, list)
   end
 
   @doc """
@@ -204,7 +204,7 @@ defmodule List do
   """
   @spec foldr([elem], acc, (elem, acc -> acc)) :: acc when elem: var, acc: var
   def foldr(list, acc, fun) when is_list(list) and is_function(fun) do
-    :avm_lists.foldr(fun, acc, list)
+    :lists.foldr(fun, acc, list)
   end
 
   @doc """
@@ -269,7 +269,7 @@ defmodule List do
   """
   @spec keyfind([tuple], any, non_neg_integer, any) :: any
   def keyfind(list, key, position, default \\ nil) do
-    :avm_lists.keyfind(key, position + 1, list) || default
+    :lists.keyfind(key, position + 1, list) || default
   end
 
   @doc """
@@ -291,7 +291,7 @@ defmodule List do
   """
   @spec keymember?([tuple], any, non_neg_integer) :: boolean
   def keymember?(list, key, position) do
-    :avm_lists.keymember(key, position + 1, list)
+    :lists.keymember(key, position + 1, list)
   end
 
   @doc """
@@ -313,7 +313,7 @@ defmodule List do
   """
   @spec keydelete([tuple], any, non_neg_integer) :: [tuple]
   def keydelete(list, key, position) do
-    :avm_lists.keydelete(key, position + 1, list)
+    :lists.keydelete(key, position + 1, list)
   end
 
   @doc """

--- a/libs/include/estdlib.hrl
+++ b/libs/include/estdlib.hrl
@@ -17,15 +17,15 @@
 %   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--define(CALENDAR,       avm_calendar).
+-define(CALENDAR,       calendar).
 -define(ERLANG,             erlang).
--define(GEN_SERVER,     avm_gen_server).
--define(GEN_STATEM,     avm_gen_statem).
--define(INET,           avm_inet).
--define(IO_LIB,         avm_io_lib).
--define(IO,             avm_io).
--define(GEN_UDP,        avm_gen_udp).
--define(GEN_TCP,        avm_gen_tcp).
--define(LISTS,          avm_lists).
--define(PROPLISTS,      avm_proplists).
--define(TIMER,          avm_timer).
+-define(GEN_SERVER,     gen_server).
+-define(GEN_STATEM,     gen_statem).
+-define(INET,           inet).
+-define(IO_LIB,         io_lib).
+-define(IO,             io).
+-define(GEN_UDP,        gen_udp).
+-define(GEN_TCP,        gen_tcp).
+-define(LISTS,          lists).
+-define(PROPLISTS,      proplists).
+-define(TIMER,          timer).


### PR DESCRIPTION
These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
