### PR TITLE
Added support for maps opcodes.

### DIFF
--- a/doc/atomvm-memory.md
+++ b/doc/atomvm-memory.md
@@ -248,6 +248,46 @@ Tuples are represented as boxed terms containing a boxed header (`boxed[0]`), a 
     |                                |
     |<---------- word-size --------->|
 
+
+### Maps
+
+Maps are represented as boxed terms containing a boxed header (`boxed[0]`), a type tag of `0x3C` (`111100b`), followed by:
+
+* a term pointer to a tuple of arity `n` containing the keys in the map;
+* a sequence of `n`-many words, containing the values of the map corresponding (in order) to the keys in the reference tuple.
+
+The keys and values are single word terms, i.e., either immediates or pointers to boxed terms or lists.
+
+            +=========================+======+
+    +-----> |    boxed-tuple (n)      |000000|
+    |       +-------------------------+------+
+    |       |             key-1              |
+    |       +--------------------------------+
+    |       |             key-2              |
+    |       +--------------------------------+
+    |       |               ...              |
+    |       +--------------------------------+
+    |       |             key-n              |
+    |       +================================+
+    |       |                                |
+    |                       ...
+    |       |                         |< 6  >|
+    |       +=========================+======+
+    |       |    boxed-size (n)       |111100| boxed[0]
+    |       +-------------------------+------+
+    +-----------------<   keys               | boxed[1]
+            +--------------------------------+
+            |             value-1            | boxed[2]
+            +--------------------------------+
+            |               ...              | ...
+            +--------------------------------+
+            |             value-n            | boxed[2 + n]
+            +================================+
+            |                                |
+            |<---------- word-size --------->|
+
+The tuple of keys may or may not be contiguous with the boxed term holding the map itself (and in general will not be, after garbage collection).
+
 ### Binaries
 
 Binaries are stored in several different ways, depending on their size and the kinds of data to which they refer.

--- a/src/libAtomVM/opcodes.h
+++ b/src/libAtomVM/opcodes.h
@@ -116,7 +116,11 @@
 #define OP_RECV_SET 151
 #define OP_GC_BIF3 152
 #define OP_LINE 153
+#define OP_PUT_MAP_ASSOC 154
+#define OP_PUT_MAP_EXACT 155
 #define OP_IS_MAP 156
+#define OP_HAS_MAP_FIELDS 157
+#define OP_GET_MAP_ELEMENTS 158
 #define OP_IS_TAGGED_TUPLE 159
 #define OP_GET_HD 162
 #define OP_GET_TL 163

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -291,6 +291,7 @@ compile_erlang(test_ordering_1)
 compile_erlang(test_bs)
 compile_erlang(test_gc)
 compile_erlang(test_raise)
+compile_erlang(test_map)
 
 compile_erlang(ceilint)
 compile_erlang(ceilbadarg)
@@ -680,6 +681,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_bs.beam
     test_gc.beam
     test_raise.beam
+    test_map.beam
 
     ceilint.beam
     ceilbadarg.beam

