### PR TITLE
Deprecate `term_from_int32` and `term_from_int64`

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -94,7 +94,7 @@ term bif_erlang_byte_size_1(Context *ctx, uint32_t fail_label, int live, term ar
         len = term_binary_size(arg1);
     }
 
-    return term_from_int32(len);
+    return term_from_int(len);
 }
 
 term bif_erlang_bit_size_1(Context *ctx, uint32_t fail_label, int live, term arg1)
@@ -112,7 +112,7 @@ term bif_erlang_bit_size_1(Context *ctx, uint32_t fail_label, int live, term arg
         len = term_binary_size(arg1) * 8;
     }
 
-    return term_from_int32(len);
+    return term_from_int(len);
 }
 
 term bif_erlang_binary_part_3(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2, term arg3)
@@ -373,7 +373,8 @@ term bif_erlang_tuple_size_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     VALIDATE_VALUE_BIF(fail_label, arg1, term_is_tuple);
 
-    return term_from_int32(term_get_tuple_arity(arg1));
+    // tuple size is (term) header >> 6, so we know it fits a term as an int
+    return term_from_int(term_get_tuple_arity(arg1));
 }
 
 term bif_erlang_map_size_1(Context *ctx, uint32_t fail_label, int live, term arg1)
@@ -395,7 +396,8 @@ term bif_erlang_map_size_1(Context *ctx, uint32_t fail_label, int live, term arg
         RAISE_ERROR(err);
     }
 
-    return term_from_int32(term_get_map_size(arg1));
+    // map size is (term) header >> 6, so we know it fits a term as an int
+    return term_from_int(term_get_map_size(arg1));
 }
 
 term bif_erlang_map_get_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -579,7 +579,7 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
         case HEAP_SIZE_ATOM: {
             term_put_tuple_element(ret, 0, HEAP_SIZE_ATOM);
             unsigned long value = memory_heap_youngest_size(&ctx->heap);
-            term_put_tuple_element(ret, 1, term_from_int32(value));
+            term_put_tuple_element(ret, 1, term_from_int(value));
             break;
         }
 
@@ -599,7 +599,7 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
         case TOTAL_HEAP_SIZE_ATOM: {
             term_put_tuple_element(ret, 0, TOTAL_HEAP_SIZE_ATOM);
             unsigned long value = memory_heap_memory_size(&ctx->heap);
-            term_put_tuple_element(ret, 1, term_from_int32(value));
+            term_put_tuple_element(ret, 1, term_from_int(value));
             break;
         }
 
@@ -607,7 +607,7 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
         case STACK_SIZE_ATOM: {
             term_put_tuple_element(ret, 0, STACK_SIZE_ATOM);
             unsigned long value = context_stack_size(ctx);
-            term_put_tuple_element(ret, 1, term_from_int32(value));
+            term_put_tuple_element(ret, 1, term_from_int(value));
             break;
         }
 
@@ -615,7 +615,7 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
         case MESSAGE_QUEUE_LEN_ATOM: {
             term_put_tuple_element(ret, 0, MESSAGE_QUEUE_LEN_ATOM);
             unsigned long value = context_message_queue_len(ctx);
-            term_put_tuple_element(ret, 1, term_from_int32(value));
+            term_put_tuple_element(ret, 1, term_from_int(value));
             break;
         }
 
@@ -623,7 +623,7 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
         case MEMORY_ATOM: {
             term_put_tuple_element(ret, 0, MEMORY_ATOM);
             unsigned long value = context_size(ctx);
-            term_put_tuple_element(ret, 1, term_from_int32(value));
+            term_put_tuple_element(ret, 1, term_from_int(value));
             break;
         }
 

