### PR TITLE
Fixed parsing of 32-bit literals

### DIFF
--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -325,7 +325,8 @@ static term parse_external_terms(const uint8_t *external_term_buf, int *eterm_si
             int32_t value = READ_32_UNALIGNED(external_term_buf + 1);
 
             *eterm_size = 5;
-            return term_from_int32(value);
+
+            return term_make_maybe_boxed_int64(ctx, value);
         }
 
         case ATOM_EXT: {
@@ -484,8 +485,9 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, int *eterm_siz
         }
 
         case INTEGER_EXT: {
+            int32_t value = READ_32_UNALIGNED(external_term_buf + 1);
             *eterm_size = 5;
-            return 0;
+            return term_boxed_integer_size(value);
         }
 
         case ATOM_EXT: {

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -792,6 +792,15 @@ static inline term term_make_maybe_boxed_int64(Context *ctx, avm_int64_t value)
     }
 }
 
+static inline size_t term_boxed_integer_size(avm_int64_t value)
+{
+     if ((value < MIN_NOT_BOXED_INT) || (value > MAX_NOT_BOXED_INT)) {
+         return BOXED_INT_SIZE;
+     } else {
+         return 0;
+     }
+}
+
 static inline term term_from_catch_label(unsigned int module_index, unsigned int label)
 {
     return (term) ((module_index << 24) | (label << 6) | TERM_CATCH_TAG);

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -244,6 +244,7 @@ compile_erlang(bigfact3)
 compile_erlang(boxedabs)
 compile_erlang(boxedneg)
 compile_erlang(boxedmul)
+compile_erlang(boxedlit)
 compile_erlang(pow32)
 compile_erlang(pow64)
 compile_erlang(pow32_is_integer)
@@ -635,6 +636,7 @@ add_custom_target(erlang_test_modules DEPENDS
     boxedabs.beam
     boxedneg.beam
     boxedmul.beam
+    boxedlit.beam
     pow32.beam
     pow64.beam
 

--- a/tests/erlang_tests/boxedlit.erl
+++ b/tests/erlang_tests/boxedlit.erl
@@ -1,0 +1,16 @@
+-module(boxedlit).
+
+-export([start/0, pow/2, get_k/1]).
+
+start() ->
+    %% test to ensure 2^30 can be parsed accurately out of a literal term
+    K = get_k(#{k => 1073741824}),
+    K = pow(2, 30).
+
+pow(N, 0) when is_number(N) ->
+    1;
+pow(N, M) ->
+    N * pow(N, M - 1).
+
+get_k(#{k := K}) ->
+    K.

--- a/tests/test.c
+++ b/tests/test.c
@@ -280,6 +280,7 @@ struct Test tests[] =
     {"boxedabs.beam", 15},
     {"boxedneg.beam", 15},
     {"boxedmul.beam", 15},
+    {"boxedlit.beam", 1073741824},
     {"pow32.beam", 528},
     {"pow64.beam", 1794},
     {"pow32_is_integer.beam", 528},


### PR DESCRIPTION
... so that they can be parsed into boxed terms, if they are sufficiently large.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
