### PR TITLE
Added support for a subset of the functionality of the Erlang/OTP maps module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -559,6 +559,7 @@ matrix:
             - erlang
             - gperf
       script: |
+        sed -i 's/, test_maps/%, test_maps/g' tests/libs/estdlib/tests.erl
         mkdir build_tests
         cd build_tests
         cmake ..

--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(ERLANG_MODULES
     io_lib
     io
     lists
+    maps
     proplists
     string
     timer

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -28,9 +28,9 @@
     apply/3,
     start_timer/3, start_timer/4, cancel_timer/1, send_after/3,
     process_info/2, system_info/1,
-    md5/1
+    md5/1,
+    is_map/1, map_size/1, map_get/2, map_is_key/2
 ]).
-
 
 %%-----------------------------------------------------------------------------
 %% @param   Time time in milliseconds after which to send the timeout message.
@@ -178,3 +178,63 @@ apply(Module, Function, Args) ->
             Module:Function(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6);
         _ -> throw(badarg)
     end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Map     the map to test
+%% @returns `true' if `Map' is a map; `false', otherwise.
+%% @doc     Return `true' if `Map' is a map; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_map(Map::map()) -> boolean().
+is_map(_Map) ->
+    throw(bif_error).
+
+%%-----------------------------------------------------------------------------
+%% @param   Map the map
+%% @returns the size of the map
+%% @throws {badmap, Map}
+%% @doc Returns the size of (i.e., the number of entries in) the map
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec map_size(Map::map()) -> non_neg_integer().
+map_size(_Map) ->
+    throw(bif_error).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key to get
+%% @param   Map     the map from which to get the value
+%% @returns the value in `Map' associated with `Key', if it exists.
+%% @throws  {badkey, Key} | {badmap, Map}
+%% @doc     Get the value in `Map' associated with `Key', if it exists.
+%%
+%% This function throws a `{badkey, Key}' exception if 'Key' does not occur in `Map' or
+%% a `{badmap, Map}' if `Map' is not a map.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec map_get(Key::term(), Map::map()) -> Value::term().
+map_get(_Key, _Map) ->
+    throw(bif_error).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key
+%% @param   Map     the map
+%% @returns `true' if `Key' is associated with a value in `Map'; `false', otherwise.
+%% @throws  {badmap, Map}
+%% @doc     Return `true' if `Key' is associated with a value in `Map'; `false', otherwise.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec map_is_key(Key::term(), Map::map()) -> boolean().
+map_is_key(_Key, _Map) ->
+    throw(bif_error).