--- a/src/libAtomVM/inet.c
+++ b/src/libAtomVM/inet.c
@@ -72,9 +72,9 @@ uint32_t inet_addr4_to_uint32(term addr_tuple)
 term inet_make_addr4(uint32_t addr, Heap *heap)
 {
     term result = term_alloc_tuple(4, heap);
-    term_put_tuple_element(result, 0, term_from_int32((addr >> 24) & 0xFF));
-    term_put_tuple_element(result, 1, term_from_int32((addr >> 16) & 0xFF));
-    term_put_tuple_element(result, 2, term_from_int32((addr >> 8) & 0xFF));
-    term_put_tuple_element(result, 3, term_from_int32(addr & 0xFF));
+    term_put_tuple_element(result, 0, term_from_int11((addr >> 24) & 0xFF));
+    term_put_tuple_element(result, 1, term_from_int11((addr >> 16) & 0xFF));
+    term_put_tuple_element(result, 2, term_from_int11((addr >> 8) & 0xFF));
+    term_put_tuple_element(result, 3, term_from_int11(addr & 0xFF));
     return result;
 }

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -622,7 +622,7 @@ term module_get_type_by_index(const Module *mod, int type_index, Context *ctx)
             }
             term type_tuple = term_alloc_tuple(2, &ctx->heap);
             term_put_tuple_element(type_tuple, 0, globalcontext_make_atom(ctx->global, ATOM_STR("\xE", "t_bs_matchable")));
-            term_put_tuple_element(type_tuple, 1, term_from_int32(unit));
+            term_put_tuple_element(type_tuple, 1, term_from_int11(unit));
             return type_tuple;
 
         case BEAM_TYPE_CONS:

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1687,13 +1687,13 @@ static term build_datetime_from_tm(Context *ctx, struct tm *broken_down_time)
     term time_tuple = term_alloc_tuple(3, &ctx->heap);
     term date_time_tuple = term_alloc_tuple(2, &ctx->heap);
 
-    term_put_tuple_element(date_tuple, 0, term_from_int32(1900 + broken_down_time->tm_year));
-    term_put_tuple_element(date_tuple, 1, term_from_int32(broken_down_time->tm_mon + 1));
-    term_put_tuple_element(date_tuple, 2, term_from_int32(broken_down_time->tm_mday));
+    term_put_tuple_element(date_tuple, 0, term_from_int11(1900 + broken_down_time->tm_year));
+    term_put_tuple_element(date_tuple, 1, term_from_int11(broken_down_time->tm_mon + 1));
+    term_put_tuple_element(date_tuple, 2, term_from_int11(broken_down_time->tm_mday));
 
-    term_put_tuple_element(time_tuple, 0, term_from_int32(broken_down_time->tm_hour));
-    term_put_tuple_element(time_tuple, 1, term_from_int32(broken_down_time->tm_min));
-    term_put_tuple_element(time_tuple, 2, term_from_int32(broken_down_time->tm_sec));
+    term_put_tuple_element(time_tuple, 0, term_from_int11(broken_down_time->tm_hour));
+    term_put_tuple_element(time_tuple, 1, term_from_int11(broken_down_time->tm_min));
+    term_put_tuple_element(time_tuple, 2, term_from_int11(broken_down_time->tm_sec));
 
     term_put_tuple_element(date_time_tuple, 0, date_tuple);
     term_put_tuple_element(date_time_tuple, 1, time_tuple);
@@ -1772,9 +1772,9 @@ term nif_erlang_timestamp_0(Context *ctx, int argc, term argv[])
     struct timespec ts;
     sys_time(&ts);
 
-    term_put_tuple_element(timestamp_tuple, 0, term_from_int32(ts.tv_sec / 1000000));
-    term_put_tuple_element(timestamp_tuple, 1, term_from_int32(ts.tv_sec % 1000000));
-    term_put_tuple_element(timestamp_tuple, 2, term_from_int32(ts.tv_nsec / 1000));
+    term_put_tuple_element(timestamp_tuple, 0, term_from_int28(ts.tv_sec / 1000000));
+    term_put_tuple_element(timestamp_tuple, 1, term_from_int28(ts.tv_sec % 1000000));
+    term_put_tuple_element(timestamp_tuple, 2, term_from_int28(ts.tv_nsec / 1000));
 
     return timestamp_tuple;
 }
