### PR TITLE
Support for out-of-order messages in selective receive blocks.

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -61,6 +61,7 @@ Context *context_new(GlobalContext *glb)
     list_append(&glb->ready_processes, &ctx->processes_list_head);
 
     list_init(&ctx->mailbox);
+    list_init(&ctx->save_queue);
     list_init(&ctx->dictionary);
 
     ctx->global = glb;

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -77,6 +77,7 @@ struct Context
     const void *jump_to_on_restore;
 
     struct ListHead mailbox;
+    struct ListHead save_queue;
 
     struct ListHead dictionary;
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -129,6 +129,7 @@ compile_erlang(test_process_info)
 compile_erlang(test_min_heap_size)
 compile_erlang(test_system_info)
 compile_erlang(test_binary_to_term)
+compile_erlang(test_selective_receive)
 
 compile_erlang(test_funs0)
 compile_erlang(test_funs1)
@@ -499,6 +500,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_min_heap_size.beam
     test_system_info.beam
     test_binary_to_term.beam
+    test_selective_receive.beam
 
     test_funs0.beam
     test_funs1.beam

--- a/tests/erlang_tests/test_selective_receive.erl
+++ b/tests/erlang_tests/test_selective_receive.erl
@@ -1,0 +1,54 @@
+-module(test_selective_receive).
+
+-export([start/0]).
+
+start() ->
+    test_selective_receive(),
+    test_selective_receive_with_timeout(),
+    0.
+
+test_selective_receive() ->
+    Self = self(),
+    spawn(fun() ->
+        Self ! three
+    end),
+    spawn(fun() ->
+        receive after 250 -> ok end,
+        Self ! two
+    end),
+    spawn(fun() ->
+        receive after 500 -> ok end,
+        Self ! one
+    end),
+    receive
+        one ->
+            ok
+    end,
+    receive
+        two ->
+            ok
+    end,
+    receive
+        three ->
+            ok
+    end.
+
+test_selective_receive_with_timeout() ->
+    Self = self(),
+    spawn(fun() ->
+        Self ! two
+    end),
+    spawn(fun() ->
+        receive after 500 -> ok end,
+        Self ! one
+    end),
+    ok = receive
+        one ->
+            expected_timeout
+    after 250 ->
+        ok
+    end,
+    receive
+        two ->
+            ok
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -325,6 +325,7 @@ struct Test tests[] =
     {"test_ordering_0.beam", 1},
     {"test_ordering_1.beam", 1},
     {"test_binary_to_term.beam", 0},
+    {"test_selective_receive.beam", 0},
     {"test_bs.beam", 0},
 
     {"ceilint.beam", 1},


### PR DESCRIPTION
These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
