### PR TITLE
Added support for sub-binaries.

### DIFF
--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -446,3 +446,29 @@ term term_alloc_refc_binary(Context *ctx, size_t size, bool is_const)
     }
     return ret;
 }
+
+static term find_binary(term binary_or_state)
+{
+    term t = binary_or_state;
+    while (term_is_match_state(t) || term_is_sub_binary(t)) {
+        if (term_is_match_state(t)) {
+            t = term_get_match_state_binary(t);
+        } else { // term_is_sub_binary
+            t = term_get_sub_binary_ref(t);
+        }
+    }
+    return t;
+}
+
+term term_alloc_sub_binary(term binary_or_state, size_t offset, size_t len, Context *ctx)
+{
+    term *boxed = memory_heap_alloc(ctx, TERM_BOXED_SUB_BINARY_SIZE);
+    term binary = find_binary(binary_or_state);
+
+    boxed[0] = ((TERM_BOXED_SUB_BINARY_SIZE - 1) << 6) | TERM_BOXED_SUB_BINARY;
+    boxed[1] = (term) len;
+    boxed[2] = (term) offset;
+    boxed[3] = binary;
+
+    return ((term) boxed) | TERM_BOXED_VALUE_TAG;
+}

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -398,6 +398,7 @@ compile_erlang(unlink_error)
 compile_erlang(trap_exit_flag)
 
 compile_erlang(test_refc_binaries)
