### PR TITLE
CI: build-and-test.yaml: remove valgrind-suppressions.sup

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -324,7 +324,15 @@ jobs:
       run: sudo apt update -y
 
     - name: "Install deps"
+      if: matrix.container != ''
       run: sudo apt install -y ${{ matrix.compiler_pkgs}} cmake gperf zlib1g-dev doxygen valgrind libmbedtls-dev
+
+    - name: "Install deps"
+      if: matrix.container == ''
+      run: |
+        sudo apt install -y ${{ matrix.compiler_pkgs}} cmake gperf zlib1g-dev doxygen libmbedtls-dev libc6-dbg
+        # Get a more recent valgrind
+        sudo snap install valgrind --classic
 
     - name: "Checkout repo"
       uses: actions/checkout@v4
@@ -391,7 +399,7 @@ jobs:
       working-directory: build
       run: |
         ulimit -c unlimited
-        valgrind --suppressions=../tests/valgrind-suppressions.sup --error-exitcode=1 ./tests/test-erlang -s prime_smp
+        valgrind --error-exitcode=1 ./tests/test-erlang -s prime_smp
         ./tests/test-erlang -s prime_smp
 
     - name: "Test: test-enif"
@@ -429,14 +437,14 @@ jobs:
       run: |
         ulimit -c unlimited
         ./src/AtomVM ./tests/libs/etest/test_etest.avm
-        valgrind --suppressions=../tests/valgrind-suppressions.sup ./src/AtomVM ./tests/libs/etest/test_etest.avm
+        valgrind ./src/AtomVM ./tests/libs/etest/test_etest.avm
 
     - name: "Test: test_estdlib.avm"
       timeout-minutes: 30
       working-directory: build
       run: |
         ulimit -c unlimited
-        valgrind --suppressions=../tests/valgrind-suppressions.sup --error-exitcode=1 ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
         ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
 
     - name: "Test: test_eavmlib.avm"
@@ -444,7 +452,7 @@ jobs:
       working-directory: build
       run: |
         ulimit -c unlimited
-        valgrind --suppressions=../tests/valgrind-suppressions.sup --error-exitcode=1 ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
+        valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
         ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
 
     - name: "Test: test_jit.avm"
@@ -461,7 +469,7 @@ jobs:
       working-directory: build
       run: |
         ulimit -c unlimited
-        valgrind --suppressions=../tests/valgrind-suppressions.sup --error-exitcode=1 ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
+        valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
         ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
 
     - name: "Test: Tests.avm (Elixir)"
@@ -471,7 +479,7 @@ jobs:
         ulimit -c unlimited
         if command -v elixirc >/dev/null 2>&1 && command -v elixir >/dev/null 2>&1
         then
-          valgrind --suppressions=../tests/valgrind-suppressions.sup --error-exitcode=1 ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
+          valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
           ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
         else
           echo "Elixir not installed, skipping Elixir tests"

--- a/tests/valgrind-suppressions.sup
+++ b/tests/valgrind-suppressions.sup
@@ -1,7 +1,0 @@
-{
-   bogus_memcpy_overlap
-   Memcheck:Overlap
-   fun:__memcpy_chk
-   fun:memmove
-   fun:intn_to_string
-}


### PR DESCRIPTION
When using a recent valgrind suppressions are not required anymore Recent valgrind doesn't detect the false positive that has been disabled with suppressions.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