--- a/libs/estdlib/src/maps.erl
+++ b/libs/estdlib/src/maps.erl
@@ -1,0 +1,475 @@
+%%
+%% Copyright (c) 2021 dushin.net
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+
+%%-----------------------------------------------------------------------------
+%% @doc A <em>naive</em> implementation of the Erlang/OTP `maps' interface.
+%%
+%% The `maps' module provides several convenience operations for interfacing
+%% with the Erlang map type, which associates (unique) keys with values.
+%%
+%% Note that the ordering of entries in a map is implementation-defined.  While
+%% many operations in this module present entries in lexical order, users should
+%% in general make no assumptions about the ordering of entries in a map.
+%%
+%% This module implements a susbset of the Erlang/OTP `maps' interface.
+%% Some OTP functions are not implemented, and the approach favors
+%% correctness and readability over speed and performance.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(maps).
+
+-export([
+    get/2, get/3, is_key/2, put/3, iterator/1, next/1, new/0, keys/1, values/1, to_list/1, from_list/1,
+    size/1, find/2, filter/2, fold/3, map/2, merge/2, remove/2, update/3
+]).
+
+-type key() :: term().
+-type value() :: term().
+-type iterator() :: {key(), value(), iterator()} | none | nonempty_improper_list(non_neg_integer(), map()).
+-type map_or_iterator() :: map() | iterator().
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key to get
+%% @param   Map     the map from which to get the value
+%% @returns the value in `Map' associated with `Key', if it exists.
+%% @throws  {badkey, Key} | {badmap, Map}
+%% @doc     Get the value in `Map' associated with `Key', if it exists.
+%%
+%% This function throws a `{badkey, Key}' exception if 'Key' does not occur in `Map' or
+%% a `{badmap, Map}' if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get(Key::key(), Map::map()) -> Value::value().
+get(Key, Map) ->
+    erlang:map_get(Key, Map).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key
+%% @param   Map     the map
+%% @param   Default default value
+%% @throws  {badmap, Map}
+%% @returns the value in `Map' associated with `Key', or `Default', if
+%%          the key is not associated with a value in `Map'.
+%% @doc     Get the value in `Map' associated with `Key', or `Default', if
+%%          the key is not associated with a value in `Map'.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get(Key::key(), Map::map(), Default::term()) -> Value::value().
+get(Key, Map, Default) ->
+    try
+        ?MODULE:get(Key, Map)
+    catch
+        _:{badkey, _} ->
+            Default
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key
+%% @param   Map     the map
+%% @returns `true' if `Key' is associated with a value in `Map'; `false', otherwise.
+%% @throws  {badmap, Map}
+%% @doc     Return `true' if `Key' is associated with a value in `Map'; `false', otherwise.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_key(Key::key(), Map::map()) -> boolean().
+is_key(Key, Map) ->
+    erlang:is_map_key(Key, Map).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key
+%% @param   Value   the value
+%% @param   Map     the map
+%% @returns A copy of `Map' containing the `{Key, Value}' association.
+%% @throws  {badmap, Map}
+%% @doc     Return the map containing the `{Key, Value}' association.
+%%
+%% If `Key' occurs in `Map' then it will be over-written.  Otherwise, the
+%% returned map will contain the new association.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec put(Key::key(), Value::value(), Map::map()) -> map().
+put(Key, Value, Map) when is_map(Map) ->
+    Map#{Key => Value};
+put(_Key, _Value, Map) when not is_map(Map )->
+    throw({badmap, Map}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Map     the map
+%% @returns an iterator structure that can be used to iterate over associations
+%% in a map.
+%% @throws  {badmap, Map}
+%% @see next/1
+%% @doc Return an iterator structure that can be used to iterate over associations
+%% in a map.
+%%
+%% In general, users shouuld make no assumptions about the order in which entries
+%% appear in an iterator.  The order of entries in a map is implementation-defined.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec iterator(Map::map()) -> iterator().
+iterator(Map) when is_map(Map) ->
+    [0 | Map];
+iterator(Map) ->
+    throw({badmap, Map}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Iterator a map iterator
+%% @returns the key and value, along with the next iterator in the map, or the
+%%          atom `none' if there are no more items over which to iterate.
+%% @throws  badarg
+%% @doc Returns the next key and value in the map, along with
+%% a new iterator that can be used to iterate over the remainder of the map.
+%%
+%% This function throws a `badarg' exception if the supplied iterator is not
+%% of the expected type.  Only use iterators that are returned from functions
+%% in this module.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec next(Iterator::iterator()) -> {Key::key(), Value::value(), NextIterator::iterator()} | none.
+next([_Pos | _Map] = _Iterator) ->
+    throw(nif_error).
+
+%%-----------------------------------------------------------------------------
+%% @returns a new map
+%% @doc Return a new (empty) map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec new() -> iterator().
+new() ->
+    #{}.
+
+%%-----------------------------------------------------------------------------
+%% @param   Map     the map
+%% @returns the list of keys that occur in this map.
+%% @throws  {badmap, Map}
+%% @doc Returns the list of keys that occur in this map.
+%%
+%% No guarantees are provided about the order of keys returned from this function.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec keys(Map::map()) -> [key()].
+keys(Map) when is_map(Map) ->
+    iterate_keys(maps:next(maps:iterator(Map)), []);
+keys(Map) ->
+    throw({badmap, Map}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Map     the map
+%% @returns the list of values that occur in this map.
+%% @throws  {badmap, Map}
+%% @doc Returns the list of values that occur in this map.
+%%
+%% No guarantees are provided about the order of values returned from this function.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec values(Map::map()) -> [key()].
+values(Map) when is_map(Map) ->
+    iterate_values(maps:next(maps:iterator(Map)), []);
+values(Map) ->
+    throw({badmap, Map}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Map
+%% @returns a list of `[{Key, Value}]' tuples
+%% @doc Return the list of entries, expressed as `{Key, Value}' pairs, in the supplied map.
+%%
+%% No guarantees are provided about the order of entries returned from this function.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec to_list(Map::map()) -> [key()].
+to_list(Map) when is_map(Map) ->
+    iterate_entries(maps:next(maps:iterator(Map)), []);
+to_list(Map) ->
+    throw({badmap, Map}).
+
+%%-----------------------------------------------------------------------------
+%% @param   List a list of `[{Key, Value}]' pairs
+%% @returns the map containing the entries from the list of supplied key-value pairs.
+%% @throws badarg
+%% @doc This function constructs a map from the supplied list of key-value pairs.
+%%
+%% If the input list contains duplicate keys, the returned map will contain the
+%% right-most entry.
+%%
+%% This function will raise a `badarg' exception if the input is not a proper
+%% list or contains an element that is not a key-value pair.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec from_list(List::[{Key::key(), Value::value()}]) -> map().
+from_list(List) when is_list(List) ->
+    iterate_from_list(List, ?MODULE:new());
+from_list(_List) ->
+    throw(badarg).
+
+%%-----------------------------------------------------------------------------
+%% @param   Map the map
+%% @returns the size of the map
+%% @throws {badmap, Map}
+%% @doc Returns the size of (i.e., the number of entries in) the map
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec size(Map::map()) -> non_neg_integer().
+size(Map) when is_map(Map) ->
+    erlang:map_size(Map);
+size(Map) ->
+    throw({badmap, Map}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key to find
+%% @param   Map     the map in which to search
+%% @returns `{ok, Value}' if `Key' is in `Map'; `error', otherwise.
+%% @throws {badmap, Map}
+%% @doc Returns `{ok, Value}' if `Key' is in `Map'; `error', otherwise.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec find(Key::key(), Map::map()) -> {ok, Value::value()} | error.
+find(Key, Map) ->
+    try
+        {ok, ?MODULE:get(Key, Map)}
+    catch
+        _:{badkey, _} ->
+            error
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Pred    a function used to filter entries from the map
+%% @param   MapOrIterator the map or map iterator to filter
+%% @returns a map containing all elements in `MapOrIterator' that satisfy `Pred'
+%% @throws {badmap, Map} | badarg
+%% @doc Return a map who's entries are filtered by the supplied predicate.
+%%
+%% This function returns a new map containing all elements from the input
+%% `MapOrIterator' that satisfy the input `Pred'.
+%%
+%% The supplied predicate is a function from key-value inputs to a boolean value.
+%%
+%% This function throws a `{badmap, Map}' exception if `Map' is not a map or map iterator,
+%% and a `badarg' exception if the input predicate is not a function.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec filter(Pred::fun((Key::key(), Value::value()) -> boolean()), MapOrIterator::map_or_iterator()) -> map().
+filter(Pred, Map) when is_function(Pred, 2) andalso is_map(Map) ->
+    iterate_filter(Pred, maps:next(maps:iterator(Map)), ?MODULE:new());
+filter(Pred, [Pos|Map] = Iterator) when is_function(Pred, 2) andalso is_integer(Pos) andalso is_map(Map) ->
+    iterate_filter(Pred, maps:next(Iterator), ?MODULE:new());
+filter(_Pred, Map) when not is_map(Map) ->
+    throw({badmap, Map});
+filter(_Pred, _Map) ->
+    throw(badarg).
+
+%%-----------------------------------------------------------------------------
+%% @param   Fun     function over which to fold values
+%% @param   Init    the initial value of the fold accumulator
+%% @param   MapOrIterator the map or map iterator over which to fold
+%% @returns the result of folding over all elements of the supplied map.
+%% @throws {badmap, Map} | badarg
+%% @doc Fold over the entries in a map.
+%%
+%% This function takes a function used to fold over all entries in a map
+%% and an initial accumulator value to use as the value supplied to the
+%% first entry in the map.
+%%
+%% This function throws a `badmap' exception if `Map' is not a map or map iterator,
+%% and a `badarg' exception if the input function is not a function.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec fold(Fun::fun((Key::key(), Value::value(), Accum::term()) -> term()), Init::term(), MapOrIterator::map_or_iterator()) -> term().
+fold(Fun, Init, Map) when is_function(Fun, 3) andalso is_map(Map) ->
+    iterate_fold(Fun, maps:next(maps:iterator(Map)), Init);
+fold(Fun, Init, [Pos|Map] = Iterator) when is_function(Fun, 3) andalso is_integer(Pos) andalso is_map(Map) ->
+    iterate_fold(Fun, maps:next(Iterator), Init);
+fold(_Fun, _Init, Map) when not is_map(Map) ->
+    throw({badmap, Map});
+fold(_Fun, _Init, _Map) ->
+    throw(badarg).
+
+%%-----------------------------------------------------------------------------
+%% @param   Fun     the function to apply to every entry in the map
+%% @param   Map     the map to which to apply the map function
+%% @returns the result of applying `Fun' to every entry in `Map'
+%% @throws {badmap, Map} | badarg
+%% @doc Returns the result of applying a function to every element of a map.
+%%
+%% This function throws a `badmap' exception if `Map' is not a map or map iterator,
+%% and a `badarg' exception if the input function is not a function.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec map(Fun::fun((Key::key(), Value::value()) -> value()), Map::map_or_iterator()) -> map().
+map(Fun, Map) when is_function(Fun, 2) andalso is_map(Map) ->
+    iterate_map(Fun, maps:next(maps:iterator(Map)), ?MODULE:new());
+map(Fun, [Pos|Map] = Iterator) when is_function(Fun, 2) andalso is_integer(Pos) andalso is_map(Map) ->
+    iterate_map(Fun, maps:next(Iterator), ?MODULE:new());
+map(_Fun, Map) when not is_map(Map) ->
+    throw({badmap, Map});
+map(_Fun, _Map) ->
+    throw(badarg).
+
+%%-----------------------------------------------------------------------------
+%% @param   Map1  a map
+%% @param   Map2  a mpa
+%% @returns the result of merging entries from `Map1' and `Map2'.
+%% @throws {badmap, Map}
+%% @doc Merge two maps to yeild a new map.
+%%
+%% If `Map1' and `Map2' contain the same key, then the value from `Map2' will be used.
+%%
+%% This function throws a `badmap' exception if neither `Map1' nor `Map2' is a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec merge(Map1::map(), Map2::map()) -> map().
+merge(Map1, Map2) when is_map(Map1) andalso is_map(Map2) ->
+    iterate_merge(maps:next(maps:iterator(Map2)), Map1);
+merge(Map1, _Map2) when not is_map(Map1) ->
+    throw({badmap, Map1});
+merge(_Map1, Map2) when not is_map(Map2) ->
+    throw({badmap, Map2}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key to remove
+%% @param   MapOrIterator     the map or map iterator from which to remove the key
+%% @returns a new map without `Key' as an entry.
+%% @throws {badmap, Map}
+%% @doc Remove an entry from a map using a key.
+%%
+%% If `Key' does not occur in `Map', then the returned Map has the same
+%% entries as the input map or map iterator.
+%%
+%% Note.  This function extends the functionality of the OTP `remove/2' function,
+%% since the OTP interface only takes a map as input.
+%%
+%% This function throws a `badmap' exception if `Map' is not a map or map iterator.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec remove(Key::key(), MapOrIterator::map_or_iterator()) -> map().
+remove(Key, Map) when is_map(Map) ->
+    case ?MODULE:is_key(Key, Map) of
+        true ->
+            iterate_remove(Key, maps:next(maps:iterator(Map)), ?MODULE:new());
+        _ ->
+            Map
+    end;
+remove(Key, [Pos|Map] = Iterator) when is_integer(Pos) andalso is_map(Map) ->
+    iterate_remove(Key, maps:next(Iterator), ?MODULE:new());
+remove(_Key, Map) when not is_map(Map) ->
+    throw({badmap, Map}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key     the key to update
+%% @param   Value   the value to update
+%% @param   Map     the map to update
+%% @returns a new map, with `Key' updated with `Value'
+%% @throws {badmap, Map}
+%% @doc Returns a new map with an updated key-value association.
+%%
+%% This function throws a `badmap' exception if `Map' is not a map.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec update(Key::key(), Value::value(), Map::map()) -> map().
+update(Key, Value, Map) when is_map(Map) ->
+    Map#{Key => Value};
+update(_Key, _Value, Map) when not is_map(Map) ->
+    throw({badmap, Map}).
+
+
+%%
+%% Internal functions
+%%
+
+%% @private
+iterate_keys(none, Accum) ->
+    lists:reverse(Accum);
+iterate_keys({Key, _Value, Iterator}, Accum) ->
+    iterate_keys(maps:next(Iterator), [Key|Accum]).
+
+%% @private
+iterate_values(none, Accum) ->
+    lists:reverse(Accum);
+iterate_values({_Key, Value, Iterator}, Accum) ->
+    iterate_values(maps:next(Iterator), [Value|Accum]).
+
+%% @private
+iterate_entries(none, Accum) ->
+    lists:reverse(Accum);
+iterate_entries({Key, Value, Iterator}, Accum) ->
+    iterate_entries(maps:next(Iterator), [{Key, Value}|Accum]).
+
+%% @private
+iterate_filter(_Pred, none, Accum) ->
+    Accum;
+iterate_filter(Pred, {Key, Value, Iterator}, Accum) ->
+    NewAccum =
+        case Pred(Key, Value) of
+            true ->
+                Accum#{Key => Value};
+            _ ->
+                Accum
+        end,
+    iterate_filter(Pred, maps:next(Iterator), NewAccum).
+
+%% @private
+iterate_fold(_Fun, none, Accum) ->
+    Accum;
+iterate_fold(Fun, {Key, Value, Iterator}, Accum) ->
+    NewAccum = Fun(Key, Value, Accum),
+    iterate_fold(Fun, maps:next(Iterator), NewAccum).
+
+%% @private
+iterate_map(_Fun, none, Accum) ->
+    Accum;
+iterate_map(Fun, {Key, Value, Iterator}, Accum) ->
+    NewAccum = Accum#{Key => Fun(Key, Value)},
+    iterate_map(Fun, maps:next(Iterator), NewAccum).
+
+%% @private
+iterate_merge(none, Accum) ->
+    Accum;
+iterate_merge({Key, Value, Iterator}, Accum) ->
+    iterate_merge(maps:next(Iterator), Accum#{Key => Value}).
+
+%% @private
+iterate_remove(_Key, none, Accum) ->
+    Accum;
+iterate_remove(Key, {Key, _Value, Iterator}, Accum) ->
+    iterate_remove(Key, maps:next(Iterator), Accum);
+iterate_remove(Key, {OtherKey, Value, Iterator}, Accum) ->
+    iterate_remove(Key, maps:next(Iterator), Accum#{OtherKey => Value}).
+
+%% @private
+iterate_from_list([], Accum) ->
+    Accum;
+iterate_from_list([{Key, Value}|T], Accum) ->
+    iterate_from_list(T, Accum#{Key => Value});
+iterate_from_list(_List, _Accum) ->
+    throw(badarg).

--- a/libs/etest/src/etest.erl
+++ b/libs/etest/src/etest.erl
@@ -25,7 +25,7 @@
 -module(etest).
 
 -export([test/1]).
--export([assert_match/2, assert_true/1, assert_failure/2]).
+-export([assert_match/2, assert_equals/2, assert_true/1, assert_failure/2]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Tests a list of test modules
@@ -59,6 +59,19 @@ assert_match(_, _) -> fail.
 
 %%-----------------------------------------------------------------------------
 %% @param   X a term
+%% @param   Y a term
+%% @returns ok if X and Y are equal; fail otherwise.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec assert_equals(term(), term()) -> ok | fail.
+assert_equals(X, Y) ->
+    case X == Y of
+        true -> ok;
+        _ -> fail
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   X a term
 %% @returns ok if X is true; fail otherwise.
 %% @end
 %%-----------------------------------------------------------------------------
@@ -72,7 +85,7 @@ assert_true(_) -> fail.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec assert_failure(fun(), Error::atom()) -> ok | fail.
-assert_failure(F, _E) ->
+assert_failure(F, E) ->
     try
         F(),
         fail
@@ -93,9 +106,9 @@ run_test(Test) ->
         console:puts("+"), console:flush(),
         Result
     catch
-        _:_ ->
+        _:E ->
             console:puts("-"), console:flush(),
-            exception
+            {exception, E}
     end.
 
 %% @private

--- a/libs/include/etest.hrl
+++ b/libs/include/etest.hrl
@@ -25,6 +25,14 @@
             fail
     end
 ).
+-define(ASSERT_EQUALS(A, B),
+    case etest:assert_equals(A, B) of
+        ok -> ok;
+        fail ->
+            erlang:display({failed_assert_equals, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, A, B}),
+            fail
+    end
+).
 -define(ASSERT_TRUE(C),
     case etest:assert_true(C) of
         ok -> ok;
@@ -37,8 +45,7 @@
     case etest:assert_failure(fun() -> A end, E) of
         ok -> ok;
         fail ->
-            erlang:display({failed_assert_failure, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, E}),
+            erlang:display({failed_assert_failure, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, A, E}),
             fail
     end
 ).
-

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -171,6 +171,7 @@ term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2)
         }
         term err = term_alloc_tuple(2, ctx);
         term_put_tuple_element(err, 0, BADMAP_ATOM);
+        // TODO elt(2) of err term is supposed to be arg2 but may be invalidated by GC
         term_put_tuple_element(err, 1, UNSUPPORTED_ATOM);
 
         RAISE_ERROR(err);
@@ -229,14 +230,17 @@ term bif_erlang_tuple_size_1(Context *ctx, term arg1)
     return term_from_int32(term_get_tuple_arity(arg1));
 }
 
-term bif_erlang_map_size_1(Context *ctx, int _live, term arg1)
+term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
 {
+    UNUSED(live);
+
     if (!UNLIKELY(term_is_map(arg1))) {
         if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
         term_put_tuple_element(err, 0, BADMAP_ATOM);
+        // TODO elt(2) of err term is supposed to be arg1 but may be invalidated by GC
         term_put_tuple_element(err, 1, UNSUPPORTED_ATOM);
 
         RAISE_ERROR(err);
@@ -255,6 +259,7 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
         }
         term err = term_alloc_tuple(2, ctx);
         term_put_tuple_element(err, 0, BADMAP_ATOM);
+        // TODO elt(2) of err term is supposed to be arg2 but may be invalidated by GC
         term_put_tuple_element(err, 1, UNSUPPORTED_ATOM);
 
         RAISE_ERROR(err);
@@ -267,6 +272,7 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
         }
         term err = term_alloc_tuple(2, ctx);
         term_put_tuple_element(err, 0, BADKEY_ATOM);
+        // TODO elt(2) of err term is supposed to be arg1 but may be invalidated by GC
         term_put_tuple_element(err, 1, UNSUPPORTED_ATOM);
 
         RAISE_ERROR(err);

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -88,3 +88,4 @@ base64:encode/1, &base64_encode_nif
 base64:decode/1, &base64_decode_nif
 base64:encode_to_string/1, &base64_encode_to_string_nif
 base64:decode_to_string/1, &base64_decode_to_string_nif
+maps:next/1, &maps_next_nif

--- a/tests/erlang_tests/test_map.erl
+++ b/tests/erlang_tests/test_map.erl
@@ -65,7 +65,7 @@ test_is_map_key_bif() ->
             fail
     end,
     ok = try
-        is_map_key(b, foo),
+        _ = is_map_key(b, id(foo)),
         fail
     catch
         _:{badmap, _} ->
@@ -91,7 +91,7 @@ test_map_get_bif() ->
             fail
     end,
     ok = try
-        map_get(b, foo),
+        _ = map_get(b, id(foo)),
         fail
     catch
         _:{badmap, _} ->

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -12,6 +12,7 @@ set(ERLANG_MODULES
     test_gen_udp
     test_io_lib
     test_lists
+    test_maps
     test_string
     test_proplists
     test_timer

--- a/tests/libs/estdlib/test_maps.erl
+++ b/tests/libs/estdlib/test_maps.erl
@@ -1,0 +1,176 @@
+-module(test_maps).
+
+-export([test/0, id/1]).
+
+-include("etest.hrl").
+
+test() ->
+    ok = test_get(),
+    ok = test_is_key(),
+    ok = test_put(),
+    ok = test_iterator(),
+    ok = test_keys(),
+    ok = test_values(),
+    ok = test_to_list(),
+    ok = test_from_list(),
+    ok = test_size(),
+    ok = test_find(),
+    ok = test_filter(),
+    ok = test_fold(),
+    ok = test_map(),
+    ok = test_merge(),
+    ok = test_remove(),
+    ok = test_update(),
+    ok.
+
+test_get() ->
+    ?ASSERT_MATCH(maps:get(foo, id(#{foo => bar})), bar),
+    ok = check_bad_map(fun() -> maps:get(bar, id(not_a_map)) end),
+    ok = check_bad_key(fun() -> maps:get(bar, id(#{foo => bar})) end, bar),
+
+    ?ASSERT_MATCH(maps:get(gnu, id(#{foo => bar}), gnat), gnat),
+    ok.
+
+test_is_key() ->
+    ?ASSERT_MATCH(maps:is_key(foo, id(#{foo => bar})), true),
+    ok = check_bad_map(fun() -> maps:is_key(bar, id(not_a_map)) end),
+    ?ASSERT_MATCH(maps:is_key(bar, id(#{foo => bar})), false),
+    ok.
+
+test_put() ->
+    ?ASSERT_MATCH(maps:put(foo, bar, id(#{})), #{foo => bar}),
+    ?ASSERT_MATCH(maps:put(foo, bar, id(#{foo => bar})), #{foo => bar}),
+    ?ASSERT_MATCH(maps:put(foo, tapas, id(#{foo => bar})), #{foo => tapas}),
+    ?ASSERT_MATCH(maps:put(gnu, gnat, id(#{foo => bar})), #{foo => bar, gnu => gnat}),
+    ok = check_bad_map(fun() -> maps:put(bar, tapas, id(not_a_map)) end),
+    ok.
+
+test_iterator() ->
+    Map = #{c => 3, a => 1, b => 2},
+    Iterator0 = maps:iterator(Map),
+    {a, 1, Iterator1} = maps:next(Iterator0),
+    {b, 2, Iterator2} = maps:next(Iterator1),
+    {c, 3, Iterator3} = maps:next(Iterator2),
+    none = maps:next(Iterator3),
+    none = maps:next(none),
+
+    EmptyMap = maps:new(),
+    EmptyIterator = maps:iterator(EmptyMap),
+    none = maps:next(EmptyIterator),
+
+    ok.
+
+test_keys() ->
+    ?ASSERT_MATCH(maps:keys(maps:new()), []),
+    ?ASSERT_MATCH(maps:keys(#{a => 1, b => 2, c => 3}), [a, b, c]),
+    ok = check_bad_map(fun() -> maps:keys(id(not_a_map)) end),
+    ok.
+
+test_values() ->
+    ?ASSERT_MATCH(maps:values(maps:new()), []),
+    ?ASSERT_MATCH(maps:values(#{a => 1, b => 2, c => 3}), [1, 2, 3]),
+    ok = check_bad_map(fun() -> maps:values(id(not_a_map)) end),
+    ok.
+
+test_to_list() ->
+    ?ASSERT_MATCH(maps:to_list(maps:new()), []),
+    ?ASSERT_MATCH(maps:to_list(#{a => 1, b => 2, c => 3}), [{a, 1}, {b, 2}, {c, 3}]),
+    ok = check_bad_map(fun() -> maps:to_list(id(not_a_map)) end),
+    ok.
+
+test_from_list() ->
+    ?ASSERT_EQUALS(maps:from_list([]), #{}),
+    ?ASSERT_EQUALS(maps:from_list([{a, 1}, {b, 2}, {c, 3}]), #{a => 1, b => 2, c => 3}),
+    ok = etest:assert_failure(fun() -> maps:from_list(id(foo)) end, badarg),
+    ok = etest:assert_failure(fun() -> maps:from_list(id([improper|list])) end, badarg),
+    ok.
+
+test_size() ->
+    ?ASSERT_MATCH(maps:size(maps:new()), 0),
+    ?ASSERT_MATCH(maps:size(#{a => 1, b => 2, c => 3}), 3),
+    ok = check_bad_map(fun() -> maps:size(id(not_a_map)) end),
+    ok.
+
+test_find() ->
+    ?ASSERT_MATCH(maps:find(foo, maps:new()), error),
+    ?ASSERT_MATCH(maps:find(a, #{a => 1, b => 2, c => 3}), {ok, 1}),
+    ?ASSERT_MATCH(maps:find(b, #{a => 1, b => 2, c => 3}), {ok, 2}),
+    ?ASSERT_MATCH(maps:find(c, #{a => 1, b => 2, c => 3}), {ok, 3}),
+    ?ASSERT_MATCH(maps:find(foo, #{a => 1, b => 2, c => 3}), error),
+    ok = check_bad_map(fun() -> maps:find(foo, id(not_a_map)) end),
+    ok.
+
+test_filter() ->
+    Filter = fun(_Key, Value) -> Value rem 2 == 0 end,
+    ?ASSERT_EQUALS(maps:filter(Filter, maps:new()), #{}),
+    ?ASSERT_EQUALS(maps:filter(Filter, #{a => 1, b => 2, c => 3}), #{b => 2}),
+    ok = check_bad_map(fun() -> maps:filter(Filter, id(not_a_map)) end),
+    ok = check_bad_map(fun() -> maps:filter(not_a_function, id(not_a_map)) end),
+    ?ASSERT_FAILURE(maps:filter(not_a_function, maps:new()), badarg),
+    ok.
+
+test_fold() ->
+    Fun = fun(_Key, Value, Sum) -> Sum + Value end,
+    ?ASSERT_EQUALS(maps:fold(Fun, 0, maps:new()), 0),
+    ?ASSERT_EQUALS(maps:fold(Fun, 0, #{a => 1, b => 2, c => 3}), 6),
+    ok = check_bad_map(fun() -> maps:fold(Fun, any, id(not_a_map)) end),
+    ok = check_bad_map(fun() -> maps:fold(not_a_function, any, id(not_a_map)) end),
+    ?ASSERT_FAILURE(maps:fold(not_a_function, any, maps:new()), badarg),
+    ok.
+
+test_map() ->
+    Fun = fun(_Key, Value) -> 2 * Value end,
+    ?ASSERT_EQUALS(maps:map(Fun, maps:new()), #{}),
+    ?ASSERT_EQUALS(maps:map(Fun, #{a => 1, b => 2, c => 3}), #{a => 2, b => 4, c => 6}),
+    ok = check_bad_map(fun() -> maps:map(Fun, id(not_a_map)) end),
+    ok = check_bad_map(fun() -> maps:map(not_a_function, id(not_a_map)) end),
+    ?ASSERT_FAILURE(maps:map(not_a_function, maps:new()), badarg),
+    ok.
+
+test_merge() ->
+    ?ASSERT_EQUALS(maps:merge(maps:new(), maps:new()), #{}),
+    ?ASSERT_EQUALS(maps:merge(#{a => 1, b => 2, c => 3}, maps:new()), #{a => 1, b => 2, c => 3}),
+    ?ASSERT_EQUALS(maps:merge(maps:new(), #{a => 1, b => 2, c => 3}), #{a => 1, b => 2, c => 3}),
+    ok = check_bad_map(fun() -> maps:merge(maps:new(), id(not_a_map)) end),
+    ok = check_bad_map(fun() -> maps:merge(id(not_a_map), maps:new()) end),
+    ok.
+
+test_remove() ->
+    ?ASSERT_EQUALS(maps:remove(foo, maps:new()), #{}),
+    ?ASSERT_EQUALS(maps:remove(a, #{a => 1, b => 2, c => 3}), #{b => 2, c => 3}),
+    ?ASSERT_EQUALS(maps:remove(b, #{a => 1, b => 2, c => 3}), #{a => 1, c => 3}),
+    ?ASSERT_EQUALS(maps:remove(c, #{a => 1, b => 2, c => 3}), #{a => 1, b => 2}),
+    ?ASSERT_EQUALS(maps:remove(d, #{a => 1, b => 2, c => 3}), #{a => 1, b => 2, c => 3}),
+    ok = check_bad_map(fun() -> maps:remove(foo, id(not_a_map)) end),
+    ok.
+
+test_update() ->
+    ?ASSERT_EQUALS(maps:update(foo, bar, maps:new()), #{foo => bar}),
+    ?ASSERT_EQUALS(maps:update(a, 10, #{a => 1, b => 2, c => 3}), #{a => 10, b => 2,  c => 3}),
+    ?ASSERT_EQUALS(maps:update(b, 20, #{a => 1, b => 2, c => 3}), #{a => 1,  b => 20, c => 3}),
+    ?ASSERT_EQUALS(maps:update(c, 30, #{a => 1, b => 2, c => 3}), #{a => 1,  b => 2,  c => 30}),
+    ?ASSERT_EQUALS(maps:update(d, 40, #{a => 1, b => 2, c => 3}), #{a => 1,  b => 2,  c => 3, d => 40}),
+    ok = check_bad_map(fun() -> maps:update(foo, bar, id(not_a_map)) end),
+    ok.
+
+
+id(X) -> X.
+
+check_bad_map(F) ->
+    try
+        F(),
+        fail
+    catch
+        %% TODO OTP23 compiler compiles to erlang:map_ equivalents
+        _:{badmap, _} ->
+            ok
+    end.
+check_bad_key(F, _Key) ->
+    try
+        F(),
+        fail
+    catch
+        %% TODO OTP23 compiler compiles to erlang:map_ equivalents
+        _:{badkey, _} ->
+            ok
+    end.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -9,6 +9,7 @@ start() ->
         , test_gen_statem
         , test_gen_udp
         , test_io_lib
+        , test_maps
         , test_proplists
         , test_timer
         , test_supervisor


### PR DESCRIPTION
Adds support for `maps`.

Also adds code TODO comments and documentation to previously added map BIFs, and tightens up test framework a little.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
