### PR TITLE
JIT: Optimize memory usage by rewriting jump table immediately

### DIFF
--- a/libs/estdlib/src/code_server.erl
+++ b/libs/estdlib/src/code_server.erl
@@ -152,7 +152,7 @@ set_native_code(_Module, _LabelsCount, _Stream) ->
 load(Module) ->
     case erlang:system_info(emu_flavor) of
         jit ->
-            % atomvm_heap_growth, fibonacci divides compilation time by two
+            % atomvm_heap_growth, fibonacci reduces compilation time
             {Pid, Ref} = spawn_opt(
                 fun() ->
                     try


### PR DESCRIPTION
Continuation of:
- #1900 
- #1901 
- #1903 
- #1909 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
