### PR TITLE
JIT: Optimize andl 0xFFFFFF on x86-64

### DIFF
--- a/libs/jit/src/jit_x86_64_asm.erl
+++ b/libs/jit/src/jit_x86_64_asm.erl
@@ -397,6 +397,9 @@ andl(Imm, Reg) when ?IS_UINT8_T(Imm), is_atom(Reg) ->
             1 -> <<?X86_64_REX(0, 0, 0, REX_B)>>
         end,
     <<Prefix/binary, 16#83, 3:2, 4:3, MODRM_RM:3, Imm>>;
+andl(Imm, rax) when ?IS_UINT32_T(Imm) ->
+    % Special short encoding for AND EAX, imm32: 0x25 imm32
+    <<16#25, Imm:32/little>>;
 andl(Imm, Reg) when ?IS_UINT32_T(Imm), is_atom(Reg) ->
     {REX_B, MODRM_RM} = x86_64_x_reg(Reg),
     % AND r/m32, imm32: 0x81 /4 ModRM imm32 (REX prefix for r8-r15)

--- a/tests/libs/jit/jit_x86_64_asm_tests.erl
+++ b/tests/libs/jit/jit_x86_64_asm_tests.erl
@@ -442,7 +442,7 @@ andl_test_() ->
         ),
         % andl imm32, r32 (no REX)
         ?_assertAsmEqual(
-            <<16#81, 16#E0, 16#FF, 16#FF, 16#FF, 16#00>>,
+            <<16#25, 16#FF, 16#FF, 16#FF, 16#00>>,
             "andl $0xffffff, %eax",
             jit_x86_64_asm:andl(16#00FFFFFF, rax)
         ),


### PR DESCRIPTION
This follows what binutils `as` does. Unoptimized encoding wasn't wrong but if `as` is installed, the test would fail

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
