### PR TITLE
JIT: factorize tail calls to reduce binary size

### DIFF
--- a/libs/jit/src/jit_aarch64.erl
+++ b/libs/jit/src/jit_aarch64.erl
@@ -38,6 +38,7 @@
     return_if_not_equal_to_ctx/2,
     jump_to_label/2,
     jump_to_continuation/2,
+    jump_to_offset/2,
     if_block/3,
     if_else_block/4,
     shift_right/3,
@@ -530,6 +531,13 @@ jump_to_label(
             Stream1 = StreamModule:append(Stream0, I1),
             State#state{stream = Stream1, branches = [Reloc | AccBranches]}
     end.
+
+jump_to_offset(#state{stream_module = StreamModule, stream = Stream0} = State, TargetOffset) ->
+    Offset = StreamModule:offset(Stream0),
+    Rel = TargetOffset - Offset,
+    I1 = jit_aarch64_asm:b(Rel),
+    Stream1 = StreamModule:append(Stream0, I1),
+    State#state{stream = Stream1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Jump to a continuation address stored in a register.

--- a/libs/jit/src/jit_armv6m.erl
+++ b/libs/jit/src/jit_armv6m.erl
@@ -38,6 +38,7 @@
     return_if_not_equal_to_ctx/2,
     jump_to_label/2,
     jump_to_continuation/2,
+    jump_to_offset/2,
     if_block/3,
     if_else_block/4,
     shift_right/3,
@@ -726,6 +727,12 @@ jump_to_label(
     Stream1 = StreamModule:append(Stream0, CodeBlock),
     State1#state{stream = Stream1}.
 
+jump_to_offset(#state{stream_module = StreamModule, stream = Stream0} = State, TargetOffset) ->
+    Offset = StreamModule:offset(Stream0),
+    CodeBlock = branch_to_offset_code(State, Offset, TargetOffset),
+    Stream1 = StreamModule:append(Stream0, CodeBlock),
+    State#state{stream = Stream1}.
+
 %%-----------------------------------------------------------------------------
 %% @doc Jump to address in continuation pointer register
 %% The continuation points to a function prologue, so we need to compute
@@ -788,15 +795,14 @@ jump_to_continuation(
     % Free all registers as this is a terminal instruction
     State1#state{stream = Stream2, available_regs = ?AVAILABLE_REGS, used_regs = []}.
 
-branch_to_label_code(State, Offset, Label, {Label, LabelOffset}) when
-    LabelOffset - Offset =< 2050, LabelOffset - Offset >= -2044
+branch_to_offset_code(_State, Offset, TargetOffset) when
+    TargetOffset - Offset =< 2050, TargetOffset - Offset >= -2044
 ->
     % Near branch: use direct B instruction
-    Rel = LabelOffset - Offset,
-    CodeBlock = jit_armv6m_asm:b(Rel),
-    {State, CodeBlock};
-branch_to_label_code(
-    #state{available_regs = [TempReg | _]} = State0, Offset, Label, {Label, LabelOffset}
+    Rel = TargetOffset - Offset,
+    jit_armv6m_asm:b(Rel);
+branch_to_offset_code(
+    #state{available_regs = [TempReg | _]}, Offset, TargetOffset
 ) ->
     % Far branch: use register-based sequence, need temporary register
     if
@@ -807,19 +813,22 @@ branch_to_label_code(
             I3 = jit_armv6m_asm:bx(TempReg),
             % Unaligned : need nop
             I4 = jit_armv6m_asm:nop(),
-            LiteralValue = LabelOffset - Offset - 5,
+            LiteralValue = TargetOffset - Offset - 5,
             I5 = <<LiteralValue:32/little>>,
-            CodeBlock = <<I1/binary, I2/binary, I3/binary, I4/binary, I5/binary>>;
+            <<I1/binary, I2/binary, I3/binary, I4/binary, I5/binary>>;
         true ->
             % Unaligned
             I1 = jit_armv6m_asm:ldr(TempReg, {pc, 4}),
             I2 = jit_armv6m_asm:add(TempReg, pc),
             I3 = jit_armv6m_asm:bx(TempReg),
-            LiteralValue = LabelOffset - Offset - 5,
+            LiteralValue = TargetOffset - Offset - 5,
             I4 = <<LiteralValue:32/little>>,
-            CodeBlock = <<I1/binary, I2/binary, I3/binary, I4/binary>>
-    end,
-    {State0, CodeBlock};
+            <<I1/binary, I2/binary, I3/binary, I4/binary>>
+    end.
+
+branch_to_label_code(State, Offset, Label, {Label, LabelOffset}) ->
+    CodeBlock = branch_to_offset_code(State, Offset, LabelOffset),
+    {State, CodeBlock};
 branch_to_label_code(
     #state{available_regs = [TempReg | _], branches = Branches} = State0, Offset, Label, false
 ) ->

--- a/libs/jit/src/jit_x86_64.erl
+++ b/libs/jit/src/jit_x86_64.erl
@@ -38,6 +38,7 @@
     return_if_not_equal_to_ctx/2,
     jump_to_label/2,
     jump_to_continuation/2,
+    jump_to_offset/2,
     if_block/3,
     if_else_block/4,
     shift_right/3,
@@ -523,6 +524,13 @@ jump_to_label(
             Stream1 = StreamModule:append(Stream0, I1),
             State#state{stream = Stream1, branches = [Reloc | AccBranches]}
     end.
+
+jump_to_offset(#state{stream_module = StreamModule, stream = Stream0} = State, TargetOffset) ->
+    Offset = StreamModule:offset(Stream0),
+    RelOffset = TargetOffset - Offset,
+    I1 = jit_x86_64_asm:jmp(RelOffset),
+    Stream1 = StreamModule:append(Stream0, I1),
+    State#state{stream = Stream1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Jump to a continuation address stored in a register.

--- a/tests/libs/jit/jit_tests.erl
+++ b/tests/libs/jit/jit_tests.erl
@@ -62,6 +62,44 @@
     <<0, 0, 0, 3, 0, 0, 0, 2, 15, 255, 0, 16>>
 ).
 
+% Code chunk from bool_min2.erl - tests tail-call cache optimization
+% This module has multiple return opcodes which trigger the tail-call cache:
+% - The first return creates a cached implementation
+% - Subsequent returns use jump_to_offset to jump back to the cached code
+-define(CODE_CHUNK_3,
+    <<16#00, 16#00, 16#00, 16#10, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#B2, 16#00,
+        16#00, 16#00, 16#09, 16#00, 16#00, 16#00, 16#03, 16#01, 16#10, 16#99, 16#10, 16#02, 16#12,
+        16#22, 16#00, 16#01, 16#20, 16#0C, 16#10, 16#00, 16#AC, 16#17, 16#10, 16#04, 16#40, 16#32,
+        16#23, 16#40, 16#32, 16#33, 16#40, 16#32, 16#13, 16#40, 16#42, 16#43, 16#40, 16#32, 16#03,
+        16#99, 16#20, 16#04, 16#50, 16#45, 16#04, 16#10, 16#65, 16#40, 16#03, 16#04, 16#40, 16#42,
+        16#23, 16#40, 16#42, 16#33, 16#40, 16#32, 16#13, 16#40, 16#42, 16#43, 16#40, 16#42, 16#03,
+        16#99, 16#30, 16#04, 16#50, 16#45, 16#04, 16#10, 16#65, 16#99, 16#20, 16#7D, 16#05, 16#10,
+        16#00, 16#57, 16#04, 16#10, 16#57, 16#03, 16#10, 16#03, 16#12, 16#10, 16#13, 16#01, 16#30,
+        16#99, 16#40, 16#02, 16#12, 16#72, 16#50, 16#01, 16#40, 16#99, 16#50, 16#0B, 16#05, 16#10,
+        16#03, 16#13, 16#03, 16#0B, 16#05, 16#10, 16#23, 16#33, 16#13, 16#0B, 16#05, 16#20, 16#57,
+        16#03, 16#20, 16#57, 16#13, 16#20, 16#03, 16#0A, 16#05, 16#30, 16#43, 16#13, 16#0B, 16#05,
+        16#20, 16#57, 16#03, 16#20, 16#57, 16#13, 16#20, 16#03, 16#13, 16#01, 16#50, 16#99, 16#60,
+        16#02, 16#12, 16#B2, 16#10, 16#01, 16#60, 16#3B, 16#03, 16#55, 16#17, 16#40, 16#32, 16#85,
+        16#42, 16#75, 16#01, 16#70, 16#40, 16#11, 16#03, 16#13, 16#01, 16#80, 16#40, 16#01, 16#03,
+        16#13, 16#03>>
+).
+-define(ATU8_CHUNK_3,
+    <<16#FF, 16#FF, 16#FF, 16#F5, 16#90, 16#62, 16#6F, 16#6F, 16#6C, 16#5F, 16#6D, 16#69, 16#6E,
+        16#32, 16#50, 16#73, 16#74, 16#61, 16#72, 16#74, 16#50, 16#66, 16#61, 16#6C, 16#73, 16#65,
+        16#40, 16#74, 16#72, 16#75, 16#65, 16#60, 16#65, 16#72, 16#6C, 16#61, 16#6E, 16#67, 16#10,
+        16#2B, 16#10, 16#66, 16#30, 16#61, 16#6E, 16#64, 16#20, 16#6F, 16#72, 16#30, 16#6E, 16#6F,
+        16#74, 16#B0, 16#6F, 16#6E, 16#65, 16#5F, 16#69, 16#66, 16#5F, 16#74, 16#72, 16#75, 16#65>>
+).
+-define(TYPE_CHUNK_3,
+    <<16#00, 16#00, 16#00, 16#03, 16#00, 16#00, 16#00, 16#03, 16#0F, 16#FF, 16#30, 16#20, 16#00,
+        16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00,
+        16#00, 16#01, 16#00, 16#01>>
+).
+-define(LINE_CHUNK_3,
+    <<16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#07, 16#00,
+        16#00, 16#00, 16#06, 16#00, 16#00, 16#00, 16#00, 16#41, 16#51, 16#61, 16#81, 16#91, 16#B1>>
+).
+
 compile_minimal_x86_64_test() ->
     Stream0 = jit_stream_binary:new(0),
     <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = ?CODE_CHUNK_0,
@@ -105,24 +143,33 @@ check_labels_table0(N, <<N:16, _Offset:32, Rest/binary>>) -> check_labels_table0
 
 check_lines_table(<<LinesCount:16, _Lines:(LinesCount * 6)/binary>>) -> ok.
 
-term_to_int_verify_is_match_state_typed_optimization_x86_64_test() ->
-    % Compile CODE_CHUNK_1 which contains a typed register for term_to_int optimization
-    Stream0 = jit_stream_binary:new(0),
-    <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = ?CODE_CHUNK_1,
-    Stream1 = jit_stream_binary:append(
-        Stream0, jit:beam_chunk_header(LabelsCount, ?JIT_ARCH_X86_64, ?JIT_VARIANT_PIC)
-    ),
-    Stream2 = jit_x86_64:new(?JIT_VARIANT_PIC, jit_stream_binary, Stream1),
+backend_to_arch(jit_x86_64) -> ?JIT_ARCH_X86_64;
+backend_to_arch(jit_aarch64) -> ?JIT_ARCH_AARCH64;
+backend_to_arch(jit_armv6m) -> ?JIT_ARCH_ARMV6M.
 
-    AtomResolver = jit_precompile:atom_resolver(?ATU8_CHUNK_1),
+compile_stream_for_backend(Backend, CodeChunk, AtomChunk, TypeChunk) ->
+    Stream0 = jit_stream_binary:new(0),
+    <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = CodeChunk,
+    Arch = backend_to_arch(Backend),
+    Stream1 = jit_stream_binary:append(
+        Stream0, jit:beam_chunk_header(LabelsCount, Arch, ?JIT_VARIANT_PIC)
+    ),
+    Stream2 = Backend:new(?JIT_VARIANT_PIC, jit_stream_binary, Stream1),
+
+    AtomResolver = jit_precompile:atom_resolver(AtomChunk),
     LiteralResolver = fun(_) -> test_literal end,
-    TypeResolver = jit_precompile:type_resolver(?TYPE_CHUNK_1),
+    TypeResolver = jit_precompile:type_resolver(TypeChunk),
 
     % Compile with typed register support
-    {_LabelsCount, Stream3} = jit:compile(
-        ?CODE_CHUNK_1, AtomResolver, LiteralResolver, TypeResolver, jit_x86_64, Stream2
+    {LabelsCount, Stream3} = jit:compile(
+        CodeChunk, AtomResolver, LiteralResolver, TypeResolver, Backend, Stream2
     ),
-    CompiledCode = jit_x86_64:stream(Stream3),
+    Backend:stream(Stream3).
+
+term_to_int_verify_is_match_state_typed_optimization_x86_64_test() ->
+    CompiledCode = compile_stream_for_backend(
+        jit_x86_64, ?CODE_CHUNK_1, ?ATU8_CHUNK_1, ?TYPE_CHUNK_1
+    ),
 
     % Check the reading of x[1] is immediatly followed by a shift right.
     % 15c:	4c 8b 5f 38          	mov    0x38(%rdi),%r11
@@ -183,23 +230,9 @@ term_to_int_verify_is_match_state_typed_optimization_x86_64_test() ->
     ok.
 
 verify_is_function_typed_optimization_x86_64_test() ->
-    % Compile CODE_CHUNK_1 which contains a typed register for term_to_int optimization
-    Stream0 = jit_stream_binary:new(0),
-    <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = ?CODE_CHUNK_2,
-    Stream1 = jit_stream_binary:append(
-        Stream0, jit:beam_chunk_header(LabelsCount, ?JIT_ARCH_X86_64, ?JIT_VARIANT_PIC)
+    CompiledCode = compile_stream_for_backend(
+        jit_x86_64, ?CODE_CHUNK_2, ?ATU8_CHUNK_2, ?TYPE_CHUNK_2
     ),
-    Stream2 = jit_x86_64:new(?JIT_VARIANT_PIC, jit_stream_binary, Stream1),
-
-    AtomResolver = jit_precompile:atom_resolver(?ATU8_CHUNK_2),
-    LiteralResolver = fun(_) -> test_literal end,
-    TypeResolver = jit_precompile:type_resolver(?TYPE_CHUNK_2),
-
-    % Compile with typed register support
-    {_LabelsCount, Stream3} = jit:compile(
-        ?CODE_CHUNK_2, AtomResolver, LiteralResolver, TypeResolver, jit_x86_64, Stream2
-    ),
-    CompiledCode = jit_x86_64:stream(Stream3),
 
     % Check that call to allocate is directly followed by the building the cp
     % for call
@@ -247,6 +280,50 @@ verify_is_function_typed_optimization_x86_64_test() ->
             CompiledCode,
             <<16#48, 16#8b, 16#42, 16#10, 16#ff, 16#e0, 16#48, 16#8b, 16#47, 16#38, 16#4c, 16#8b,
                 16#1e, 16#45, 16#8b, 16#1b, 16#49, 16#c1, 16#e3, 16#18>>
+        )
+    ),
+    ok.
+
+tail_call_cache_armv6m_test() ->
+    CompiledCode = compile_stream_for_backend(
+        jit_armv6m, ?CODE_CHUNK_3, ?ATU8_CHUNK_3, ?TYPE_CHUNK_3
+    ),
+
+    % Check that we have the following pattern:
+    %   8c:	278c      	movs	r7, #140	@ 0x8c
+    %   8e:	6816      	ldr	r6, [r2, #0]
+    %   90:	463a      	mov	r2, r7
+    %   92:	4b01      	ldr	r3, [pc, #4]	@ (0x98)
+    %   94:	e002      	b.n	0x9c
+    %   96:	0000      	movs	r0, r0
+    %   98:	01cb      	lsls	r3, r1, #7
+    %   9a:	0000      	movs	r0, r0
+    %   9c:	9f05      	ldr	r7, [sp, #20]
+    %   9e:	9605      	str	r6, [sp, #20]
+    %   a0:	46be      	mov	lr, r7
+
+    % Check for the first return implementation (call_primitive_last for PRIM_RETURN)
+    % Pattern: movs r7, #140 / ldr r6, [r2, #0] / mov r2, r7
+    % 278c 6816 463a
+    ?assertMatch(
+        {_, _},
+        binary:match(CompiledCode, <<16#278c:16/little, 16#6816:16/little, 16#463a:16/little>>)
+    ),
+
+    %   3f0:	4f00      	ldr	r7, [pc, #0]	@ (0x3f4)
+    %   3f2:	e001      	b.n	0x3f8
+    %   3f4:	03f0      	lsls	r0, r6, #15
+    %   3f6:	0000      	movs	r0, r0
+    %   3f8:	e648      	b.n	0x8c
+
+    % Check for tail-call cache jump: ldr r7, [pc, #0] followed by b.n (backward branch)
+    % Pattern: 4f00 e6f5 (ldr r7, [pc, #0] / b.n 0x8c)
+    ?assertMatch(
+        {_, _},
+        binary:match(
+            CompiledCode,
+            <<16#4f00:16/little, 16#e001:16/little, 16#03f0:16/little, 0:16/little,
+                16#e648:16/little>>
         )
     ),
     ok.


### PR DESCRIPTION
Continuation of #1900 

Use a cache to remember tail calls that were already implemented and
replace further implementations of the same tail call with a jump to the
previous implementation.

Coverage shows that all cases are covered in `libs/estdlib/src` and `libs/jit/src`:

- `OP_RETURN`: 50 misses, 1735 hits (97%)
- `OP_JUMP/OP_CALL_LAST/OP_CALL_ONLY`: 656 misses, 389 hits (37%)
- `OP_CALL_LAST`: 220 misses, 206 hits (48%)
- `OP_FUNC_INFO`: 58 misses, 1619 hits (97%)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
