### PR TITLE
Implement monitoring process by registered name

### DIFF
--- a/code-queries/non-term-to-term-func.ql
+++ b/code-queries/non-term-to-term-func.ql
@@ -20,6 +20,10 @@ predicate isTermType(Type t) {
     (
         t instanceof TypedefType
         and isTermType(t.(TypedefType).getBaseType())
+    ) or
+    (
+        t instanceof SpecifiedType
+        and isTermType(t.(SpecifiedType).getBaseType())
     )
 }
 

--- a/code-queries/term-to-non-term-func.ql
+++ b/code-queries/term-to-non-term-func.ql
@@ -20,6 +20,10 @@ predicate isTermType(Type t) {
     (
         t instanceof TypedefType
         and isTermType(t.(TypedefType).getBaseType())
+    ) or
+    (
+        t instanceof SpecifiedType
+        and isTermType(t.(SpecifiedType).getBaseType())
     )
 }
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -1133,8 +1133,8 @@ send(_Target, _Message) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec monitor
-    (Type :: process, Pid :: pid()) -> reference();
-    (Type :: port, Port :: port()) -> reference().
+    (Type :: process, Pid :: pid() | atom()) -> reference();
+    (Type :: port, Port :: port() | atom()) -> reference().
 monitor(_Type, _PidOrPort) ->
     erlang:nif_error(undefined).
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -30,6 +30,7 @@
 #include "globalcontext.h"
 #include "list.h"
 #include "mailbox.h"
+#include "memory.h"
 #include "smp.h"
 #include "synclist.h"
 #include "sys.h"
@@ -252,6 +253,7 @@ void context_destroy(Context *ctx)
                 case CONTEXT_MONITOR_LINK_LOCAL:
                 case CONTEXT_MONITOR_MONITORED_LOCAL:
                 case CONTEXT_MONITOR_MONITORING_LOCAL:
+                case CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME:
                     UNREACHABLE();
             }
         }
