### PR TITLE
Fix flappiness of `test_tcp_socket` shutdown test with a retry

### DIFF
--- a/tests/libs/estdlib/test_tcp_socket.erl
+++ b/tests/libs/estdlib/test_tcp_socket.erl
@@ -93,8 +93,14 @@ test_shutdown_of_side(Port, Side) ->
             case catch (socket:send(Socket, erlang:atom_to_binary(Side, latin1))) of
                 {error, _} ->
                     ok;
-                {ok, Data} ->
-                    error({expected_error_on_send, Side, Data})
+                {ok, Data1} ->
+                    %% Second send will fail
+                    case catch (socket:send(Socket, erlang:atom_to_binary(Side, latin1))) of
+                        {error, _} ->
+                            ok;
+                        {ok, Data2} ->
+                            error({expected_error_on_send, Side, Data1, Data2})
+                    end
             end
     end,
 


### PR DESCRIPTION
In some cases, CI allows to write to socket after call to shutdown. Try a second time as we already do with recv.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
