### PR TITLE
CI: reduce the scope of FreeBSD CI tests

### DIFF
--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -61,7 +61,7 @@ jobs:
         copyback: false
 
         prepare: |
-          pkg install -y curl cmake gperf erlang elixir rebar3 mbedtls
+          pkg install -y curl cmake gperf erlang elixir rebar3 mbedtls3
 
         run: |
           set -e
@@ -79,6 +79,8 @@ jobs:
           cmake --version
           echo "**hw.ncpu:**"
           sysctl -n hw.ncpu
+
+          sed -i '' 's/test_http_server/%test_http_server/g' tests/libs/eavmlib/tests.erl
 
           echo "%%"
           echo "%% Running CMake ..."


### PR DESCRIPTION
Right now complete FreeBSD workflow fail, so exclude `test_http_server` so we can run the rest of the tests on FreeBSD.
Let's readd http_test as soon as #1500 is fixed.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
