### PR TITLE
Support shift left/right on integers > 27 bits

### DIFF
--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -75,6 +75,7 @@ compile_erlang(negatives2)
 compile_erlang(datetime)
 compile_erlang(timestamp)
 compile_erlang(is_type)
+compile_erlang(test_bitshift)
 compile_erlang(test_bitwise)
 compile_erlang(test_bitwise2)
 compile_erlang(test_gt_and_le)
@@ -445,6 +446,7 @@ add_custom_target(erlang_test_modules DEPENDS
     datetime.beam
     timestamp.beam
     is_type.beam
+    test_bitshift.beam
     test_bitwise.beam
     test_bitwise2.beam
     test_gt_and_le.beam

--- a/tests/erlang_tests/test_bitshift.erl
+++ b/tests/erlang_tests/test_bitshift.erl
@@ -1,0 +1,26 @@
+-module(test_bitshift).
+
+-export([start/0, shift_left/2, shift_right/2]).
+
+start() ->
+    test_shift(64 - 3),
+    0.
+
+test_shift(M) ->
+    test_shift(0, M, 1).
+
+test_shift(N, N, _E) ->
+    ok;
+test_shift(N, M, E) ->
+    verify_shift(E, 16#01, N),
+    test_shift(N + 1, M, E * 2).
+
+verify_shift(E, A, B) ->
+    E = shift_left(A, B),
+    A = shift_right(E, B).
+
+shift_left(A, B) ->
+    A bsl B.
+
+shift_right(A, B) ->
+    A bsr B.

--- a/tests/test.c
+++ b/tests/test.c
@@ -112,6 +112,7 @@ struct Test tests[] =
     {"datetime.beam", 3},
     {"timestamp.beam", 1},
     {"is_type.beam", 255},
+    {"test_bitshift.beam", 0},
     {"test_bitwise.beam", -4},
     {"test_bitwise2.beam", 0},
     {"test_gt_and_le.beam", 255},


### PR DESCRIPTION
Adds support for shift operations on large (boxed) integers.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
