### PR TITLE
JIT: fix parameter passing bug when registers were exhausted on x86-64

### DIFF
--- a/libs/jit/src/jit_x86_64_asm.erl
+++ b/libs/jit/src/jit_x86_64_asm.erl
@@ -56,7 +56,8 @@
     popq/1,
     jmpq/1,
     retq/0,
-    cmpb/2
+    cmpb/2,
+    xchgq/2
 ]).
 
 -define(IS_SINT8_T(X), is_integer(X) andalso X >= -128 andalso X =< 127).
@@ -566,3 +567,25 @@ jmpq({Reg}) ->
 
 retq() ->
     <<16#C3>>.
+
+%% XCHG r64, r64: Exchange two 64-bit registers
+%% Encoding: REX.W + 87 /r
+xchgq(rax, rax) ->
+    % NOP
+    <<16#90>>;
+xchgq(rax, Reg) when is_atom(Reg) ->
+    % Special short encoding for XCHG rax, r64
+    % For low registers: REX.W + 0x90 + reg
+    % For high registers: REX.W + REX.B + 0x90 + reg (need REX.B to access r8-r11)
+    case x86_64_x_reg(Reg) of
+        {0, Index} -> <<16#48, (16#90 + Index)>>;
+        {1, Index} -> <<16#49, (16#90 + Index)>>
+    end;
+xchgq(Reg, rax) when is_atom(Reg) ->
+    % XCHG is commutative
+    xchgq(rax, Reg);
+xchgq(RegA, RegB) when is_atom(RegA), is_atom(RegB) ->
+    % General form: REX.W + 87 /r
+    {REX_R, MODRM_REG} = x86_64_x_reg(RegA),
+    {REX_B, MODRM_RM} = x86_64_x_reg(RegB),
+    <<?X86_64_REX(1, REX_R, 0, REX_B), 16#87, 3:2, MODRM_REG:3, MODRM_RM:3>>.

--- a/tests/libs/jit/jit_x86_64_asm_tests.erl
+++ b/tests/libs/jit/jit_x86_64_asm_tests.erl
@@ -957,3 +957,38 @@ retq_test_() ->
     [
         ?_assertAsmEqual(<<16#c3>>, "retq", jit_x86_64_asm:retq())
     ].
+
+xchgq_test_() ->
+    [
+        ?_assertAsmEqual(<<16#90>>, "xchg %rax,%rax", jit_x86_64_asm:xchgq(rax, rax)),
+        ?_assertAsmEqual(<<16#48, 16#91>>, "xchg %rax,%rcx", jit_x86_64_asm:xchgq(rax, rcx)),
+        ?_assertAsmEqual(<<16#48, 16#92>>, "xchg %rax,%rdx", jit_x86_64_asm:xchgq(rax, rdx)),
+        ?_assertAsmEqual(<<16#48, 16#96>>, "xchg %rax,%rsi", jit_x86_64_asm:xchgq(rax, rsi)),
+        ?_assertAsmEqual(<<16#48, 16#97>>, "xchg %rax,%rdi", jit_x86_64_asm:xchgq(rax, rdi)),
+        ?_assertAsmEqual(<<16#49, 16#90>>, "xchg %rax,%r8", jit_x86_64_asm:xchgq(rax, r8)),
+        ?_assertAsmEqual(<<16#49, 16#91>>, "xchg %rax,%r9", jit_x86_64_asm:xchgq(rax, r9)),
+        ?_assertAsmEqual(<<16#49, 16#92>>, "xchg %rax,%r10", jit_x86_64_asm:xchgq(rax, r10)),
+        ?_assertAsmEqual(<<16#49, 16#93>>, "xchg %rax,%r11", jit_x86_64_asm:xchgq(rax, r11)),
+
+        % xchg reg, rax - commutative, should use same short encoding
+        ?_assertAsmEqual(<<16#48, 16#91>>, "xchg %rcx,%rax", jit_x86_64_asm:xchgq(rcx, rax)),
+        ?_assertAsmEqual(<<16#48, 16#92>>, "xchg %rdx,%rax", jit_x86_64_asm:xchgq(rdx, rax)),
+        ?_assertAsmEqual(<<16#49, 16#91>>, "xchg %r9,%rax", jit_x86_64_asm:xchgq(r9, rax)),
+
+        % xchg reg, reg - general form (REX.W + 0x87 /r)
+        ?_assertAsmEqual(
+            <<16#48, 16#87, 16#D1>>, "xchg %rdx,%rcx", jit_x86_64_asm:xchgq(rdx, rcx)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#87, 16#F2>>, "xchg %rsi,%rdx", jit_x86_64_asm:xchgq(rsi, rdx)
+        ),
+        ?_assertAsmEqual(
+            <<16#4C, 16#87, 16#C1>>, "xchg %r8,%rcx", jit_x86_64_asm:xchgq(r8, rcx)
+        ),
+        ?_assertAsmEqual(
+            <<16#4D, 16#87, 16#C8>>, "xchg %r9,%r8", jit_x86_64_asm:xchgq(r9, r8)
+        ),
+        ?_assertAsmEqual(
+            <<16#4D, 16#87, 16#D1>>, "xchg %r10,%r9", jit_x86_64_asm:xchgq(r10, r9)
+        )
+    ].


### PR DESCRIPTION
Add xchgq instruction to simplify encoding

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