@@ -2943,16 +2943,16 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
     }
 
     if (key == PROCESS_COUNT_ATOM) {
-        return term_from_int32(nif_num_processes(ctx->global));
+        return term_from_int28(nif_num_processes(ctx->global));
     }
     if (key == PORT_COUNT_ATOM) {
-        return term_from_int32(nif_num_ports(ctx->global));
+        return term_from_int28(nif_num_ports(ctx->global));
     }
     if (key == ATOM_COUNT_ATOM) {
-        return term_from_int32(atom_table_count(ctx->global->atom_table));
+        return term_from_int28(atom_table_count(ctx->global->atom_table));
     }
     if (key == WORDSIZE_ATOM) {
-        return term_from_int32(TERM_BYTES);
+        return term_from_int28(TERM_BYTES);
     }
     if (key == MACHINE_ATOM) {
         if (memory_ensure_free_opt(ctx, (sizeof("ATOM") - 1) * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
@@ -2961,7 +2961,7 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
         return term_from_string((const uint8_t *) "ATOM", sizeof("ATOM") - 1, &ctx->heap);
     }
     if (key == AVM_FLOATSIZE_ATOM) {
-        return term_from_int32(sizeof(avm_float_t));
+        return term_from_int11(sizeof(avm_float_t));
     }
     if (key == SYSTEM_ARCHITECTURE_ATOM) {
         char buf[128];
@@ -3008,16 +3008,16 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
     }
     if (key == SCHEDULERS_ATOM) {
 #ifndef AVM_NO_SMP
-        return term_from_int32(smp_get_online_processors());
+        return term_from_int11(smp_get_online_processors());
 #else
-        return term_from_int32(1);
+        return term_from_int11(1);
 #endif
     }
     if (key == SCHEDULERS_ONLINE_ATOM) {
 #ifndef AVM_NO_SMP
-        return term_from_int32(ctx->global->online_schedulers);
+        return term_from_int11(ctx->global->online_schedulers);
 #else
-        return term_from_int32(1);
+        return term_from_int11(1);
 #endif
     }
     if (key == EMU_FLAVOR_ATOM) {
@@ -3055,7 +3055,7 @@ static term nif_erlang_system_flag(Context *ctx, int argc, term argv[])
         }
         while (!ATOMIC_COMPARE_EXCHANGE_WEAK_INT(&ctx->global->online_schedulers, &old_value, new_value)) {
         };
-        return term_from_int32(old_value);
+        return term_from_int11(old_value);
     }
 #else
     UNUSED(value);
@@ -3802,7 +3802,7 @@ static term nif_erts_debug_flat_size(Context *ctx, int argc, term argv[])
 
     terms_count = memory_estimate_usage(argv[0]);
 
-    return term_from_int32(terms_count);
+    return term_from_int28(terms_count);
 }
 
 static term make_list_from_ascii_buf(const uint8_t *buf, size_t len, Context *ctx)

--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -99,7 +99,7 @@ term port_heap_create_error_tuple(Heap *heap, term reason)
 
 term port_heap_create_sys_error_tuple(Heap *heap, term syscall, int errno)
 {
-    term reason = port_heap_create_tuple2(heap, syscall, term_from_int32(errno));
+    term reason = port_heap_create_tuple2(heap, syscall, term_from_int(errno));
     return port_heap_create_error_tuple(heap, reason);
 }
 

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -948,12 +948,25 @@ static inline term term_from_int11(int16_t value)
 }
 
 /**
+ * @brief Term from int28
+ *
+ * @details Returns a term for a given 28 bits integer value.
+ * @param value the value that will be converted to a term.
+ * @return a term that encapsulates the integer value.
+ */
+static inline term term_from_int28(int32_t value)
+{
+    return (value << 4) | TERM_INTEGER_TAG;
+}
+
+/**
  * @brief Term from int32
  *
  * @details Returns a term for a given 32 bits integer value.
  * @param value the value that will be converted to a term.
  * @return a term that encapsulates the integer value.
  */
+static inline term term_from_int32(int32_t value) __attribute__ ((deprecated ("term_from_int32 is unsafe and will be removed")));
 static inline term term_from_int32(int32_t value)
 {
 #if TERM_BITS == 32
@@ -975,6 +988,7 @@ static inline term term_from_int32(int32_t value)
 #endif
 }
 
