### PR TITLE
Start using atomvm.org

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 # This is a workflow for atomvm/AtomVM to Publish API documentation and other content from the `doc` directory to
-# atomvm.net hosted on GitHub Pages
+# doc.atomvm.org hosted on GitHub Pages
 
 name: Build Docs
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 # This is a workflow for atomvm/AtomVM to Publish API documentation and other content from the `doc` directory to
-# atomvm.net hosted on GitHub Pages
+# doc.atomvm.org hosted on GitHub Pages
 
 name: Publish Docs
 

--- a/README.Md
+++ b/README.Md
@@ -28,10 +28,10 @@ Getting Started
 ===============
 There is much more information, including a more complete
 ["Getting Started Guide"](https://doc.atomvm.org/release-0.6/getting-started-guide.html),
-[examples](https://www.atomvm.net/sample-code),
+[examples](https://atomvm.org/sample-code),
 detailed [build instructions](https://doc.atomvm.org/release-0.6/build-instructions.html),
-and [contact information](https://www.atomvm.net/contact) available on the
-[AtomVM](https://atomvm.net) project website.
+and [contact information](https://atomvm.org/contact) available on the
+[AtomVM](https://atomvm.org) project website.
 
 >Don't forget to check out the [examples repository](https://github.com/atomvm/atomvm_examples) to
 >help get you started on your next IoT project.

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -1,5 +1,5 @@
 <!--
- Copyright 2023 AtomVM <atomvm.net>
+ Copyright 2023 AtomVM <atomvm.org>
 
  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 -->

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -2329,7 +2329,7 @@ Currently, the `net:getaddrinfo/1,2` functions only supports reporting of IPv4 a
 For example:
 
 ```erlang
-{ok, AddrInfos} = net:getaddrinfo("www.atomvm.net"),
+{ok, AddrInfos} = net:getaddrinfo("atomvm.org"),
 
 lists:foreach(
     fun(AddrInfo) ->
@@ -2368,7 +2368,7 @@ with OTP 22 ff., AtomVM supports both the `address` and `addr` keys in this map 
 If you want to narrow the information you get back to a specific service type, you can specify a service name or port number (as a string value) as the second parameter:
 
 ```erlang
-{ok, AddrInfos} = net:getaddrinfo("www.atomvm.net", "https"),
+{ok, AddrInfos} = net:getaddrinfo("atomvm.org", "https"),
 ...
 ```
 

--- a/examples/erlang/http_client.erl
+++ b/examples/erlang/http_client.erl
@@ -25,7 +25,7 @@
 
 start() ->
     ssl:start(),
-    ConnectResult = ahttp_client:connect(https, "atomvm.net", 443, [
+    ConnectResult = ahttp_client:connect(https, "test.atomvm.org", 443, [
         {active, ?ACTIVE}, {verify, verify_none}, {parse_headers, [<<"Location">>]}
     ]),
     case ConnectResult of

--- a/src/platforms/esp32/test/main/test_erl_sources/test_ssl.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_ssl.erl
@@ -50,7 +50,7 @@ start() ->
     ok = send_loop(
         SSLContext,
         Socket,
-        <<"GET / HTTP/1.1\r\nHost: atomvm.net\r\nUser-Agent: AtomVM within qemu\r\n\r\n">>
+        <<"GET / HTTP/1.1\r\nHost: test.atomvm.org\r\nUser-Agent: AtomVM within qemu\r\n\r\n">>
     ),
     % Read
     {ok, <<"HTTP/1.1">>} = recv_loop(SSLContext, Socket, 8, []),

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -27,7 +27,7 @@ test() ->
 
 test_passive() ->
     ok = ssl:start(),
-    ConnectResult = ahttp_client:connect(https, "www.atomvm.net", 443, [
+    ConnectResult = ahttp_client:connect(https, "test.atomvm.org", 443, [
         {active, false}, {verify, verify_none}, {parse_headers, [<<"Location">>]}
     ]),
     case ConnectResult of
@@ -47,7 +47,7 @@ test_passive() ->
     ok.
 
 test_active() ->
-    ConnectResult = ahttp_client:connect(http, "www.atomvm.net", 80, [{active, true}]),
+    ConnectResult = ahttp_client:connect(http, "test.atomvm.org", 80, [{active, true}]),
     case ConnectResult of
         {ok, Conn} ->
             case ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined) of

--- a/tests/libs/estdlib/test_net.erl
+++ b/tests/libs/estdlib/test_net.erl
@@ -28,7 +28,7 @@ test() ->
     ok.
 
 test_getaddrinfo() ->
-    ok = test_getaddrinfo("www.atomvm.net"),
+    ok = test_getaddrinfo("test.atomvm.org"),
     ok.
 
 test_getaddrinfo(Host) ->
@@ -69,8 +69,8 @@ test_getaddrinfo(Host) ->
     ok.
 
 test_getaddrinfo2() ->
-    ok = test_getaddrinfo2("www.atomvm.net", "https"),
-    ok = test_getaddrinfo2("www.atomvm.net", "443"),
+    ok = test_getaddrinfo2("test.atomvm.org", "https"),
+    ok = test_getaddrinfo2("test.atomvm.org", "443"),
     ok = test_getaddrinfo2(undefined, "443"),
     ok.
 

--- a/tests/libs/estdlib/test_ssl.erl
+++ b/tests/libs/estdlib/test_ssl.erl
@@ -61,32 +61,32 @@ test_start_twice() ->
     ok = ssl:start().
 
 test_connect_close() ->
-    {ok, SSLSocket} = ssl:connect("www.atomvm.net", 443, [{verify, verify_none}, {active, false}]),
+    {ok, SSLSocket} = ssl:connect("test.atomvm.org", 443, [{verify, verify_none}, {active, false}]),
     ok = ssl:close(SSLSocket).
 
 test_connect_error() ->
-    {error, _Error} = ssl:connect("www.atomvm.net", 80, [{verify, verify_none}, {active, false}]),
+    {error, _Error} = ssl:connect("test.atomvm.org", 80, [{verify, verify_none}, {active, false}]),
     ok.
 
 test_send_recv() ->
-    {ok, SSLSocket} = ssl:connect("www.atomvm.net", 443, [
+    {ok, SSLSocket} = ssl:connect("test.atomvm.org", 443, [
         {verify, verify_none}, {active, false}, {binary, true}
     ]),
     UserAgent = erlang:system_info(machine),
     ok = ssl:send(SSLSocket, [
-        <<"GET / HTTP/1.1\r\nHost: www.atomvm.net\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
+        <<"GET / HTTP/1.1\r\nHost: test.atomvm.org\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
     ]),
     {ok, <<"HTTP/1.1 200 OK">>} = ssl:recv(SSLSocket, 15),
     ok = ssl:close(SSLSocket),
     ok.
 
 test_send_recv_zero() ->
-    {ok, SSLSocket} = ssl:connect("www.atomvm.net", 443, [
+    {ok, SSLSocket} = ssl:connect("test.atomvm.org", 443, [
         {verify, verify_none}, {active, false}, {binary, true}
     ]),
     UserAgent = erlang:system_info(machine),
     ok = ssl:send(SSLSocket, [
-        <<"GET / HTTP/1.1\r\nHost: www.atomvm.net\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
+        <<"GET / HTTP/1.1\r\nHost: test.atomvm.org\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
     ]),
     {ok, <<"HTTP/1.1 200 OK", _/binary>>} = ssl:recv(SSLSocket, 0),
     ok = ssl:close(SSLSocket),


### PR DESCRIPTION
Find and replace all occurrences of atomvm.net with [atomvm.org](https://atomvm.org).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
