### PR TITLE
Make `erlang:is_number/1` return true for floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ memory error
 - Fix `is_function/2` guard
 - Fixed segfault when calling `lists:reverse/1` (#1600)
 - Fixed nif_atomvm_posix_read GC bug
+- Fixed `erlang:is_number/1` function, now returns true also for floats
 
 ### Changed
 

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -213,8 +213,7 @@ term bif_erlang_is_number_1(Context *ctx, uint32_t fail_label, term arg1)
     UNUSED(ctx);
     UNUSED(fail_label);
 
-    //TODO: change to term_is_number
-    return term_is_any_integer(arg1) ? TRUE_ATOM : FALSE_ATOM;
+    return term_is_number(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
 term bif_erlang_is_pid_1(Context *ctx, uint32_t fail_label, term arg1)

--- a/tests/erlang_tests/float_is_number.erl
+++ b/tests/erlang_tests/float_is_number.erl
@@ -23,10 +23,13 @@
 -export([start/0, pow/2, test/1, id/1]).
 
 start() ->
-    Res = (pow(-2, 63) + id(10.0)) * id(-1.0),
+    Res = ?MODULE:id((pow(-2, 63) + id(10.0)) * id(-1.0)),
+    true = ?MODULE:id(is_number(Res)),
     test(Res).
 
 id(I) when is_float(I) ->
+    I;
+id(I) when is_atom(I) ->
     I.
 
 pow(_N, 0) ->


### PR DESCRIPTION
Fix an old TODO: "change to term_is_number", so `is_number(5.1)` returns `true` instead of `false`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
