### PR TITLE
Add which_children/1 to supervisor.erl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `erlang:module_loaded/1`
 - Added `binary:replace/3`, `binary:replace/4`
 - Added `binary:match/2` and `binary:match/3`
+- Added `supervisor:which_children/1`
 
 ### Changed
 


### PR DESCRIPTION
Needed for more complete GenServer/Supervisor.ex very soon.

(Think Registry.ex needs it down the line..)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
