### PR TITLE
JIT: optimize `verify_is_match_state` using types

### DIFF
--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -616,16 +616,13 @@ term module_get_type_by_index(const Module *mod, int type_index, Context *ctx)
             return globalcontext_make_atom(ctx->global, ATOM_STR("\x6", "t_atom"));
 
         case BEAM_TYPE_BITSTRING:
-            if (type_bits & BEAM_TYPE_HAS_UNIT) {
-                if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
-                    return globalcontext_make_atom(ctx->global, ATOM_STR("\x3", "any"));
-                }
-                term type_tuple = term_alloc_tuple(2, &ctx->heap);
-                term_put_tuple_element(type_tuple, 0, globalcontext_make_atom(ctx->global, ATOM_STR("\xD", "t_bs_matchable")));
-                term_put_tuple_element(type_tuple, 1, term_from_int32(unit));
-                return type_tuple;
+            if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
+                return globalcontext_make_atom(ctx->global, ATOM_STR("\x3", "any"));
             }
-            return globalcontext_make_atom(ctx->global, ATOM_STR("\xD", "t_bs_matchable"));
+            term type_tuple = term_alloc_tuple(2, &ctx->heap);
+            term_put_tuple_element(type_tuple, 0, globalcontext_make_atom(ctx->global, ATOM_STR("\xE", "t_bs_matchable")));
+            term_put_tuple_element(type_tuple, 1, term_from_int32(unit));
+            return type_tuple;
 
         case BEAM_TYPE_CONS:
             return globalcontext_make_atom(ctx->global, ATOM_STR("\x6", "t_cons"));


### PR DESCRIPTION
Continuation of:
-  #1770 
- #1833
- #1834

First optimization using type information: simplify some term_to_int implementations.

Current benchmark:
|test                 |JIT disabled (c06edb2bca8dacc8c17661575b39bcfc2c5922ea)|HEAD~2, JIT enabled (9b14b166899f3248189b71c6c157c6ae110df6c4)|This PR (c673c494f0b4fe031646b9c93e3df9742c52405f) |
|--------------|---------------- |------------------------|--------|
|erlang-tests   | 11.45s                  | 9.95s  | 9.96s |
|benchmark (entire run)                      | 17.03s                 | 15.35s | 15.48s |
|benchmark : pingpong_speed_test | 3.59s                 | 3.23s | 3.28s |
|benchmark : prime_speed_test       |  0.26s                            | 0.17s | 0.17s |
|benchmark : sudoku_solution_test |  0.26s                            | 1.34s | 1.35s |
|benchmark : sudoku_puzzle_test   |    10.51s                            | 9.18s | 9.22s |

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