+static inline term term_from_int64(int64_t value) __attribute__ ((deprecated ("term_from_int64 is unsafe and will be removed")));
 static inline term term_from_int64(int64_t value)
 {
 #if TERM_BITS == 32

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -143,10 +143,10 @@ uint32_t socket_tuple_to_addr(term addr_tuple)
 term socket_ctx_tuple_from_addr(Context *ctx, uint32_t addr)
 {
     term terms[4];
-    terms[0] = term_from_int32((addr >> 24) & 0xFF);
-    terms[1] = term_from_int32((addr >> 16) & 0xFF);
-    terms[2] = term_from_int32((addr >> 8) & 0xFF);
-    terms[3] = term_from_int32(addr & 0xFF);
+    terms[0] = term_from_int11((addr >> 24) & 0xFF);
+    terms[1] = term_from_int11((addr >> 16) & 0xFF);
+    terms[2] = term_from_int11((addr >> 8) & 0xFF);
+    terms[3] = term_from_int11(addr & 0xFF);
 
     return port_create_tuple_n(ctx, 4, terms);
 }
@@ -154,10 +154,10 @@ term socket_ctx_tuple_from_addr(Context *ctx, uint32_t addr)
 term socket_heap_tuple_from_addr(Heap *heap, uint32_t addr)
 {
     term terms[4];
-    terms[0] = term_from_int32((addr >> 24) & 0xFF);
-    terms[1] = term_from_int32((addr >> 16) & 0xFF);
-    terms[2] = term_from_int32((addr >> 8) & 0xFF);
-    terms[3] = term_from_int32(addr & 0xFF);
+    terms[0] = term_from_int11((addr >> 24) & 0xFF);
+    terms[1] = term_from_int11((addr >> 16) & 0xFF);
+    terms[2] = term_from_int11((addr >> 8) & 0xFF);
+    terms[3] = term_from_int11(addr & 0xFF);
 
     return port_heap_create_tuple_n(heap, 4, terms);
 }
@@ -686,7 +686,7 @@ term socket_driver_do_sendto(Context *ctx, term dest_address, term dest_port, te
         return port_create_sys_error_tuple(ctx, SENDTO_ATOM, errno);
     } else {
         TRACE("socket_driver_do_sendto: sent data with len: %li, to: %i, port: %i\n", len, ntohl(addr.sin_addr.s_addr), ntohs(addr.sin_port));
-        term sent_atom = term_from_int32(sent_data);
+        term sent_atom = term_from_int(sent_data);
         return port_create_ok_tuple(ctx, sent_atom);
     }
 }
@@ -892,7 +892,7 @@ static EventListener *active_recvfrom_callback(GlobalContext *glb, EventListener
         }
         term pid = socket_data->controlling_process;
         term addr = socket_heap_tuple_from_addr(&heap, htonl(clientaddr.sin_addr.s_addr));
-        term port = term_from_int32(htons(clientaddr.sin_port));
+        term port = term_from_int28(htons(clientaddr.sin_port));
         term packet = socket_create_packet_term(buf, len, socket_data->binary, &heap, glb);
         term socket_pid = term_port_from_local_process_id(ctx->process_id);
         term socket_wrapper = create_udp_socket_wrapper(socket_pid, &heap, glb);
@@ -961,7 +961,7 @@ static EventListener *passive_recvfrom_callback(GlobalContext *glb, EventListene
         term pid = listener->pid;
         term ref = term_from_ref_ticks(listener->ref_ticks, &heap);
         term addr = socket_heap_tuple_from_addr(&heap, htonl(clientaddr.sin_addr.s_addr));
-        term port = term_from_int32(htons(clientaddr.sin_port));
+        term port = term_from_int28(htons(clientaddr.sin_port));
         term packet = socket_create_packet_term(buf, len, socket_data->binary, &heap, glb);
         term addr_port_packet = port_heap_create_tuple3(&heap, addr, port, packet);
         term payload = port_heap_create_ok_tuple(&heap, addr_port_packet);


### PR DESCRIPTION
Continuation of:
- #1896 

Introduce `term_from_int28` that is always safe and update usage in main library and generic_unix port

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