--- a/tests/erlang_tests/test_map.erl
+++ b/tests/erlang_tests/test_map.erl
@@ -1,0 +1,231 @@
+-module(test_map).
+
+-export([start/0]).
+
+start() ->
+    ok = test_literal_map(),
+    ok = test_extend_map(),
+    ok = test_exact_map(),
+    ok = test_generate_map(),
+    ok = test_compare(),
+    ok = test_match_case(),
+    ok = test_match_clause(),
+    ok = test_external_terms(),
+    0.
+
+test_literal_map() ->
+    Map = #{a => 1, b => 2},
+    #{a := A, b := B} = Map,
+    A = 1,
+    B = 2,
+    %% No such c
+    try
+        #{c := _C} = Map, fail
+    catch
+        _:_E ->
+            ok
+    end.
+
+test_extend_map() ->
+    Map = #{a => 1, b => id(2)},
+    #{a := A, b := B} = Map,
+    A = 1,
+    B = 2,
+    Map2 = Map#{c => 3},
+    #{c := C2} = Map2,
+    C2 = 3,
+    Map3 = Map2#{c => bar, d => tapas},
+    #{c := C3, d := D3} = Map3,
+    C3 = bar,
+    D3 = tapas,
+    %% No such c
+    try
+        #{e := _} = Map3, fail
+    catch
+        _:_E ->
+            ok
+    end.
+
+test_exact_map() ->
+    Map = #{a => 1, b => 2},
+    #{a := A, b := B} = Map,
+    A = 1,
+    B = 2,
+    Map2 = Map#{a := id(foo)},
+    #{a := A2, b := B} = Map2,
+    A2 = foo,
+    %% No such c
+    try
+        _ = id(Map2#{id(c) := id(bar)}), fail
+    catch
+        _:_E ->
+            ok
+    end.
+
+test_generate_map() ->
+    ok = test_entries([]),
+    ok = test_entries([{a,1}, {b,2}, {c,3}]),
+    ok = test_entries([{[foo, bar], {tapas, gnu}}, {gnu, #{gnat => top}}]),
+    ok = test_entries(generate_random_entries(32)).
+
+test_entries(KVList) ->
+    Map = build_map(KVList),
+    test_entries(Map, remove_duplicates(KVList)).
+
+test_entries(_Map, []) ->
+    ok;
+test_entries(Map, [{K,V}|T]) ->
+    #{K := V1} = Map,
+    case V1 of
+        V -> ok;
+        SomethingElse ->
+            erlang:display({expected, V, got, SomethingElse}),
+            true = id(false)
+    end,
+    test_entries(Map, T).
+
+test_match_case() ->
+    Map1 = #{a => id(1), b => id(2), c => id(3)},
+    Map2 = #{a => id(1), b => id(2), c => id(3)},
+    ok = case Map1 of
+        Map2 -> ok;
+        _ -> fail
+    end,
+    Map3 = #{foo => id(bar), bar => id(tapas), tapas => id(yum)},
+    ok = case Map3 of
+        #{foo := bar} ->
+            ok;
+        _ -> fail
+    end,
+    ok = case Map3 of
+        #{foo := baz} ->
+            fail;
+        _ -> ok
+    end.
+
+test_match_clause() ->
+    ok = match_clause(#{a => id(1), b => id(2), c => id(3)}),
+    fail = match_clause(#{a => id(foo), b => id(2), c => id(3)}),
+    ok.
+
+match_clause(#{a := 1, b := 2}) ->
+    ok;
+match_clause(_) ->
+    fail.
+
+test_compare() ->
+    Map1 = #{a => id(1), b => id(2), c => id(3)},
+    Map2 = #{a => id(1), b => id(2), c => id(3)},
+    Map3 = #{foo => id(bar), bar => id(tapas), tapas => id(yum)},
+    true = Map1 == Map2,
+    true = Map1 =:= Map2,
+    false = Map1 =/= Map2,
+    false = Map2 == Map3,
+    false = Map2 =:= Map3,
+    false = Map1 < Map2,
+    true = Map2 < Map3,
+    false = Map3 < Map2,
+    true = #{} < build_map(generate_random_entries(8)),
+    true = #{a => id(1), b => id(2)} < #{a => id(1), b => id(2), c => id(3)},
+    true = #{a => id(1), b => id(2)} < #{a => id(1), b => id(tapas)},
+    true = #{a => id(1), b => id(2)} < #{foo => id(bar), bar => id(tapas)},
+    true = #{a => id(1), b => id(2)} < #{a => id(1), b => id(3)},
+    ok.
+
+test_external_terms() ->
+    Map = build_map(generate_random_entries(8)),
+    Bin = term_to_binary(Map),
+    Map2 = binary_to_term(Bin),
+    true = Map =:= Map2,
+    ok.
+
+build_map(KVList) ->
+    build_map(KVList, #{}).
+
+build_map([], Accum) ->
+    Accum;
+build_map([{K,V}|T], Accum) ->
+    NewAccum = Accum#{K => V},
+    build_map(T, NewAccum).
+
+generate_random_entries(Size) ->
+    generate_random_entries(Size, []).
+
+generate_random_entries(0, Accum) ->
+    Accum;
+generate_random_entries(N, Accum) ->
+    generate_random_entries(N - 1, [generate_random_entry()|Accum]).
+
+generate_random_entry() ->
+    {random_term(), random_term()}.
+
+random_term() ->
+    case random(5) of
+        1 ->
+            random_atom();
+        2 ->
+            random_int();
+        3 ->
+            random_tuple();
+        4 ->
+            random_binary();
+        5 ->
+            random_list()
+    end.
+
+random_atom() ->
+    case random(3) of
+        1 -> foo;
+        2 -> bar;
+        3 -> tapas
+    end.
+
+random_int() ->
+    random(256).
+
+random_tuple() ->
+    case random(3) of
+        1 ->
+            {random_atom()};
+        2 ->
+            {random_atom(), random_int()};
+        3 ->
+            {random_atom(), random_int(), random_int()}
+    end.
+
+random_binary() ->
+    Size = random(3) * 50,
+    atomvm:rand_bytes(Size).
+
+random_list() ->
+    binary_to_list(random_binary()).
+
+random(N) ->
+    (abs(atomvm:random()) rem N) + 1.
+
+remove_duplicates(KVList) ->
+    reverse(remove_duplicates(reverse(KVList), [])).
+
+remove_duplicates([], Accum) ->
+    Accum;
+remove_duplicates([{K,_V}=E|T], Accum) ->
+    case has_key(Accum, K) of
+        true ->
+            remove_duplicates(T, Accum);
+        _ ->
+            remove_duplicates(T, [E|Accum])
+    end.
+
+has_key([], _K) -> false;
+has_key([{K, _V}|_], K) -> true;
+has_key([_|T], K) ->
+    has_key(T, K).
+
+reverse(L) -> reverse(L, []).
+
+reverse([], A) ->
+    A;
+reverse([H|T], Accum) ->
+    reverse(T, [H|Accum]).
+
+id(X) -> X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -330,6 +330,7 @@ struct Test tests[] =
     {"test_bs.beam", 0},
     {"test_gc.beam", 0 },
     {"test_raise.beam", 7},
+    {"test_map.beam", 0},
 
     {"ceilint.beam", 1},
     {"ceilbadarg.beam", -1},


### PR DESCRIPTION
This change set adds support for the opcodes needed to support map syntax only.  Additional work is needed to support map bifs and the OTP `map` module.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
