### PR TITLE
bigint: fix crash in externalterm due to uninitialized value in `SMALL_BIG_EXT`

### DIFF
--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -574,12 +574,12 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
             uint8_t sign_byte = external_term_buf[2];
             const uint8_t *int_bytes = external_term_buf + 3;
             bool is_negative = sign_byte != 0x00;
+            *eterm_size = SMALL_BIG_EXT_BASE_SIZE + int_len;
 
             if (int_len <= 8) {
                 avm_uint64_t unsigned_value = read_bytes(int_bytes, int_len);
                 if (!uint64_does_overflow_int64(unsigned_value, is_negative)) {
                     avm_int64_t value = int64_cond_neg_unsigned(is_negative, unsigned_value);
-                    *eterm_size = SMALL_BIG_EXT_BASE_SIZE + int_len;
                     return term_make_maybe_boxed_int64(value, heap);
                 }
             }

--- a/tests/erlang_tests/bigint.erl
+++ b/tests/erlang_tests/bigint.erl
@@ -1784,6 +1784,25 @@ test_big_literals() ->
         )
     ),
 
+    11778076840785789394209099624956350279955 = list_sum(
+        ?MODULE:id(
+            [
+                281532703474492501731626716290297310019,
+                93306314956976059883019272415387330003,
+                214607399141421462250690668733314471655,
+                278088529617771354220434498525634157025,
+                334122505095354375669507689190891893146,
+                97282639123841533893464348356498690111,
+                139101277621645745787465467869309404885,
+                336308780620891755582747031067683052383,
+                304507291449018005568388967257032414400,
+                89470201992235757207956459849942467761
+            ]
+        ),
+        1,
+        0
+    ),
+
     0.
 
 % This function will never be called, we leave this to check if we are able to parse the BEAM file
@@ -1795,6 +1814,11 @@ lit_ovf1() ->
 % even if this integer exceeds maximum integer capacity.
 lit_ovf2() ->
     ?MODULE:id(-16#10000000000000000000000000000000000000000000000000000000000000000).
+
+list_sum([], _Index, Acc) ->
+    Acc;
+list_sum([N | Tail], Index, Acc) ->
+    list_sum(Tail, Index + 1, N * Index + Acc).
 
 test_is_integer() ->
     MaxPatternBin = <<"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF">>,


### PR DESCRIPTION
eterm_size wasn't always initialized, causing a crash while parsing external terms such as `[bigint1, bigint2, ...]`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
