### PR TITLE
Update JIT tests to use `{avm_int64_t, _}` for 64 bits integer

### DIFF
--- a/tests/libs/jit/jit_aarch64_tests.erl
+++ b/tests/libs/jit/jit_aarch64_tests.erl
@@ -819,7 +819,7 @@ call_only_or_schedule_next_and_label_relocation_test() ->
 call_bif_with_large_literal_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
     {State1, FuncPtr} = ?BACKEND:call_primitive(State0, 8, [jit_state, 2]),
-    {State2, ArgReg} = ?BACKEND:call_primitive(State1, 15, [ctx, 9208452466117618637]),
+    {State2, ArgReg} = ?BACKEND:call_primitive(State1, 15, [ctx, {avm_int64_t, 9208452466117618637}]),
     {State3, ResultReg} = ?BACKEND:call_func_ptr(State2, {free, FuncPtr}, [
         ctx, 0, 1, {free, {x_reg, 0}}, {free, ArgReg}
     ]),

--- a/tests/libs/jit/jit_x86_64_tests.erl
+++ b/tests/libs/jit/jit_x86_64_tests.erl
@@ -824,7 +824,7 @@ call_only_or_schedule_next_and_label_relocation_test() ->
 call_bif_with_large_literal_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
     {State1, FuncPtr} = ?BACKEND:call_primitive(State0, 8, [jit_state, 2]),
-    {State2, ArgReg} = ?BACKEND:call_primitive(State1, 15, [ctx, 9208452466117618637]),
+    {State2, ArgReg} = ?BACKEND:call_primitive(State1, 15, [ctx, {avm_int64_t, 9208452466117618637}]),
     {State3, ResultReg} = ?BACKEND:call_func_ptr(State2, {free, FuncPtr}, [
         ctx, 0, 1, {free, {x_reg, 0}}, {free, ArgReg}
     ]),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
