### PR TITLE
Added erlang:garbage_collect/1,2

### DIFF
--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -31,8 +31,6 @@
 
 #include "trace.h"
 
-#define MIN_FREE_SPACE_SIZE 16
-
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 static void memory_scan_and_copy(term *mem_start, const term *mem_end, term **new_heap_pos, int move);

--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 
 #define HEAP_NEED_GC_SHRINK_THRESHOLD_COEFF 64
+#define MIN_FREE_SPACE_SIZE 16
 
 #ifndef TYPEDEF_CONTEXT
 #define TYPEDEF_CONTEXT

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -73,6 +73,8 @@ erlang:pid_to_list/1, &pid_to_list_nif
 erlang:ref_to_list/1, &ref_to_list_nif
 erlang:fun_to_list/1, &fun_to_list_nif
 erlang:!/2, &send_nif
+erlang:garbage_collect/0, &garbage_collect_nif
+erlang:garbage_collect/1, &garbage_collect_nif
 erts_debug:flat_size/1, &flat_size_nif
 atomvm:read_priv/2, &atomvm_read_priv_nif
 console:print/1, &console_print_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -287,6 +287,7 @@ compile_erlang(test_match)
 compile_erlang(test_ordering_0)
 compile_erlang(test_ordering_1)
 compile_erlang(test_bs)
+compile_erlang(test_gc)
 
 compile_erlang(ceilint)
 compile_erlang(ceilbadarg)
@@ -659,6 +660,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_ordering_0.beam
     test_ordering_1.beam
     test_bs.beam
+    test_gc.beam
 
     ceilint.beam
     ceilbadarg.beam

--- a/tests/erlang_tests/test_gc.erl
+++ b/tests/erlang_tests/test_gc.erl
@@ -1,0 +1,29 @@
+-module(test_gc).
+-export([start/0]).
+
+start() ->
+    {HeapSize, _} = make_a_big_heap(),
+    MemorySize = erlang:process_info(self(), memory),
+    true = erlang:garbage_collect(),
+    NewHeapSize = erlang:process_info(self(), heap_size),
+    ok = case NewHeapSize < HeapSize of
+        true -> ok;
+        _ -> fail
+    end,
+    NewMemorySize = erlang:process_info(self(), memory),
+    ok = case NewMemorySize < MemorySize of
+        true -> ok;
+        _ -> fail
+    end,
+    0.
+
+make_a_big_heap() ->
+    LargeBlob = create_string(1024, []),
+    HeapSize = erlang:process_info(self(), heap_size),
+    {HeapSize, length(LargeBlob)}.
+
+
+create_string(0, Accum) ->
+    Accum;
+create_string(Len, Accum) ->
+    create_string(Len - 1, [Len rem 256 | Accum]).

--- a/tests/test.c
+++ b/tests/test.c
@@ -326,6 +326,7 @@ struct Test tests[] =
     {"test_ordering_1.beam", 1},
     {"test_binary_to_term.beam", 0},
     {"test_bs.beam", 0},
+    {"test_gc.beam", 0 },
 
     {"ceilint.beam", 1},
     {"ceilbadarg.beam", -1},


### PR DESCRIPTION
Useful function for debugging, and will be required in obscure edge cases with reference-counted binaries.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
