### PR TITLE
Fix run-tests-with-beam when OTP <= 23

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -43,14 +43,17 @@ jobs:
         - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
           container: erlang:21
+          archive: "true"
 
         - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
           container: erlang:22
+          archive: "true"
 
         - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
           container: erlang:23
+          archive: "true"
 
         - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
@@ -88,6 +91,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+
+    - name: "Switch to archive.debian.org"
+      if: matrix.archive == 'true'
+      run: |
+        sed -i 's|deb\.debian\.org|archive.debian.org/debian-archive|g' /etc/apt/sources.list
 
     - name: "Install deps (container)"
       if: runner.os == 'Linux'


### PR DESCRIPTION
Pre-OTP 24 containers are built with Debian Buster. Use archive.debian.org mirror.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
