### PR TITLE
Fixed timer to use selective receive

### DIFF
--- a/libs/estdlib/src/timer.erl
+++ b/libs/estdlib/src/timer.erl
@@ -2,8 +2,19 @@
 
 -export([sleep/1]).
 
--spec sleep(non_neg_integer()) -> ok.
+-define(MAX_INT, 4294967295).
+
+-spec sleep(non_neg_integer() | infinity) -> ok.
+sleep(infinity) ->
+    receive
+        '$atomvm_timer_interrupt' ->
+            {error, unexpected_interrupt}
+    after ?MAX_INT ->
+        sleep(infinity)
+    end;
 sleep(MSecs) ->
     receive
-        after MSecs -> ok
+        '$atomvm_timer_interrupt' ->
+            {error, unexpected_interrupt}
+    after MSecs -> ok
     end.

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1766,6 +1766,8 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         needs_to_wait = 1;
                     } else if ((ctx->flags & WaitingTimeout) == 0) {
                         needs_to_wait = 1;
+                    } else if (!list_is_empty(&ctx->save_queue)) {
+                        needs_to_wait = 1;
                     }
 
                     if (needs_to_wait) {

--- a/tests/libs/estdlib/test_timer.erl
+++ b/tests/libs/estdlib/test_timer.erl
@@ -4,15 +4,58 @@
 
 test() ->
     ok = test_timer(),
+    ok = test_timer_interrupt(),
+    ok = test_timer_loop(),
     ok.
 
 -include("etest.hrl").
 
 test_timer() ->
-    %% hack. until we can convert an erlang timestamp to a big integer
-    %% this will fail if run when UNIX epoch divides 1m secs
-    {_M0, S0, _Mi0} = erlang:timestamp(),
-    ok = timer:sleep(1001),
-    {_M1, S1, _Mi1} = erlang:timestamp(),
-    ok = etest:assert_true(S1 > S0),
+    T0 = erlang:timestamp(),
+    ok = timer:sleep(101),
+    T1 = erlang:timestamp(),
+    ok = etest:assert_true((to_ms(T1) - to_ms(T0)) >= 101),
     ok.
+
+test_timer_interrupt() ->
+    Self = self(),
+    Pid = spawn(fun() -> do_test_interrupt(Self) end),
+    receive ready -> ok end,
+
+    %% this message should not interrupt the timer
+    Pid ! try_to_interrupt,
+
+    Pid ! '$atomvm_timer_interrupt',
+    ?ASSERT_MATCH(pop_mailbox(), ok),
+    ok.
+
+pop_mailbox() ->
+    receive
+        X -> X
+    end.
+
+do_test_interrupt(Pid) ->
+    Pid ! ready,
+    case timer:sleep(infinity) of
+        {error, unexpected_interrupt} ->
+            Pid ! ok;
+        _ ->
+            Pid ! error
+    end.
+
+test_timer_loop() ->
+    Self = self(),
+    spawn(fun() -> timer:sleep(220), Self ! ping end),
+    ok = timer_loop(5).
+
+timer_loop(0) ->
+    ok;
+timer_loop(I) ->
+    T0 = erlang:timestamp(),
+    ok = timer:sleep(101),
+    T1 = erlang:timestamp(),
+    ok = etest:assert_true((to_ms(T1) - to_ms(T0)) >= 101),
+    timer_loop(I - 1).
+
+to_ms({MegaSecs, Secs, MicroSecs}) ->
+    ((MegaSecs * 1000000 + Secs) * 1000 + MicroSecs div 1000).


### PR DESCRIPTION
... so that arbitrary messages don't interrupt the timer.

These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
