### PR TITLE
JIT: optimize `verify_is_function` using types

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -949,13 +949,12 @@ first_pass(<<?OP_CALL_FUN, Rest0/binary>>, MMod, MSt0, State0) ->
     ?TRACE("OP_CALL_FUN ~p\n", [ArgsCount]),
     MSt1 = MMod:decrement_reductions_and_maybe_schedule_next(MSt0),
     {MSt2, FuncReg} = read_any_xreg(ArgsCount, MMod, MSt1),
-    {MSt3, Reg} = MMod:move_to_native_register(MSt2, FuncReg),
-    MSt4 = verify_is_function(Reg, MMod, MSt3),
-    MSt5 = MMod:call_primitive_with_cp(MSt4, ?PRIM_CALL_FUN, [
-        ctx, jit_state, offset, Reg, ArgsCount
+    {MSt3, Reg} = verify_is_function(FuncReg, MMod, MSt2),
+    MSt4 = MMod:call_primitive_with_cp(MSt3, ?PRIM_CALL_FUN, [
+        ctx, jit_state, offset, {free, Reg}, ArgsCount
     ]),
-    ?ASSERT_ALL_NATIVE_FREE(MSt5),
-    first_pass(Rest1, MMod, MSt5, State0);
+    ?ASSERT_ALL_NATIVE_FREE(MSt4),
+    first_pass(Rest1, MMod, MSt4, State0);
 % 77
 first_pass(<<?OP_IS_FUNCTION, Rest0/binary>>, MMod, MSt0, State0) ->
     ?ASSERT_ALL_NATIVE_FREE(MSt0),
@@ -2332,18 +2331,17 @@ first_pass(<<?OP_CALL_FUN2, Rest0/binary>>, MMod, MSt0, State0) ->
     ?ASSERT_ALL_NATIVE_FREE(MSt0),
     {MSt1, Tag, Rest1} = decode_compact_term(Rest0, MMod, MSt0, State0),
     {ArgsCount, Rest2} = decode_literal(Rest1),
-    {MSt2, Fun, Rest3} = decode_compact_term(Rest2, MMod, MSt1, State0),
+    {MSt2, Fun, Rest3} = decode_typed_compact_term(Rest2, MMod, MSt1, State0),
     ?TRACE("OP_CALL_FUN2 ~p, ~p, ~p\n", [Tag, ArgsCount, Fun]),
     % We ignore Tag (could be literal 0 or atom unsafe)
     MSt3 = MMod:free_native_registers(MSt2, [Tag]),
     MSt4 = MMod:decrement_reductions_and_maybe_schedule_next(MSt3),
-    {MSt5, Reg} = MMod:move_to_native_register(MSt4, Fun),
-    MSt6 = verify_is_function(Reg, MMod, MSt5),
-    MSt7 = MMod:call_primitive_with_cp(MSt6, ?PRIM_CALL_FUN, [
-        ctx, jit_state, offset, Reg, ArgsCount
+    {MSt5, Reg} = verify_is_function(Fun, MMod, MSt4),
+    MSt6 = MMod:call_primitive_with_cp(MSt5, ?PRIM_CALL_FUN, [
+        ctx, jit_state, offset, {free, Reg}, ArgsCount
     ]),
-    ?ASSERT_ALL_NATIVE_FREE(MSt7),
-    first_pass(Rest3, MMod, MSt7, State0);
+    ?ASSERT_ALL_NATIVE_FREE(MSt6),
+    first_pass(Rest3, MMod, MSt6, State0);
 % 180
 first_pass(<<?OP_BADRECORD, Rest0/binary>>, MMod, MSt0, State0) ->
     ?ASSERT_ALL_NATIVE_FREE(MSt0),
@@ -3026,8 +3024,18 @@ term_is_boxed_with_tag_and_get_ptr(Label, Arg1, BoxedTag, MMod, MSt1) ->
 %% @param MSt0 backend state
 %% @return new backend state
 %%-----------------------------------------------------------------------------
-verify_is_function(Arg, MMod, MSt0) ->
-    {MSt1, Reg} = MMod:copy_to_native_register(MSt0, Arg),
+verify_is_function({typed, Func, t_fun}, MMod, MSt0) ->
+    MMod:move_to_native_register(MSt0, Func);
+verify_is_function({typed, Func, any}, MMod, MSt0) ->
+    verify_is_function(Func, MMod, MSt0);
+verify_is_function({typed, Func, _Other}, MMod, MSt0) ->
+    {MSt1, Reg} = MMod:move_to_native_register(MSt0, Func),
+    MSt2 = MMod:call_primitive_last(MSt1, ?PRIM_RAISE_ERROR_TUPLE, [
+        ctx, jit_state, offset, ?BADFUN_ATOM, Reg
+    ]),
+    {MSt2, Reg};
+verify_is_function(Func, MMod, MSt0) ->
+    {MSt1, Reg} = MMod:copy_to_native_register(MSt0, Func),
     MSt2 = MMod:if_block(MSt1, {Reg, '&', ?TERM_PRIMARY_MASK, '!=', ?TERM_PRIMARY_BOXED}, fun(BSt0) ->
         MMod:call_primitive_last(BSt0, ?PRIM_RAISE_ERROR_TUPLE, [
             ctx, jit_state, offset, ?BADFUN_ATOM, Reg
@@ -3040,7 +3048,8 @@ verify_is_function(Arg, MMod, MSt0) ->
             ctx, jit_state, offset, ?BADFUN_ATOM, Reg
         ])
     end),
-    MMod:free_native_registers(MSt5, [Reg]).
+    MSt6 = MMod:free_native_registers(MSt5, [Reg]),
+    MMod:move_to_native_register(MSt6, Func).
 
 verify_is_binary_or_match_state(Label, Src, MMod, MSt0) ->
     {MSt1, Reg} = MMod:copy_to_native_register(MSt0, Src),

--- a/tests/libs/jit/jit_tests.erl
+++ b/tests/libs/jit/jit_tests.erl
@@ -48,6 +48,20 @@
     <<0, 0, 0, 3, 0, 0, 0, 3, 15, 255, 0, 2, 0, 32>>
 ).
 
+% Code chunk with typed register from test_call_simple.erl
+% Contains call_fun2 opcode with typed register that uses verify_is_function optimization
+-define(CODE_CHUNK_2,
+    <<0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 178, 0, 0, 0, 3, 0, 0, 0, 1, 1, 16, 153, 16, 2, 18, 34, 32,
+        1, 32, 77, 21, 19, 12, 0, 32, 153, 32, 178, 50, 16, 87, 19, 16, 18, 0, 19, 3>>
+).
+-define(ATU8_CHUNK_2,
+    <<255, 255, 255, 253, 8, 16, 116, 101, 115, 116, 95, 99, 97, 108, 108, 95, 115, 105, 109, 112,
+        108, 101, 144, 116, 101, 115, 116, 95, 99, 97, 108, 108, 96, 117, 110, 115, 97, 102, 101>>
+).
+-define(TYPE_CHUNK_2,
+    <<0, 0, 0, 3, 0, 0, 0, 2, 15, 255, 0, 16>>
+).
+
 compile_minimal_x86_64_test() ->
     Stream0 = jit_stream_binary:new(0),
     <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = ?CODE_CHUNK_0,
@@ -128,4 +142,73 @@ term_to_int_typed_optimization_x86_64_test() ->
         binary:match(CompiledCode, <<16#4c, 16#8b, 16#5f, 16#38, 16#49, 16#c1, 16#eb, 16#04>>)
     ),
 
+    ok.
+
+verify_is_function_typed_optimization_x86_64_test() ->
+    % Compile CODE_CHUNK_1 which contains a typed register for term_to_int optimization
+    Stream0 = jit_stream_binary:new(0),
+    <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = ?CODE_CHUNK_2,
+    Stream1 = jit_stream_binary:append(
+        Stream0, jit:beam_chunk_header(LabelsCount, ?JIT_ARCH_X86_64, ?JIT_VARIANT_PIC)
+    ),
+    Stream2 = jit_x86_64:new(?JIT_VARIANT_PIC, jit_stream_binary, Stream1),
+
+    AtomResolver = jit_precompile:atom_resolver(?ATU8_CHUNK_2),
+    LiteralResolver = fun(_) -> test_literal end,
+    TypeResolver = jit_precompile:type_resolver(?TYPE_CHUNK_2),
+
+    % Compile with typed register support
+    {_LabelsCount, Stream3} = jit:compile(
+        ?CODE_CHUNK_2, AtomResolver, LiteralResolver, TypeResolver, jit_x86_64, Stream2
+    ),
+    CompiledCode = jit_x86_64:stream(Stream3),
+
+    % Check that call to allocate is directly followed by the building the cp
+    % for call
+    % b6:	48 8b 42 10          	mov    0x10(%rdx),%rax
+    % ba:	ff e0                	jmpq   *%rax
+    % bc:	48 8b 47 38          	mov    0x38(%rdi),%rax
+    % c0:	4c 8b 1e             	mov    (%rsi),%r11
+    % c3:	45 8b 1b             	mov    (%r11),%r11d
+    % c6:	49 c1 e3 18          	shl    $0x18,%r11
+    % ...
+
+    % As opposed to:
+    % b6:	48 8b 42 10          	mov    0x10(%rdx),%rax
+    % ba:	ff e0                	jmpq   *%rax
+    % bc:	48 8b 47 38          	mov    0x38(%rdi),%rax
+    % c0:	49 89 c3             	mov    %rax,%r11
+    % c3:	4d 89 da             	mov    %r11,%r10
+    % c6:	41 80 e2 03          	and    $0x3,%r10b
+    % ca:	41 80 fa 02          	cmp    $0x2,%r10b
+    % ce:	74 1a                	je     0xea
+    % d0:	48 8b 82 98 00 00 00 	mov    0x98(%rdx),%rax
+    % d7:	48 c7 c2 d7 00 00 00 	mov    $0xd7,%rdx
+    % de:	48 c7 c1 8b 01 00 00 	mov    $0x18b,%rcx
+    % e5:	4d 89 d8             	mov    %r11,%r8
+    % e8:	ff e0                	jmpq   *%rax
+    % ea:	49 83 e3 fc          	and    $0xfffffffffffffffc,%r11
+    % ee:	4d 8b 1b             	mov    (%r11),%r11
+    % f1:	4d 89 da             	mov    %r11,%r10
+    % f4:	41 80 e2 3f          	and    $0x3f,%r10b
+    % f8:	41 80 fa 14          	cmp    $0x14,%r10b
+    % fc:	74 1a                	je     0x118
+    % fe:	48 8b 82 98 00 00 00 	mov    0x98(%rdx),%rax
+    % 105:	48 c7 c2 05 01 00 00 	mov    $0x105,%rdx
+    % 10c:	48 c7 c1 8b 01 00 00 	mov    $0x18b,%rcx
+    % 113:	4d 89 d8             	mov    %r11,%r8
+    % 116:	ff e0                	jmpq   *%rax
+    % 118:	4c 8b 1e             	mov    (%rsi),%r11
+    % 11b:	45 8b 1b             	mov    (%r11),%r11d
+    % 11e:	49 c1 e3 18          	shl    $0x18,%r11
+    % ...
+
+    ?assertMatch(
+        {_, 20},
+        binary:match(
+            CompiledCode,
+            <<16#48, 16#8b, 16#42, 16#10, 16#ff, 16#e0, 16#48, 16#8b, 16#47, 16#38, 16#4c, 16#8b,
+                16#1e, 16#45, 16#8b, 16#1b, 16#49, 16#c1, 16#e3, 16#18>>
+        )
+    ),
     ok.


### PR DESCRIPTION
Continuation of:
- #1770 
- #1833
- #1834

First optimization using type information: simplify some term_to_int implementations.

Current benchmark:
|test                 |JIT disabled (c06edb2bca8dacc8c17661575b39bcfc2c5922ea)|HEAD~3, JIT enabled (9b14b166899f3248189b71c6c157c6ae110df6c4)|This PR (00dee78da38ed0e643cf4ebb79ff7813d7344567) |
|--------------|---------------- |------------------------|--------|
|erlang-tests   | 11.45s                  | 9.95s  | 9.98s |
|benchmark (entire run)                      | 17.03s                 | 15.35s | 15.39s |
|benchmark : pingpong_speed_test | 3.59s                 | 3.23s | 3.19s |
|benchmark : prime_speed_test       |  0.26s                            | 0.17s | 0.17s |
|benchmark : sudoku_solution_test |  0.26s                            | 1.34s | 1.36s |
|benchmark : sudoku_puzzle_test   |    10.51s                            | 9.18s | 9.23s |

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
