### PR TITLE
Improved error handling when startup beam cannot be loaded.

### DIFF
--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -171,7 +171,7 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
 
     Module *mod = malloc(sizeof(Module));
     if (IS_NULL_PTR(mod)) {
-        fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
+        fprintf(stderr, "Error: Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
         return NULL;
     }
     memset(mod, 0, sizeof(Module));
@@ -180,11 +180,13 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
     mod->global = global;
 
     if (UNLIKELY(module_populate_atoms_table(mod, beam_file + offsets[AT8U]) != MODULE_LOAD_OK)) {
+        fprintf(stderr, "Error: Failed to populate atoms table: %s:%i.\n", __FILE__, __LINE__);
         module_destroy(mod);
         return NULL;
     }
 
     if (UNLIKELY(module_build_imported_functions_table(mod, beam_file + offsets[IMPT]) != MODULE_LOAD_OK)) {
+        fprintf(stderr, "Error: Failed to build imported functions table: %s:%i.\n", __FILE__, __LINE__);
         module_destroy(mod);
         return NULL;
     }
@@ -200,6 +202,7 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
     mod->str_table_len = sizes[STRT];
     mod->labels = calloc(ENDIAN_SWAP_32(mod->code->labels), sizeof(void *));
     if (IS_NULL_PTR(mod->labels)) {
+        fprintf(stderr, "Error: Null module lables: %s:%i.\n", __FILE__, __LINE__);
         module_destroy(mod);
         return NULL;
     }
@@ -212,7 +215,7 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
                 return NULL;
             }
         #else
-            fprintf(stderr, "zlib required to uncompress literals.\n");
+            fprintf(stderr, "Error: zlib required to uncompress literals.\n");
             module_destroy(mod);
             return NULL;
         #endif

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -96,6 +96,10 @@ void app_main()
     }
 
     Module *mod = module_new_from_iff_binary(glb, startup_beam, startup_beam_size);
+    if (IS_NULL_PTR(mod)) {
+        fprintf(stderr, "Error.  Unable to load startup module %s\n", startup_module_name);
+        abort();
+    }
     globalcontext_insert_module_with_filename(glb, mod, startup_module_name);
     Context *ctx = context_new(glb);
     ctx->leader = 1;


### PR DESCRIPTION
These changes should make malformed BEAM or AVM files easier to diagnose.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
