### PR TITLE
ESP32: Default SPI peripheral to non-deprecated value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `externalterm_to_term_copy` added in [0.6.5] and introduced flags to `externalterm_to_term` to perform copy.
 - Release images for ESP32 chips are built with ESP-IDF v5.4
+- ESP32: SPI peripheral defaults to `"spi2"` instead of deprecated `hspi`
 
 ### Fixed
 

--- a/libs/eavmlib/src/spi.erl
+++ b/libs/eavmlib/src/spi.erl
@@ -42,6 +42,7 @@
 
 -export([open/1, close/1, read_at/4, write_at/5, write/3, write_read/3]).
 
+%% TODO remove deprecated hspi and vspi
 -type peripheral() :: hspi | vspi | string() | binary().
 -type bus_config() :: [
     {poci, non_neg_integer()}
@@ -102,7 +103,7 @@
 %%   <tr> <td>`miso'</td> <td>`non_neg_integer()'</td> <td>-</td> <td>MISO pin number</td></tr>
 %%   <tr> <td>`mosi'</td> <td>`non_neg_integer()'</td> <td>-</td> <td>MOSI pin number</td></tr>
 %%   <tr> <td>`sclk'</td> <td>`non_neg_integer()'</td> <td>-</td> <td>SCLK pin number</td></tr>
-%%   <tr> <td>`peripheral'</td> <td>`hspi | vspi'</td> <td>`hspi'</td> <td>SPI Peripheral (ESP32 only)</td></tr>
+%%   <tr> <td>`peripheral'</td> <td>`"spi2" | "spi3"'</td> <td>`"spi2"'</td> <td>SPI Peripheral (ESP32 only)</td></tr>
 %% </table>
 %%
 %% Each device configuration is a properties list containing the following entries:
@@ -309,7 +310,7 @@ validate_bus_config(MaybeOldBusConfig) when
 ->
     BusConfig = migrate_deprecated(MaybeOldBusConfig),
     ValidatedConfig0 = #{
-        peripheral => validate_peripheral(get_value(peripheral, BusConfig, hspi)),
+        peripheral => validate_peripheral(get_value(peripheral, BusConfig, <<"spi2">>)),
         sclk => validate_integer_entry(sclk, BusConfig)
     },
     ValidatedConfig1 = maybe_validate_optional_integer(miso, ValidatedConfig0, BusConfig),


### PR DESCRIPTION
spi.erl currently defaults to the deprecated hspi value. Leading to difficult to understand deprecation warning, when simply using defaults:
https://github.com/atomvm/AtomVM/blob/8806d07bb8f6323e45bcd9d071589048db10958b/libs/eavmlib/src/spi.erl#L394

spi2 is available all boards:
https://github.com/atomvm/AtomVM/blob/8806d07bb8f6323e45bcd9d071589048db10958b/src/platforms/esp32/components/avm_builtins/spi_driver.c#L58

Experienced when using https://github.com/karlsson/avm_ls, and also experienced by @karlsson a year ago here: https://github.com/atomvm/AtomVM/pull/1136

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
