### PR TITLE
BIFs: bnot: add support to boxed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where binary matching could fail due to a missing preservation of the matched binary.
 - Fixed a bug where `lists:seq/2` wouldn't return the empty list in valid cases.
+- bnot operator wasn't supporting boxed integers (integers bigger than 28-bit on 32-bit CPUs, and
+bigger than 60-bit on 64-bit CPUs).
 
 ### Changed
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -337,6 +337,7 @@ compile_erlang(literal_test0)
 compile_erlang(literal_test1)
 compile_erlang(literal_test2)
 compile_erlang(test_extended_literal_large)
+compile_erlang(bnot64)
 
 compile_erlang(test_list_eq)
 compile_erlang(test_tuple_eq)
@@ -838,6 +839,8 @@ add_custom_target(erlang_test_modules DEPENDS
     literal_test1.beam
     literal_test2.beam
     test_extended_literal_large.beam
+
+    bnot64.beam
 
     test_list_eq.beam
     test_tuple_eq.beam

--- a/tests/erlang_tests/bnot64.erl
+++ b/tests/erlang_tests/bnot64.erl
@@ -1,0 +1,39 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(bnot64).
+-export([start/0, mybnot/1, id/1]).
+
+start() ->
+    -16#7AFECAFF = ?MODULE:mybnot(?MODULE:id(16#7AFECAFE)),
+    16#7AFECAFD = ?MODULE:mybnot(?MODULE:id(-16#7AFECAFE)),
+    -16#CAFECAFF = ?MODULE:mybnot(?MODULE:id(16#CAFECAFE)),
+    16#CAFECAFD = ?MODULE:mybnot(?MODULE:id(-16#CAFECAFE)),
+    -16#7AFECAFE12345679 = ?MODULE:mybnot(?MODULE:id(16#7AFECAFE12345678)),
+    16#7AFECAFE12345677 = ?MODULE:mybnot(?MODULE:id(-16#7AFECAFE12345678)),
+    0.
+
+mybnot(I) when is_integer(I) ->
+    bnot ?MODULE:id(I);
+mybnot(X) ->
+    {error, X}.
+
+id(X) ->
+    X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -371,6 +371,8 @@ struct Test tests[] = {
     TEST_CASE(literal_test2),
     TEST_CASE(test_extended_literal_large),
 
+    TEST_CASE(bnot64),
+
     TEST_CASE_EXPECTED(test_list_eq, 1),
     TEST_CASE_EXPECTED(test_tuple_eq, 1),
     TEST_CASE_EXPECTED(test_tuple_list_eq, 1),


### PR DESCRIPTION
bnot was missing support to boxed integers, so it wasn't supporting integers > 28 bits on 32 bit systems, and > 60 bits on 64 bit systems.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
