### PR TITLE
JIT (aarch64): fix encoding of illegal orr instructions

### DIFF
--- a/tests/libs/jit/jit_aarch64_asm_tests.erl
+++ b/tests/libs/jit/jit_aarch64_asm_tests.erl
@@ -356,7 +356,13 @@ orr_test_() ->
         ),
 
         %% Test orr with unencodable immediate
-        ?_assertError({unencodable_immediate, 16#123456}, jit_aarch64_asm:orr(r0, r0, 16#123456))
+        ?_assertError({unencodable_immediate, 16#123456}, jit_aarch64_asm:orr(r0, r0, 16#123456)),
+
+        %% Test orr with -1 (all ones) - should be unencodable as bitmask immediate
+        ?_assertError({unencodable_immediate, -1}, jit_aarch64_asm:orr(r8, xzr, -1)),
+
+        %% Test orr with 0 (all zeros) - should be unencodable as bitmask immediate
+        ?_assertError({unencodable_immediate, 0}, jit_aarch64_asm:orr(r8, xzr, 0))
     ].
 
 str_test_() ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
