### PR TITLE
Add file:native_name_encoding/0

### DIFF
--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set(ERLANG_MODULES
     erpc
     erts_debug
     ets
+    file
     gen_event
     gen_server
     gen_statem

--- a/libs/estdlib/src/file.erl
+++ b/libs/estdlib/src/file.erl
@@ -1,0 +1,27 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Software Mansion S.A.
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(file).
+
+-export([native_name_encoding/0]).
+
+-spec native_name_encoding() -> latin1 | utf8.
+native_name_encoding() ->
+    utf8.

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -49,6 +49,7 @@ set(ERLANG_MODULES
     test_timer
     test_supervisor
     test_lists_subtraction
+    test_file
     test_tcp_socket
     test_udp_socket
     notify_init_server

--- a/tests/libs/estdlib/test_file.erl
+++ b/tests/libs/estdlib/test_file.erl
@@ -1,0 +1,37 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Tomasz Sobkiewicz <tomasz.sobkiewicz@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_file).
+-export([start/0, test/0]).
+
+start() ->
+    test().
+
+test() ->
+    Res = file:native_name_encoding(),
+    ok = is_proper_encoding(Res),
+    ok.
+
+is_proper_encoding(utf8) ->
+    ok;
+is_proper_encoding(latin1) ->
+    ok;
+is_proper_encoding(_) ->
+    error.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -81,7 +81,8 @@ get_non_networking_tests(_OTPVersion) ->
         test_spawn,
         test_supervisor,
         test_lists_subtraction,
-        test_os
+        test_os,
+        test_file
     ].
 
 get_networking_tests(OTPVersion) when


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
