### PR TITLE
Bump default eunit timeout from 30s to 60s to reduce CI flappiness

### DIFF
--- a/libs/etest/src/eunit.erl
+++ b/libs/etest/src/eunit.erl
@@ -31,7 +31,7 @@
     test/2
 ]).
 
--define(DEFAULT_TIMEOUT, 30000).
+-define(DEFAULT_TIMEOUT, 60000).
 
 -type option() :: exact_execution | {exact_execution, boolean()}.
 -type test() ::


### PR DESCRIPTION
The following run failed with a timeout error:
https://github.com/atomvm/AtomVM/actions/runs/18611684516/job/53070676653?pr=1907#step:23:179

This test should execute in few ms, but GitHub Actions was stuck for 50 seconds. Bump the timeout from 30s to 60s to reduce the likelihood of having this failure again.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