@@ -418,13 +420,32 @@ void context_process_monitor_down_signal(Context *ctx, struct TermSignal *signal
     LIST_FOR_EACH (item, &ctx->monitors_head) {
         struct Monitor *monitor = GET_LIST_ENTRY(item, struct Monitor, monitor_list_head);
         if (monitor->monitor_type == CONTEXT_MONITOR_MONITORING_LOCAL) {
-            struct MonitorLocalMonitor *monitored_monitor = CONTAINER_OF(monitor, struct MonitorLocalMonitor, monitor);
-            if (monitored_monitor->monitor_obj == monitor_obj && monitored_monitor->ref_ticks == ref_ticks) {
+            struct MonitorLocalMonitor *monitoring_monitor = CONTAINER_OF(monitor, struct MonitorLocalMonitor, monitor);
+            if (monitoring_monitor->monitor_obj == monitor_obj && monitoring_monitor->ref_ticks == ref_ticks) {
                 // Remove link
                 list_remove(&monitor->monitor_list_head);
                 free(monitor);
                 // Enqueue the term as a message.
                 mailbox_send(ctx, signal->signal_term);
+                break;
+            }
+        } else if (monitor->monitor_type == CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME) {
+            int32_t monitor_process_id = term_to_local_process_id(monitor_obj);
+            struct MonitorLocalRegisteredNameMonitor *monitoring_monitor = CONTAINER_OF(monitor, struct MonitorLocalRegisteredNameMonitor, monitor);
+            if (monitoring_monitor->monitor_process_id == monitor_process_id && monitoring_monitor->ref_ticks == ref_ticks) {
+                // Remove link
+                list_remove(&monitor->monitor_list_head);
+
+                // We need to modify the monitor_obj item
+                BEGIN_WITH_STACK_HEAP(TUPLE_SIZE(2), temp_heap)
+                term name_tuple = term_alloc_tuple(2, &temp_heap);
+                term_put_tuple_element(name_tuple, 0, monitoring_monitor->monitor_name);
+                term_put_tuple_element(name_tuple, 1, ctx->global->node_name);
+                term_put_tuple_element(signal->signal_term, 3, name_tuple);
+                mailbox_send(ctx, signal->signal_term);
+                END_WITH_STACK_HEAP(temp_heap, ctx->global);
+
+                free(monitor);
                 break;
             }
         }
@@ -623,6 +644,18 @@ static struct Monitor *context_monitors_handle_terminate(Context *ctx)
                 free(monitor);
                 break;
             }
+            case CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME: {
+                // We are the monitoring process.
+                struct MonitorLocalRegisteredNameMonitor *monitoring_monitor = CONTAINER_OF(monitor, struct MonitorLocalRegisteredNameMonitor, monitor);
+                int32_t local_process_id = monitoring_monitor->monitor_process_id;
+                Context *target = globalcontext_get_process_nolock(glb, local_process_id);
+                if (LIKELY(target != NULL)) {
+                    // target can be null if we didn't process a MonitorDownSignal
+                    mailbox_send_ref_signal(target, DemonitorSignal, monitoring_monitor->ref_ticks);
+                }
+                free(monitor);
+                break;
+            }
             case CONTEXT_MONITOR_LINK_LOCAL: {
                 struct LinkLocalMonitor *link_monitor = CONTAINER_OF(monitor, struct LinkLocalMonitor, monitor);
                 // Handle the case of inactive link.
@@ -747,6 +780,20 @@ struct Monitor *monitor_new(term monitor_pid, uint64_t ref_ticks, bool is_monito
     return &monitor->monitor;
 }
 
+struct Monitor *monitor_registeredname_monitor_new(int32_t monitor_process_id, term monitor_name, uint64_t ref_ticks)
+{
+    struct MonitorLocalRegisteredNameMonitor *monitor = malloc(sizeof(struct MonitorLocalRegisteredNameMonitor));
+    if (IS_NULL_PTR(monitor)) {
+        return NULL;
+    }
+    monitor->monitor.monitor_type = CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME;
+    monitor->monitor_process_id = monitor_process_id;
+    monitor->monitor_name = monitor_name;
+    monitor->ref_ticks = ref_ticks;
+
+    return &monitor->monitor;
+}
+
 struct Monitor *monitor_resource_monitor_new(void *resource, uint64_t ref_ticks)
 {
     struct ResourceContextMonitor *monitor = malloc(sizeof(struct ResourceContextMonitor));
@@ -781,6 +828,17 @@ bool context_add_monitor(Context *ctx, struct Monitor *new_monitor)
                     struct MonitorLocalMonitor *new_local_monitor = CONTAINER_OF(new_monitor, struct MonitorLocalMonitor, monitor);
                     struct MonitorLocalMonitor *existing_local_monitor = CONTAINER_OF(existing, struct MonitorLocalMonitor, monitor);
                     if (UNLIKELY(existing_local_monitor->monitor_obj == new_local_monitor->monitor_obj && existing_local_monitor->ref_ticks == new_local_monitor->ref_ticks)) {
+                        free(new_monitor);
+                        return false;
+                    }
+                    break;
+                }
+                case CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME: {
+                    struct MonitorLocalRegisteredNameMonitor *new_local_registeredname_monitor = CONTAINER_OF(new_monitor, struct MonitorLocalRegisteredNameMonitor, monitor);
+                    struct MonitorLocalRegisteredNameMonitor *existing_local_registeredname_monitor = CONTAINER_OF(existing, struct MonitorLocalRegisteredNameMonitor, monitor);
+                    if (UNLIKELY(existing_local_registeredname_monitor->monitor_process_id == new_local_registeredname_monitor->monitor_process_id
+                            && existing_local_registeredname_monitor->monitor_name == new_local_registeredname_monitor->monitor_name
+                            && existing_local_registeredname_monitor->ref_ticks == new_local_registeredname_monitor->ref_ticks)) {
                         free(new_monitor);
                         return false;
                     }
@@ -933,6 +991,15 @@ void context_demonitor(Context *ctx, uint64_t ref_ticks)
                 }
                 break;
             }
+            case CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME: {
+                struct MonitorLocalRegisteredNameMonitor *local_registeredname_monitor = CONTAINER_OF(monitor, struct MonitorLocalRegisteredNameMonitor, monitor);
+                if (local_registeredname_monitor->ref_ticks == ref_ticks) {
+                    list_remove(&monitor->monitor_list_head);
+                    free(monitor);
+                    return;
+                }
+                break;
+            }
             case CONTEXT_MONITOR_RESOURCE: {
                 struct ResourceContextMonitor *resource_monitor = CONTAINER_OF(monitor, struct ResourceContextMonitor, monitor);
                 if (resource_monitor->ref_ticks == ref_ticks) {
@@ -960,6 +1027,14 @@ term context_get_monitor_pid(Context *ctx, uint64_t ref_ticks, bool *is_monitori
                 if (local_monitor->ref_ticks == ref_ticks) {
                     *is_monitoring = monitor->monitor_type == CONTEXT_MONITOR_MONITORING_LOCAL;
                     return local_monitor->monitor_obj;
+                }
+                break;
+            }
+            case CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME: {
+                struct MonitorLocalRegisteredNameMonitor *local_registeredname_monitor = CONTAINER_OF(monitor, struct MonitorLocalRegisteredNameMonitor, monitor);
+                if (local_registeredname_monitor->ref_ticks == ref_ticks) {
+                    *is_monitoring = true;
+                    return term_from_local_process_id(local_registeredname_monitor->monitor_process_id);
                 }
                 break;
             }
@@ -1100,6 +1175,16 @@ COLD_FUNC void context_dump(Context *ctx)
                 fprintf(stderr, "monitored by ");
                 term_display(stderr, monitored_monitor->monitor_obj, ctx);
                 fprintf(stderr, " ref=%lu", (long unsigned) monitored_monitor->ref_ticks);
+                fprintf(stderr, "\n");
+                break;
+            }
+            case CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME: {
+                struct MonitorLocalRegisteredNameMonitor *local_registeredname_monitor = CONTAINER_OF(monitor, struct MonitorLocalRegisteredNameMonitor, monitor);
+                fprintf(stderr, "monitor to ");
+                term_display(stderr, local_registeredname_monitor->monitor_name, ctx);
+                fprintf(stderr, " (");
+                term_display(stderr, term_from_local_process_id(local_registeredname_monitor->monitor_process_id), ctx);
+                fprintf(stderr, ") ref=%lu", (long unsigned) local_registeredname_monitor->ref_ticks);
                 fprintf(stderr, "\n");
                 break;
             }

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -159,6 +159,7 @@ enum ContextMonitorType
     CONTEXT_MONITOR_MONITORED_LOCAL,
     CONTEXT_MONITOR_RESOURCE,
     CONTEXT_MONITOR_LINK_REMOTE,
+    CONTEXT_MONITOR_MONITORING_LOCAL_REGISTEREDNAME,
 };
 
 #define UNLINK_ID_LINK_ACTIVE 0x0
@@ -184,6 +185,14 @@ struct MonitorLocalMonitor
     struct Monitor monitor;
     uint64_t ref_ticks;
     term monitor_obj;
+};
+
+struct MonitorLocalRegisteredNameMonitor
+{
+    struct Monitor monitor;
+    uint64_t ref_ticks;
+    int32_t monitor_process_id;
+    term monitor_name;
 };
 
 // The other half is called ResourceMonitor and is a linked list of resources
@@ -477,12 +486,23 @@ struct Monitor *monitor_link_new(term link_pid);
 /**
  * @brief Create a monitor on a process.
  *
- * @param monitor_pid monitoring process
+ * @param monitor_pid monitored process
  * @param ref_ticks reference of the monitor
  * @param is_monitoring if ctx is the monitoring process
  * @return the allocated monitor or NULL if allocation failed
  */
 struct Monitor *monitor_new(term monitor_pid, uint64_t ref_ticks, bool is_monitoring);
+
+/**
+ * @brief Create a monitor on a process by registered name.
+ *
+ * @param monitor_process_id monitored process id
+ * @param monitor_name name of the monitor (atom)
+ * @param ref_ticks reference of the monitor
+ * @param is_monitoring if ctx is the monitoring process
+ * @return the allocated monitor or NULL if allocation failed
+ */
+struct Monitor *monitor_registeredname_monitor_new(int32_t monitor_process_id, term monitor_name, uint64_t ref_ticks);
 
 /**
  * @brief Create a resource monitor.
@@ -545,8 +565,8 @@ void context_demonitor(Context *ctx, uint64_t ref_ticks);
  * @param ctx the context being executed
  * @param ref_ticks reference of the monitor to remove
  * @param is_monitoring whether ctx is the monitoring process.
- * @return pid of monitoring process, self() if process is monitoring (and not
- * monitored) or term_invalid() if no monitor could be found.
+ * @return pid of monitored or monitoring process or term_invalid()
+ * if no monitor could be found.
  */
 term context_get_monitor_pid(Context *ctx, uint64_t ref_ticks, bool *is_monitoring);
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4133,28 +4133,47 @@ static term nif_erlang_monitor(Context *ctx, int argc, term argv[])
     UNUSED(argc);
 
     term object_type = argv[0];
-    term target_pid = argv[1];
+    term target_proc = argv[1];
+    term target_pid;
+    size_t target_proc_size = 0;
 
     if (object_type != PROCESS_ATOM && object_type != PORT_ATOM) {
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    VALIDATE_VALUE(target_pid, term_is_local_pid_or_port);
-
-    int local_process_id = term_to_local_process_id(target_pid);
-    // Monitoring self is possible but no monitor is actually created
-    if (UNLIKELY(local_process_id == ctx->process_id)) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, REF_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-        }
-        uint64_t ref_ticks = globalcontext_get_ref_ticks(ctx->global);
-        term ref = term_from_ref_ticks(ref_ticks, &ctx->heap);
-        return ref;
+    if (term_is_atom(target_proc)) {
+        target_pid = globalcontext_get_registered_process(ctx->global, term_to_atom_index(target_proc));
+        target_proc_size = TUPLE_SIZE(2);
+    } else {
+        VALIDATE_VALUE(target_proc, term_is_local_pid_or_port);
+        target_pid = target_proc;
     }
 
-    Context *target = globalcontext_get_process_lock(ctx->global, local_process_id);
+    Context *target;
+    int32_t local_process_id;
+    // gcc < 14 is not smart enough to find out local_process_id is not used initialized below
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 14
+    local_process_id = 0;
+#endif
+    if (UNLIKELY(target_pid == UNDEFINED_ATOM)) {
+        target = NULL;
+    } else {
+        local_process_id = term_to_local_process_id(target_pid);
+        // Monitoring self is possible but no monitor is actually created
+        if (UNLIKELY(local_process_id == ctx->process_id)) {
+            if (UNLIKELY(memory_ensure_free_opt(ctx, REF_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            }
+            uint64_t ref_ticks = globalcontext_get_ref_ticks(ctx->global);
+            term ref = term_from_ref_ticks(ref_ticks, &ctx->heap);
+            return ref;
+        }
+
+        target = globalcontext_get_process_lock(ctx->global, local_process_id);
+    }
+
     if (IS_NULL_PTR(target)) {
-        int res_size = REF_SIZE + TUPLE_SIZE(5);
+        int res_size = REF_SIZE + TUPLE_SIZE(5) + target_proc_size;
         if (UNLIKELY(memory_ensure_free_opt(ctx, res_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
@@ -4164,7 +4183,14 @@ static term nif_erlang_monitor(Context *ctx, int argc, term argv[])
         term_put_tuple_element(down_message_tuple, 0, DOWN_ATOM);
         term_put_tuple_element(down_message_tuple, 1, ref);
         term_put_tuple_element(down_message_tuple, 2, object_type);
-        term_put_tuple_element(down_message_tuple, 3, target_pid);
+        if (term_is_atom(target_proc)) {
+            term target_proc_tuple = term_alloc_tuple(2, &ctx->heap);
+            term_put_tuple_element(target_proc_tuple, 0, target_proc);
+            term_put_tuple_element(target_proc_tuple, 1, ctx->global->node_name);
+            term_put_tuple_element(down_message_tuple, 3, target_proc_tuple);
+        } else {
+            term_put_tuple_element(down_message_tuple, 3, target_proc);
+        }
         term_put_tuple_element(down_message_tuple, 4, NOPROC_ATOM);
         mailbox_send(ctx, down_message_tuple);
         return ref;
@@ -4175,7 +4201,12 @@ static term nif_erlang_monitor(Context *ctx, int argc, term argv[])
     }
     uint64_t ref_ticks = globalcontext_get_ref_ticks(ctx->global);
     term monitoring_pid = term_from_local_process_id(ctx->process_id);
-    struct Monitor *self_monitor = monitor_new(target_pid, ref_ticks, true);
+    struct Monitor *self_monitor;
+    if (term_is_atom(target_proc)) {
+        self_monitor = monitor_registeredname_monitor_new(local_process_id, target_proc, ref_ticks);
+    } else {
+        self_monitor = monitor_new(target_pid, ref_ticks, true);
+    }
     if (IS_NULL_PTR(self_monitor)) {
         globalcontext_get_process_unlock(ctx->global, target);
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);

--- a/tests/libs/estdlib/test_gen_server.erl
+++ b/tests/libs/estdlib/test_gen_server.erl
@@ -46,6 +46,7 @@ test() ->
     ok = test_timeout_info(),
     ok = test_register(),
     ok = test_call_unregistered(),
+    ok = test_cast_unregistered(),
     ok = test_normal_exit_call(),
     ok = test_abnormal_exit_call(),
     ok = test_crash_call(),
@@ -332,12 +333,18 @@ test_call_unregistered() ->
         gen_server:call(?MODULE, foo),
         fail
     catch
-        exit:{noproc, _Location} ->
-            % erlang:display({C, E}),
+        exit:{noproc, Location} ->
+            erlang:display({noproc, Location}),
+            ok;
+        T:V ->
+            erlang:display({T, V}),
             ok
     after
         ok = gen_server:stop(Pid)
     end.
+
+test_cast_unregistered() ->
+    ok = gen_server:cast(?MODULE, foo).
 
 test_normal_exit_call() ->
     {ok, Pid} = gen_server:start(?MODULE, [], []),


### PR DESCRIPTION
Also simplify gen_server implementation when ServerRef is an atom

Steps 1 & 2 towards fix of #1787 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
