### PR TITLE
Maps fixes

### DIFF
--- a/libs/estdlib/src/io_lib.erl
+++ b/libs/estdlib/src/io_lib.erl
@@ -99,6 +99,8 @@ to_string(T, Q) when is_binary(T) ->
     "<<" ++ Data ++ ">>";
 to_string(T, _Q) when is_tuple(T) ->
     "{" ++ lists:flatten(lists:join(",", [to_string(E, quote) || E <- erlang:tuple_to_list(T)])) ++ "}";
+to_string(T, _Q) when is_map(T) ->
+    "#{" ++ lists:flatten(lists:join(",", [to_string(K, quote) ++ " => " ++ to_string(V, quote) || {K, V} <- maps:to_list(T)])) ++ "}";
 to_string(_T, _Q) -> "unknown".
 
 %% @private

--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -213,3 +213,18 @@ int interop_write_iolist(term t, char *p)
     temp_stack_destory(&temp_stack);
     return 1;
 }
+
+term interop_map_get_value(Context *ctx, term map, term key)
+{
+    return interop_map_get_value_default(ctx, map, key, term_nil());
+}
+
+term interop_map_get_value_default(Context *ctx, term map, term key, term default_value)
+{
+    int pos = term_find_map_pos(ctx, map, key);
+    if (pos == -1) {
+        return default_value;
+    } else {
+        return term_get_map_value(map, pos);
+    }
+}

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -20,6 +20,7 @@
 #ifndef _INTEROP_H_
 #define _INTEROP_H_
 
+#include "context.h"
 #include "term.h"
 
 char *interop_term_to_string(term t, int *ok);
@@ -27,6 +28,8 @@ char *interop_binary_to_string(term binary);
 char *interop_list_to_string(term list, int *ok);
 term interop_proplist_get_value(term list, term key);
 term interop_proplist_get_value_default(term list, term key, term default_value);
+term interop_map_get_value(Context *ctx, term map, term key);
+term interop_map_get_value_default(Context *ctx, term map, term key, term default_value);
 
 int interop_iolist_size(term t, int *ok);
 int interop_write_iolist(term t, char *p);

--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -21,6 +21,12 @@ test() ->
     ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [<<1, 2, 3>>]), "foo: <<1,2,3>>\n"),
     ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [{bar, tapas}]), "foo: {bar,tapas}\n"),
     ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [{bar, "tapas"}]), "foo: {bar,\"tapas\"}\n"),
+    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [#{}]), "foo: #{}\n"),
+    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [#{a => 1}]), "foo: #{a => 1}\n"),
+    ?ASSERT_MATCH(io_lib:format("foo: ~p", [#{a => 1, b => 2}]), "foo: #{a => 1,b => 2}"),
+    ?ASSERT_MATCH(io_lib:format("foo: ~p", [#{b => 2, a => 1}]), "foo: #{a => 1,b => 2}"),
+    ?ASSERT_MATCH(io_lib:format("foo: ~p", [#{{x, y} => z}]), "foo: #{{x,y} => z}"),
+    ?ASSERT_MATCH(io_lib:format("foo: ~p", [#{"foo" => "bar"}]), "foo: #{\"foo\" => \"bar\"}"),
 
     ?ASSERT_MATCH(io_lib:format("~p", [foo]), "foo"),
     ?ASSERT_MATCH(io_lib:format("\t~p", [bar]), "\tbar"),


### PR DESCRIPTION
Added support for maps to io_lib and added a useful C function (used by third-party ports) for searching for map entries.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
