### PR TITLE
Fix issue with bs_private_append that shouldn't gc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ integer (this never happens with integers < 28 bits)
 used the same "PicoW" dhcp hostname, causing collisions when multiple rp2040 are on the same
 network. (See issue #1094)
 - Fixed possible memory corruption when doing binary matching.
+- Fixed an issue with `bs_private_append` that shouldn't gc, affecting code compiled with OTP<25
 
 ### Changed
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4511,7 +4511,7 @@ wait_timeout_trap_handler:
                     // TODO: further investigate unit.
                     // We currently do not support unaligned binaries, unit seems to be equal to 1 binary comprehensions
                     size_t src_size = term_binary_size(src);
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_heap_size(size_val / 8), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_heap_size(size_val / 8), MEMORY_NO_GC) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     DECODE_COMPACT_TERM(src, src_pc)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