+compile_erlang(test_sub_binaries)
 
 add_custom_target(erlang_test_modules DEPENDS
     add.beam
@@ -777,6 +778,7 @@ add_custom_target(erlang_test_modules DEPENDS
     sexp_lexer.beam
 
     test_refc_binaries.beam
+    test_sub_binaries.beam
     test_function_exported.beam
     test_list_to_tuple.beam
 

--- a/tests/erlang_tests/test_sub_binaries.erl
+++ b/tests/erlang_tests/test_sub_binaries.erl
@@ -1,0 +1,269 @@
+-module(test_sub_binaries).
+
+-export([start/0, loop/1]).
+
+-define(LITERAL_BIN,
+    <<"0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">>
+).
+
+-record(state, {
+    bin
+}).
+
+-define(VERIFY(X), case X of true -> ok; _ -> throw({assertion_failure, ??X, ?MODULE, ?FUNCTION_NAME, ?LINE}) end).
+
+start() ->
+    ok = run_test(fun() -> test_heap_sub_binary() end),
+    ok = run_test(fun() -> test_const_sub_binary() end),
+    ok = run_test(fun() -> test_non_const_sub_binary() end),
+    ok = run_test(fun() -> test_send_sub_binary() end),
+    ok = run_test(fun() -> test_spawn_sub_binary() end),
+    ok = run_test(fun() -> test_spawn_fun_sub_binary() end),
+    ok = run_test(fun() -> test_split_sub_binary() end),
+    ok = run_test(fun() -> test_bit_syntax_tail() end),
+    ok = run_test(fun() -> test_bit_syntax_get_binary() end),
+    ok = run_test(fun() -> test_count_binary() end),
+    0.
+
+test_heap_sub_binary() ->
+    HeapSize0 = get_heap_size(),
+    Bin = create_binary(63),
+    HeapSize1 = get_heap_size(),
+    ?VERIFY(HeapSize0 < HeapSize1),
+
+    SubBin = binary:part(Bin, 1, 7),
+    HeapSize2 = get_heap_size(),
+    ?VERIFY(HeapSize1 < HeapSize2),
+    ?VERIFY((HeapSize2 - HeapSize1) >= 8),
+
+    id(Bin), id(SubBin), ok.
+
+test_const_sub_binary() ->
+    HeapSize0 = get_heap_size(),
+    BinarySize = erlang:byte_size(?LITERAL_BIN),
+    ?VERIFY(HeapSize0 < BinarySize),
+
+    SmallSubBin = binary:part(?LITERAL_BIN, 1, 15),
+    HeapSize1 = get_heap_size(),
+    ?VERIFY(HeapSize0 < HeapSize1),
+    ?VERIFY(erlang:byte_size(SmallSubBin) < HeapSize1),
+
+    LargeSubBin = binary:part(?LITERAL_BIN, 1, BinarySize - 1),
+    HeapSize2 = get_heap_size(),
+    ?VERIFY(HeapSize2 < HeapSize1 + erlang:byte_size(LargeSubBin)),
+
+    id(SmallSubBin), id(LargeSubBin), ok.
+
+test_non_const_sub_binary() ->
+    HeapSize0 = get_heap_size(),
+    String = create_string(1024),
+    HeapSize1 = get_heap_size(),
+    ?VERIFY(HeapSize0 < HeapSize1),
+    Bin = create_binary(String),
+    BinarySize = erlang:byte_size(Bin),
+    HeapSize2 = get_heap_size(),
+    ?VERIFY(HeapSize1 < HeapSize2),
+    ?VERIFY(HeapSize2 < (HeapSize1 + erlang:byte_size(Bin))),
+
+    LargeSubBin = binary:part(Bin, 1, BinarySize - 1),
+    HeapSize3 = get_heap_size(),
+    ?VERIFY(HeapSize3 < HeapSize2 + erlang:byte_size(LargeSubBin)),
+
+    id(String), id(Bin), id(LargeSubBin),
+    ok.
+
+test_send_sub_binary() ->
+    Bin = create_binary(1024),
+    BinarySize = erlang:byte_size(Bin),
+    Pid = erlang:spawn(fun() -> loop(#state{}) end),
+    PidHeapSize0 = get_heap_size(Pid),
+    %%
+    %% Send the process a refc binary, and check heap size
+    %%
+    LargeSubBin = binary:part(Bin, 1, BinarySize - 1),
+    ok = send(Pid, {ref, LargeSubBin}),
+    PidHeapSize1 = get_heap_size(Pid),
+    ?VERIFY(PidHeapSize0 < PidHeapSize1),
+    ?VERIFY(PidHeapSize1 < 1024),
+    %%
+    %% Make sure we can get what we sent
+    %%
+    LargeSubBin = send(Pid, get),
+    %%
+    %% Free the refc binary; heap should decrease
+    %%
+    ok = send(Pid, free),
+    PidHeapSize2 = get_heap_size(Pid),
+    ?VERIFY(PidHeapSize2 < PidHeapSize1),
+    ok = send(Pid, halt),
+    ok.
+
+test_spawn_sub_binary() ->
+    Bin = create_binary(1024),
+    BinarySize = erlang:byte_size(Bin),
+    %%
+    %% Spawn a function, passing a refc binary through the args
+    %%
+    LargeSubBin = binary:part(Bin, 1, BinarySize - 1),
+    Pid = erlang:spawn(?MODULE, loop, [#state{bin=LargeSubBin}]),
+    PidHeapSize0 = get_heap_size(Pid),
+    %%
+    %% Make sure we can get what we spawned
+    %%
+    LargeSubBin = send(Pid, get),
+    %%
+    %% Free the refc binary; heap should decrease
+    %%
+    ok = send(Pid, free),
+    PidHeapSize2 = get_heap_size(Pid),
+    ?VERIFY(PidHeapSize2 < PidHeapSize0),
+    ok = send(Pid, halt),
+    ok.
+
+test_spawn_fun_sub_binary() ->
+    Bin = create_binary(1024),
+    BinarySize = erlang:byte_size(Bin),
+    %%
+    %% Spawn a function, passing a refc binary through the args
+    %%
+    LargeSubBin = binary:part(Bin, 1, BinarySize - 1),
+    Pid = erlang:spawn(fun() -> loop(#state{bin=LargeSubBin}) end),
+    PidHeapSize0 = get_heap_size(Pid),
+    %%
+    %% Make sure we can get what we spawned
+    %%
+    LargeSubBin = send(Pid, get),
+    %%
+    %% Free the refc binary; heap should decrease
+    %%
+    ok = send(Pid, free),
+    PidHeapSize2 = get_heap_size(Pid),
+    ?VERIFY(PidHeapSize2 < PidHeapSize0),
+    ok = send(Pid, halt),
+    ok.
+
+test_split_sub_binary() ->
+    HeapSize0 = get_heap_size(),
+    Bin = create_binary(1024),
+    [SmallSubBin, LargeSubBin] = binary:split(Bin, <<4,5,6>>),
+    HeapSize1 = get_heap_size(),
+
+    ?VERIFY(erlang:byte_size(SmallSubBin) < (HeapSize1 - HeapSize0)),
+    ?VERIFY((HeapSize1 - HeapSize0) < erlang:byte_size(LargeSubBin)),
+
+    id(SmallSubBin), id(LargeSubBin), ok.
+
+test_bit_syntax_tail() ->
+    _HeapSize0 = get_heap_size(),
+    Bin = create_binary(1024),
+    BinarySize = erlang:byte_size(Bin),
+    HeapSize1 = get_heap_size(),
+    LargeSubBin = binary:part(Bin, 1, BinarySize - 1),
+
+    LargeSubBin = match_rest(Bin),
+    HeapSize2 = get_heap_size(),
+
+    ?VERIFY((HeapSize2 - HeapSize1) < erlang:byte_size(LargeSubBin)),
+
+    id(Bin), id(LargeSubBin), ok.
+
+match_rest(<<_:8, Rest/binary>>) ->
+    Rest.
+
+test_bit_syntax_get_binary() ->
+    _HeapSize0 = get_heap_size(),
+    Bin = create_binary(1024),
+    HeapSize1 = get_heap_size(),
+    LargeSubBin = binary:part(Bin, 0, 512),
+
+    LargeSubBin = match_binary(Bin),
+    HeapSize2 = get_heap_size(),
+
+    ?VERIFY((HeapSize2 - HeapSize1) < erlang:byte_size(LargeSubBin)),
+
+    id(Bin), id(LargeSubBin), ok.
+
+match_binary(<<Initial:512/binary, _Rest/binary>>) ->
+    Initial.
+
+
+test_count_binary() ->
+    Bin = create_binary(1024),
+    ?VERIFY(1024 =:= count_binary(Bin, 0)),
+    ok.
+
+count_binary(<<"">>, Accum) ->
+    Accum;
+count_binary(<<_Byte:8, Rest/binary>>, Accum) ->
+    count_binary(Rest, Accum + 1).
+
+
+%%
+%% helper functions
+%%
+
+get_heap_size() ->
+    get_heap_size(self()).
+
+get_heap_size(Pid) ->
+    erlang:garbage_collect(),
+    {heap_size, Size} = erlang:process_info(Pid, heap_size),
+    Size * erlang:system_info(wordsize).
+
+send(Pid, Msg) ->
+    Ref = erlang:make_ref(),
+    Pid ! {self(), Ref, Msg},
+    receive
+        {Ref, Reply} -> Reply
+    end.
+
+loop(State) ->
+    erlang:garbage_collect(),
+    receive
+        {Pid, Ref, get} ->
+            Pid ! {Ref, State#state.bin},
+            loop(State);
+        {Pid, Ref, free} ->
+            Pid ! {Ref, ok},
+            loop(State#state{bin=undefined});
+        {Pid, Ref, {ref, Bin}} ->
+            Pid ! {Ref, ok},
+            loop(State#state{bin=Bin});
+        {Pid, Ref, halt} ->
+            Pid ! {Ref, ok}
+    end.
+
+create_binary(N) when is_integer(N) ->
+    erlang:list_to_binary(create_string(N, []));
+create_binary(S) when is_list(S) ->
+    list_to_binary(S).
+
+create_string(N) ->
+    create_string(N, []).
+
+create_string(0, Accum) ->
+    Accum;
+create_string(N, Accum) ->
+    create_string(N - 1, [N rem 256 | Accum]).
+
+
+run_test(Fun) ->
+    Self = self(),
+    _Pid = spawn(fun() -> execute(Self, Fun) end),
+    receive
+        ok ->
+            ok;
+        Error ->
+            Error
+    end.
+
+execute(Pid, Fun) ->
+    Result = try
+        Fun(), ok
+    catch
+        _:Error ->
+            {error, Error}
+    end,
+    Pid ! Result.
+
+id(X) -> X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -331,6 +331,8 @@ struct Test tests[] =
     {"test_gc.beam", 0 },
     {"test_raise.beam", 7},
     {"test_map.beam", 0},
+    {"test_refc_binaries.beam", 0},
+    {"test_sub_binaries.beam", 0},
 
     {"ceilint.beam", 1},
     {"ceilbadarg.beam", -1},


### PR DESCRIPTION
This change set adds support for sub-binaries, which can significantly reduce the amount of heap space used when processing large binaries.

Sub-binaries are sub-sets of reference counted binaries that are sufficiently large (> 8 bytes).  Sub-binaries are created via the `binary:part/3` function, `binary:split/2` function, and the `/binary` bit syntax modifier.


These changes are made under the terms of the LGPL v2.1 (or any later version)
and Apache 2.0 licenses.
