### PR TITLE
eunit: return error if tests fail

### DIFF
--- a/libs/etest/src/eunit.erl
+++ b/libs/etest/src/eunit.erl
@@ -266,5 +266,4 @@ start() ->
         [],
         code:all_available()
     ),
-    test(TestModules, [exact_execution]),
-    ok.
+    test(TestModules, [exact_execution]).


### PR DESCRIPTION
eunit tests, especially when generated with pack_eunit macro, wouldn't fail because eunit:start/0 always returned ok.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
