### PR TITLE
Add aarch64 support to unaligned memory access macros

### DIFF
--- a/src/libAtomVM/utils.h
+++ b/src/libAtomVM/utils.h
@@ -45,7 +45,7 @@ extern "C" {
             ( (((uint8_t *)(ptr))[0] << 24) | (((uint8_t *) (ptr))[1] << 16) | (((uint8_t *)(ptr))[2] << 8) | ((uint8_t *)(ptr))[3] )
     #endif
 
-    #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+    #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86) || defined(__aarch64__) || defined(_M_ARM64)
         #define READ_64_UNALIGNED(ptr) \
             __builtin_bswap64(*((uint64_t *) (ptr)))
 


### PR DESCRIPTION
Adds AArch64/ARM64 architecture detection to the unaligned memory access and byte-swapping macros.

Claude claims:

Erlang Code Pattern | Speedup | Example Use Case
-- | -- | --
Binary pattern matching (multi-byte) | 5-10x | <<A:64/big, B:32/big>> = Data
Network protocol parsing | 5-8x | TCP/IP, MQTT, HTTP headers
Sensor data reading (I2C/SPI) | 3-5x | <<Temp:16/big, Pressure:32/big>>
File I/O & serialization | 2-5x | term_to_binary(), binary files
Binary construction (multi-byte) | 3-6x | <<Value:64/big, Other:32/big>>
String/binary operations | 1.5-3x | Binary concatenation
Typical IoT application | 15-30% | Overall speedup

But something also tells me modern compilers already optimize these..

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
