### PR TITLE
Fixes to inet:sockname/1 and inet:peername/1

### DIFF
--- a/libs/estdlib/src/inet.erl
+++ b/libs/estdlib/src/inet.erl
@@ -57,7 +57,7 @@ close(Socket) ->
 %%          This function should be called on a running socket instance.
 %% @end
 %%-----------------------------------------------------------------------------
--spec sockname(Socket::socket()) -> {address(), port_number()} | {error, Reason::term()}.
+-spec sockname(Socket::socket()) -> {ok, {address(), port_number()}} | {error, Reason::term()}.
 sockname(Socket) ->
     call(Socket, {sockname}).
 
@@ -68,7 +68,7 @@ sockname(Socket) ->
 %%          This function should be called on a running socket instance.
 %% @end
 %%-----------------------------------------------------------------------------
--spec peername(Socket::socket()) -> {address(), port_number()} | {error, Reason::term()}.
+-spec peername(Socket::socket()) -> {ok, {address(), port_number()}} | {error, Reason::term()}.
 peername(Socket) ->
     call(Socket, {peername}).
 

--- a/src/platforms/esp32/main/socket_driver.c
+++ b/src/platforms/esp32/main/socket_driver.c
@@ -1195,14 +1195,17 @@ static void do_sockname(Context *ctx, term msg)
         term_put_tuple_element(return_msg, 0, ERROR_ATOM);
         term_put_tuple_element(return_msg, 1, term_from_int(result));
     } else {
-        if (UNLIKELY(memory_ensure_free(ctx, 3 + 8) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free(ctx, 3 + 3 + 8) != MEMORY_GC_OK)) {
             abort();
         }
         return_msg = term_alloc_tuple(2, ctx);
         term addr_term = socket_addr_to_tuple(ctx, &addr);
         term port_term = term_from_int(port);
-        term_put_tuple_element(return_msg, 0, addr_term);
-        term_put_tuple_element(return_msg, 1, port_term);
+        term address_port_term = term_alloc_tuple(2, ctx);
+        term_put_tuple_element(address_port_term, 0, addr_term);
+        term_put_tuple_element(address_port_term, 1, port_term);
+        term_put_tuple_element(return_msg, 0, OK_ATOM);
+        term_put_tuple_element(return_msg, 1, address_port_term);
     }
 
     term result_tuple = term_alloc_tuple(2, ctx);
@@ -1231,14 +1234,17 @@ static void do_peername(Context *ctx, term msg)
         term_put_tuple_element(return_msg, 0, ERROR_ATOM);
         term_put_tuple_element(return_msg, 1, term_from_int(result));
     } else {
-        if (UNLIKELY(memory_ensure_free(ctx, 3 + 8) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free(ctx, 3 + 3 + 8) != MEMORY_GC_OK)) {
             abort();
         }
         return_msg = term_alloc_tuple(2, ctx);
         term addr_term = socket_addr_to_tuple(ctx, &addr);
         term port_term = term_from_int(port);
-        term_put_tuple_element(return_msg, 0, addr_term);
-        term_put_tuple_element(return_msg, 1, port_term);
+        term address_port_term = term_alloc_tuple(2, ctx);
+        term_put_tuple_element(address_port_term, 0, addr_term);
+        term_put_tuple_element(address_port_term, 1, port_term);
+        term_put_tuple_element(return_msg, 0, OK_ATOM);
+        term_put_tuple_element(return_msg, 1, address_port_term);
     }
 
     term result_tuple = term_alloc_tuple(2, ctx);
@@ -1301,17 +1307,17 @@ static void socket_consume_mailbox(Context *ctx)
                 break;
 
             case GET_PORT_ATOM:
-                fprintf(stderr, "get_port\n");
+                TRACE("get_port\n");
                 do_get_port(ctx, msg);
                 break;
 
             case SOCKNAME_ATOM:
-                fprintf(stderr, "sockname\n");
+                TRACE("sockname\n");
                 do_sockname(ctx, msg);
                 break;
 
             case PEERNAME_ATOM:
-                fprintf(stderr, "peername\n");
+                TRACE("peername\n");
                 do_peername(ctx, msg);
                 break;
 

--- a/src/platforms/generic_unix/socket_driver.c
+++ b/src/platforms/generic_unix/socket_driver.c
@@ -440,15 +440,20 @@ term socket_driver_sockname(Context *ctx)
         port_ensure_available(ctx, 3);
         return port_create_error_tuple(ctx, term_from_int(errno));
     } else {
-        port_ensure_available(ctx, 8);
+        port_ensure_available(ctx, 11);
         term addr_term = socket_tuple_from_addr(
             ctx, ntohl(addr.sin_addr.s_addr)
         );
         term port_term = term_from_int(ntohs(addr.sin_port));
-        return port_create_tuple2(
+        term addr_port = port_create_tuple2(
             ctx,
             addr_term,
             port_term
+        );
+        return port_create_tuple2(
+            ctx,
+            OK_ATOM,
+            addr_port
         );
     }
 }
@@ -464,15 +469,20 @@ term socket_driver_peername(Context *ctx)
         port_ensure_available(ctx, 3);
         return port_create_error_tuple(ctx, term_from_int(errno));
     } else {
-        port_ensure_available(ctx, 8);
+        port_ensure_available(ctx, 11);
         term addr_term = socket_tuple_from_addr(
             ctx, ntohl(addr.sin_addr.s_addr)
         );
         term port_term = term_from_int(ntohs(addr.sin_port));
-        return port_create_tuple2(
+        term addr_port = port_create_tuple2(
             ctx,
             addr_term,
             port_term
+        );
+        return port_create_tuple2(
+            ctx,
+            OK_ATOM,
+            addr_port
         );
     }
 }


### PR DESCRIPTION
The return signature on these functions were not in compliance with the OTP implementation.  This has been fixed.
Also converted stray printfs to TRACE in esp32 socket driver

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
