### PR TITLE
list.h: fix list_last function

### DIFF
--- a/src/libAtomVM/list.h
+++ b/src/libAtomVM/list.h
@@ -70,7 +70,7 @@ static inline struct ListHead *list_first(struct ListHead *head)
 
 static inline struct ListHead *list_last(struct ListHead *head)
 {
-    return head->next;
+    return head->prev;
 }
 
 #endif


### PR DESCRIPTION
It was actually returning the first item instead of the last

Signed-off-by: Riccardo Binetti <rbino@gmx.com>

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
