### PR TITLE
intn: fix big integer `0x80000000` to `int64` conversion

### DIFF
--- a/src/libAtomVM/intn.h
+++ b/src/libAtomVM/intn.h
@@ -191,7 +191,7 @@ static inline int64_t intn_2_digits_to_int64(
         case 0:
             return 0;
         case 1:
-            return int32_cond_neg_unsigned(sign == IntNNegativeInteger, num[0]);
+            return int64_cond_neg_unsigned(sign == IntNNegativeInteger, num[0]);
         case 2: {
             uint64_t utmp = intn_digits_to_u64(num);
             return int64_cond_neg_unsigned(sign == IntNNegativeInteger, utmp);

--- a/tests/erlang_tests/bigint.erl
+++ b/tests/erlang_tests/bigint.erl
@@ -1642,6 +1642,14 @@ test_band() ->
         ?MODULE:id(?MODULE:id(Pattern13) band ?MODULE:id(Pattern14)), 16
     ),
 
+    Pattern15 = erlang:binary_to_integer(?MODULE:id(<<"80008000">>), 16),
+    Pattern16 = erlang:binary_to_integer(
+        ?MODULE:id(<<"7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF">>), 16
+    ),
+    <<"80008000">> = erlang:integer_to_binary(
+        ?MODULE:id(?MODULE:id(Pattern15) band ?MODULE:id(Pattern16)), 16
+    ),
+
     0.
 
 test_bxor() ->


### PR DESCRIPTION
A negative sign was appearing out of the blue.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
