### PR TITLE
Name change for component_nifs script

### DIFF
--- a/doc/atomvm-esp32.md
+++ b/doc/atomvm-esp32.md
@@ -45,9 +45,9 @@ Generally, this requires the following steps:
 * Create an IDF SDK component, as described in the IDF SDK documentation
 * Select a moniker that is unique to your nif, such as `my_nif`
 * Create a header file called `my_nif.h` that can be located by your component's build
-* The header file should contain a declaration of the `<moniker>_nifs_get_nif` Nif locator function, which takes a nif name and returns a const pointer to a `struct Nif`, e.g.,
+* The header file should contain a declaration of the `<moniker>_get_nif` Nif locator function, which takes a nif name and returns a const pointer to a `struct Nif`, e.g.,
 
-    const struct Nif *my_nif_nifs_get_nif(const char *nifname);
+    const struct Nif *my_nif_get_nif(const char *nifname);
 
 * Create a `component_nifs.txt` file in the `main` directory of the AtomVM `esp32` build tree that contains your moniker on a single line, e.g.,
 

--- a/src/platforms/esp32/main/component_nifs.py
+++ b/src/platforms/esp32/main/component_nifs.py
@@ -29,7 +29,7 @@ def insert(component_nif, component_nifs_txt) :
     buf += "#include <%s.h>\n" % component_nif
     components_pos = component_nifs_txt.find("// COMPONENTS")
     buf += component_nifs_txt[includes_pos:components_pos]
-    buf += "if ((nif = %s_nifs_get_nif(nifname)) != NULL) { return nif; }\n    " % component_nif
+    buf += "if ((nif = %s_get_nif(nifname)) != NULL) { return nif; }\n    " % component_nif
     buf += component_nifs_txt[components_pos:]
     return buf
 


### PR DESCRIPTION
I realized the extra "_nifs_" string in the component nif get function was extraneous.  Best to fix it now, before it gets any real use.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
