### PR TITLE
NIFs: fix "warning: initializer-string for character array is too long"

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4163,7 +4163,13 @@ static term nif_console_print(Context *ctx, int argc, term argv[])
     return OK_ATOM;
 }
 
-static char b64_table[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static char b64_table[64] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+                             'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+                             'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
+                             'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+                             'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
+                             'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',
+                             '8', '9', '+', '/'};
 
 // per https://tools.ietf.org/rfc/rfc4648.txt
 


### PR DESCRIPTION
Fix warning.
Question to myself: does the compiler align differently this 64 bytes array instead of the previous 65 bytes string?

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
