### PR TITLE
JIT: optimize op_return by not always returning to VM

### DIFF
--- a/tests/libs/jit/jit_aarch64_tests.erl
+++ b/tests/libs/jit/jit_aarch64_tests.erl
@@ -1719,6 +1719,21 @@ mul_test_() ->
             ]
         end}.
 
+%% Test jump_to_continuation optimization for intra-module returns
+jump_to_continuation_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    State1 = ?BACKEND:jump_to_continuation(State0, {free, r0}),
+    Stream = ?BACKEND:stream(State1),
+    % Expected: adr x7, NetOffset; add x7, x7, x0; br x7
+    % With default offset 0, NetOffset = 0 - 0 = 0, temp register is r7
+    Dump =
+        <<
+            "   0:	10000007 	adr	x7, 0x0\n"
+            "   4:	8b0000e7 	add	x7, x7, x0\n"
+            "   8:	d61f00e0 	br	x7"
+        >>,
+    ?assertEqual(dump_to_bin(Dump), Stream).
+
 dump_to_bin(Dump) ->
     dump_to_bin0(Dump, addr, []).
 


### PR DESCRIPTION
op_return implementation is expensive as it's returning to VM. Optimize it if we're staying in the same module.
This yields a 4% speed increase on the prng_test from the benchmark.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
