### PR TITLE
intn: do not parse integers > 256 bit

### DIFF
--- a/src/libAtomVM/intn.c
+++ b/src/libAtomVM/intn.c
@@ -882,6 +882,7 @@ static void ipow(int base, int exp, intn_digit_t *out)
 int intn_parse(
     const char buf[], size_t buf_len, int base, intn_digit_t *out, intn_integer_sign_t *out_sign)
 {
+    // maximum number of digits for every chunk that is parsed using int64_parse_ascii_buf
     static const uint8_t base_max_digits[] = { 63, 40, 31, 27, 24, 22, 21, 20, 19, 18, 17, 17, 16,
         16, 15, 15, 15, 15, 14, 14, 14, 14, 13, 13, 13, 13,
         13, 13, 13, 12, 12, 12, 12, 12, 12 };
@@ -923,14 +924,25 @@ int intn_parse(
             // TODO: check overflows
             intn_mulmnu(out, out_len, mult, 2, new_out);
             new_out_len = MAX(2, intn_count_digits(new_out, INTN_MUL_OUT_LEN(out_len, 2)));
+            if (UNLIKELY(out_len > INTN_MAX_IN_LEN)) {
+                assert(out_len <= INTN_MAX_RES_LEN);
+                // we are above the allowed 256 bits, so it is going to be overflow
+                // if still have some room in our buffer, so we are safe
+                return -1;
+            }
         }
 
         intn_integer_sign_t ignored_sign;
         intn_digit_t parsed_as_intn[2];
         int64_to_intn_2(parsed_chunk, parsed_as_intn, &ignored_sign);
 
-        // TODO: check overflows
         out_len = intn_addmnu(new_out, new_out_len, parsed_as_intn, 2, out);
+        if (UNLIKELY(out_len > INTN_MAX_IN_LEN)) {
+            assert(out_len <= INTN_MAX_RES_LEN);
+            // we are above the allowed 256 bits, so it is going to be overflow
+            // if still have some room in our buffer, so we are safe
+            return -1;
+        }
 
         pos += parsed_digits;
         buf_to_int64_opts = BufToInt64RejectSign;

--- a/tests/erlang_tests/bigint.erl
+++ b/tests/erlang_tests/bigint.erl
@@ -245,6 +245,57 @@ parse_bigint() ->
         )
     end),
 
+    TooBig1 = <<"10000000000000000000000000000000000000000000000000000000000000000">>,
+    ok = expect_atomvm_error(badarg, fun() ->
+        binary_to_integer(
+            ?MODULE:id(
+                TooBig1
+            ),
+            16
+        )
+    end),
+
+    TooBig2 = <<"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF">>,
+    ok = expect_atomvm_error(badarg, fun() ->
+        binary_to_integer(
+            ?MODULE:id(
+                TooBig2
+            ),
+            16
+        )
+    end),
+
+    TooBig3 = <<"ACRLOAJ1MN6J7S7EH8796SS9GJF9GD34BPDF15DIES8ME9Q9G7HSG">>,
+    ok = expect_atomvm_error(badarg, fun() ->
+        binary_to_integer(
+            ?MODULE:id(
+                TooBig3
+            ),
+            29
+        )
+    end),
+
+    TooBig4 = <<"2AVFFIPA2YC3I7N7GI96SUVLXY3W2PM5SW8JCGASD013YIUGHJ3MBVOYDJ9PIXSH0SNR4">>,
+    ok = expect_atomvm_error(badarg, fun() ->
+        binary_to_integer(
+            ?MODULE:id(
+                TooBig4
+            ),
+            35
+        )
+    end),
+
+    TooBig5 =
+        <<"2AVFFIPA2YC3I7N7GI96SUVLXY3W2PM5SW8JCGASD013YIUGHJ3MBVOYDJ9PIXSH0SNR40000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005">>,
+    ok = expect_atomvm_error(badarg, fun() ->
+        binary_to_integer(
+            ?MODULE:id(
+                TooBig5
+            ),
+            35
+        )
+    end),
+
     0.
 
 test_cmp() ->
@@ -1273,15 +1324,18 @@ choose_result(AResult, BResult) ->
         beam -> BResult
     end.
 
-expect_overflow(OvfFun) ->
+expect_atomvm_error(Error, ErrFun) ->
     Machine = ?MODULE:get_machine_atom(),
-    try {Machine, OvfFun()} of
+    try {Machine, ErrFun()} of
         {beam, I} when is_integer(I) -> ok;
         {atomvm, Result} -> {unexpected_result, Result}
     catch
-        error:overflow -> ok;
+        error:Error -> ok;
         _:E -> {unexpected_error, E}
     end.
+
+expect_overflow(OvfFun) ->
+    expect_atomvm_error(overflow, OvfFun).
 
 expect_overflow_or_limit(OvfFun) ->
     try OvfFun() of


### PR DESCRIPTION
Avoid crash when a string representing a > 256 bit integer is given.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
