### PR TITLE
Fix startup beam path

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libgen.h>
 
 #include "atom.h"
 #include "avmpack.h"
@@ -111,7 +112,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "Cannot load startup module: %s\n", startup_module_name);
         return EXIT_FAILURE;
     }
-    globalcontext_insert_module_with_filename(glb, mod, startup_module_name);
+    globalcontext_insert_module_with_filename(glb, mod, basename(startup_module_name));
     mod->module_platform_data = NULL;
     Context *ctx = context_new(glb);
     ctx->leader = 1;


### PR DESCRIPTION
This change sets the module name of the startup BEAM to the basename of the file path, instead of the full path.  This allows users to use full paths to BEAM files reliably.  (Without this change, module lookups fail when BEAM files are specified on the command line that use paths specifiers.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
