### PR TITLE
Add count_children/1 to supervisor.erl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `erlang:module_loaded/1`
 - Added `binary:replace/3`, `binary:replace/4`
 - Added `binary:match/2` and `binary:match/3`
-- Added `supervisor:which_children/1`
+- Added `supervisor:which_children/1` and `supervisor:count_children/1`
 - Added `monitored_by` in `process_info/2`
 
 ### Changed

--- a/tests/libs/estdlib/test_supervisor.erl
+++ b/tests/libs/estdlib/test_supervisor.erl
@@ -34,6 +34,7 @@ test() ->
     ok = test_terminate_delete_child(),
     ok = test_terminate_timeout(),
     ok = test_which_children(),
+    ok = test_count_children(),
     ok.
 
 test_basic_supervisor() ->
@@ -84,6 +85,55 @@ test_start_child() ->
     {ok, _InfoPid, info} = supervisor:start_child(SupPid, #{
         id => child_info, start => {?MODULE, child_start, [info]}
     }),
+    unlink(SupPid),
+    exit(SupPid, shutdown),
+    ok.
+
+test_count_children() ->
+    % Test with no children - all counts should be zero
+    {ok, SupPid} = supervisor:start_link(?MODULE, {test_no_child, self()}),
+    [{specs, 0}, {active, 0}, {supervisors, 0}, {workers, 0}] = supervisor:count_children(SupPid),
+
+    % Add a worker child and verify counts
+    {ok, _ChildPid} = supervisor:start_child(SupPid, #{
+        id => test_worker,
+        start => {ping_pong_server, start_link, [self()]},
+        restart => permanent,
+        shutdown => 5000,
+        type => worker
+    }),
+
+    % Check count_children with one active worker
+    [{specs, 1}, {active, 1}, {supervisors, 0}, {workers, 1}] = supervisor:count_children(SupPid),
+
+    % Add a supervisor child and verify counts
+    {ok, _SupervisorPid} = supervisor:start_child(SupPid, #{
+        id => test_supervisor,
+        start => {?MODULE, start_link, [self()]},
+        restart => permanent,
+        shutdown => infinity,
+        type => supervisor
+    }),
+
+    % Check count_children with one worker and one supervisor
+    [{specs, 2}, {active, 2}, {supervisors, 1}, {workers, 1}] = supervisor:count_children(SupPid),
+
+    % Terminate the worker child - spec remains but child becomes inactive
+    ok = supervisor:terminate_child(SupPid, test_worker),
+    [{specs, 2}, {active, 1}, {supervisors, 1}, {workers, 1}] = supervisor:count_children(SupPid),
+
+    % Delete the worker child - removes the spec completely
+    ok = supervisor:delete_child(SupPid, test_worker),
+    [{specs, 1}, {active, 1}, {supervisors, 1}, {workers, 0}] = supervisor:count_children(SupPid),
+
+    % Terminate the supervisor child - spec remains but child becomes inactive
+    ok = supervisor:terminate_child(SupPid, test_supervisor),
+    [{specs, 1}, {active, 0}, {supervisors, 1}, {workers, 0}] = supervisor:count_children(SupPid),
+
+    % Delete the supervisor child - removes the spec completely
+    ok = supervisor:delete_child(SupPid, test_supervisor),
+    [{specs, 0}, {active, 0}, {supervisors, 0}, {workers, 0}] = supervisor:count_children(SupPid),
+
     unlink(SupPid),
     exit(SupPid, shutdown),
     ok.


### PR DESCRIPTION
Last little one and then the road is clear for GenServer.ex and Supervisor.ex..

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
