### PR TITLE
Expand VM image partition (esp32)

### DIFF
--- a/doc/atomvm-esp32.md
+++ b/doc/atomvm-esp32.md
@@ -90,12 +90,12 @@ The AtomVM Flash memory is partitioned to include areas for the above binary art
 
 The flash layout is roughly as follows:
 
-    0x00       0x1000           0x8000  0x9000         0xF000     0x10000                0x110000               0x210000
+    0x00       0x1000           0x8000  0x9000         0xF000     0x10000                0x1D0000               0x210000
     +----------+-------- -------+-------+------- ------+----------+---------  -----------+----------  ----------+----------  ----------+
     |          |                |       |              |          |                      |                      |                      |
     +----------+-------- -------+-------+------- ------+----------+---------  -----------+----------  ----------+----------  ----------+
     |<-------->|<------- ------>|<----->|<------ ----->|<-------->|<--------  ---------->|<---------  --------->|<---------  --------->|
-        4kB           28kB         3kB         24kB         4kB             1mB                     1mB                    1mB
+        4kB           28kB         3kB         24kB         4kB            1.75mB                    256k                    1mB
       Secure      Bootloader    Partition      NVS       PHY_INIT          AtomVM                  lib.avm               main.avm
        Boot                       Table                                virtual machine
 
@@ -108,8 +108,8 @@ The following table summarizes the partitions created on the ESP32 when deployin
 | Partition Table | 0x8000 | 3kB | The AtomVM-defined partition table. |
 | NVS | 0x9000 | 24kB | Space for non-volatile storage. |
 | PHY_INIT | 0xF000 | 4kB | Initialization data for physical layer radio signal data. |
-| AtomVM virtual machine | 0x10000 | 1mB | The AtomVM virtual machine (compiled from C code). |
-| lib.avm | 0x110000 | 1mB | The AtomVM BEAM library, compiled from Erlang and Elixir files in the AtomVM source tree. |
+| AtomVM virtual machine | 0x10000 | 1.75mB | The AtomVM virtual machine (compiled from C code). |
+| lib.avm | 0x1D0000 | 256k | The AtomVM BEAM library, compiled from Erlang and Elixir files in the AtomVM source tree. |
 | main.avm | 0x210000 | 1mB | The user application.  This is where users flash their compiled Erlang/Elixir code |
 
 ### The `lib.avm` and `main.avm` partitions

--- a/src/platforms/esp32/mkimage.config
+++ b/src/platforms/esp32/mkimage.config
@@ -11,13 +11,13 @@
             path => "${ROOT_DIR}/src/platforms/esp32/build/partitions.bin"
         },
         #{
-            name => "AtomvVM Virtual Machine",
+            name => "AtomVM Virtual Machine",
             offset => "0x10000",
             path => "${ROOT_DIR}/src/platforms/esp32/build/atomvvm-esp32.bin"
         },
         #{
-            name => "AtomvVM Core BEAM Library",
-            offset =>  "0x110000",
+            name => "AtomVM Core BEAM Library",
+            offset =>  "0x1D0000",
             path => "${BUILD_DIR}/libs/atomvmlib.avm"
         }
     ]

--- a/src/platforms/esp32/partitions.csv
+++ b/src/platforms/esp32/partitions.csv
@@ -1,7 +1,7 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
-nvs,      data, nvs,       0x9000,   0x6000,
-phy_init, data, phy,       0xf000,   0x1000,
-factory,  app,  factory,  0x10000,       1M,
-lib.avm,  data, phy,     0x110000,       1M,
-main.avm, data, phy,     0x210000,       1M,
+nvs,      data, nvs,       0x9000,     0x6000,
+phy_init, data, phy,       0xf000,     0x1000,
+factory,  app,  factory,  0x10000,   0x1C0000,
+lib.avm,  data, phy,     0x1D0000,    0x40000,
+main.avm, data, phy,     0x210000,   0x100000

--- a/tools/release/esp32/flashimage.sh
+++ b/tools/release/esp32/flashimage.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+##
+## Copyright (c) dushin.net
+## All rights reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+THIS_DIR="$(cd $(dirname $0) && pwd)"
+ROOT_DIR="$(cd "${THIS_DIR}/../../.." && pwd)"
+
+FLASH_OFFSET=0x1000 ${ROOT_DIR}/tools/dev/flash.sh "${ROOT_DIR}/src/platforms/esp32/build/atomvm-$(git rev-parse --short HEAD).img"


### PR DESCRIPTION
Increased the size of the AtomVM image partition (factory) to 1.75mb, and decreased the size of the AtomVM library partition (data) to 256k.  No user-interface changes.

This change makes room for VM images that are bigger than 1MB.  The current AtomVM library is just under 50k, so a 256k partition should be ample room for core libraries to grow fivefold.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
