### PR TITLE
bif.c: remove `args_to_bigint`

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -88,8 +88,8 @@ _Static_assert(
 static term make_bigint(Context *ctx, uint32_t fail_label, uint32_t live,
     const intn_digit_t bigres[], size_t bigres_len, intn_integer_sign_t sign);
 
-static void term_to_bigint(term arg1, intn_digit_t *tmp_buf1, intn_digit_t **b1, size_t *b1_len,
-    intn_integer_sign_t *b1_sign);
+static void term_to_bigint(term arg1, intn_digit_t *tmp_buf1, const intn_digit_t **b1,
+    size_t *b1_len, intn_integer_sign_t *b1_sign);
 
 const struct ExportedFunction *bif_registry_get_handler(const char *mfa)
 {
@@ -552,11 +552,11 @@ static term add_maybe_bigint(Context *ctx, uint32_t fail_label, uint32_t live, t
     intn_digit_t tmp_buf1[INTN_INT64_LEN];
     intn_digit_t tmp_buf2[INTN_INT64_LEN];
 
-    intn_digit_t *bn1;
+    const intn_digit_t *bn1;
     size_t bn1_len;
     intn_integer_sign_t bn1_sign;
     term_to_bigint(arg1, tmp_buf1, &bn1, &bn1_len, &bn1_sign);
-    intn_digit_t *bn2;
+    const intn_digit_t *bn2;
     size_t bn2_len;
     intn_integer_sign_t bn2_sign;
     term_to_bigint(arg2, tmp_buf2, &bn2, &bn2_len, &bn2_sign);
@@ -690,11 +690,11 @@ static term sub_maybe_bigint(Context *ctx, uint32_t fail_label, uint32_t live, t
     intn_digit_t tmp_buf1[INTN_INT64_LEN];
     intn_digit_t tmp_buf2[INTN_INT64_LEN];
 
-    intn_digit_t *bn1;
+    const intn_digit_t *bn1;
     size_t bn1_len;
     intn_integer_sign_t bn1_sign;
     term_to_bigint(arg1, tmp_buf1, &bn1, &bn1_len, &bn1_sign);
-    intn_digit_t *bn2;
+    const intn_digit_t *bn2;
     size_t bn2_len;
     intn_integer_sign_t bn2_sign;
     term_to_bigint(arg2, tmp_buf2, &bn2, &bn2_len, &bn2_sign);
@@ -838,8 +838,8 @@ static term make_bigint(Context *ctx, uint32_t fail_label, uint32_t live,
     }
 }
 
-static void term_to_bigint(term arg1, intn_digit_t *tmp_buf1, intn_digit_t **b1, size_t *b1_len,
-    intn_integer_sign_t *b1_sign)
+static void term_to_bigint(term arg1, intn_digit_t *tmp_buf1, const intn_digit_t **b1,
+    size_t *b1_len, intn_integer_sign_t *b1_sign)
 {
     if (term_is_boxed_integer(arg1)
         && (term_boxed_size(arg1) > (INTN_INT64_LEN * sizeof(intn_digit_t)) / sizeof(term))) {
@@ -870,11 +870,11 @@ static term mul_maybe_bigint(Context *ctx, uint32_t fail_label, uint32_t live, t
     intn_digit_t tmp_buf1[INTN_INT64_LEN];
     intn_digit_t tmp_buf2[INTN_INT64_LEN];
 
-    intn_digit_t *bn1;
+    const intn_digit_t *bn1;
     size_t bn1_len;
     intn_integer_sign_t bn1_sign;
     term_to_bigint(arg1, tmp_buf1, &bn1, &bn1_len, &bn1_sign);
-    intn_digit_t *bn2;
+    const intn_digit_t *bn2;
     size_t bn2_len;
     intn_integer_sign_t bn2_sign;
     term_to_bigint(arg2, tmp_buf2, &bn2, &bn2_len, &bn2_sign);
@@ -1033,11 +1033,11 @@ static term div_maybe_bigint(Context *ctx, uint32_t fail_label, uint32_t live, t
     intn_digit_t tmp_buf1[INTN_INT64_LEN];
     intn_digit_t tmp_buf2[INTN_INT64_LEN];
 
-    intn_digit_t *bn1;
+    const intn_digit_t *bn1;
     size_t bn1_len;
     intn_integer_sign_t bn1_sign;
     term_to_bigint(arg1, tmp_buf1, &bn1, &bn1_len, &bn1_sign);
-    intn_digit_t *bn2;
+    const intn_digit_t *bn2;
     size_t bn2_len;
     intn_integer_sign_t bn2_sign;
     term_to_bigint(arg2, tmp_buf2, &bn2, &bn2_len, &bn2_sign);
@@ -1353,11 +1353,11 @@ static term rem_maybe_bigint(Context *ctx, uint32_t fail_label, uint32_t live, t
     intn_digit_t tmp_buf1[INTN_INT64_LEN];
     intn_digit_t tmp_buf2[INTN_INT64_LEN];
 
-    intn_digit_t *bn1;
+    const intn_digit_t *bn1;
     size_t bn1_len;
     intn_integer_sign_t bn1_sign;
     term_to_bigint(arg1, tmp_buf1, &bn1, &bn1_len, &bn1_sign);
-    intn_digit_t *bn2;
+    const intn_digit_t *bn2;
     size_t bn2_len;
     intn_integer_sign_t bn2_sign;
     term_to_bigint(arg2, tmp_buf2, &bn2, &bn2_len, &bn2_sign);
@@ -1616,11 +1616,11 @@ static inline term bitwise_helper(
         } else {
             intn_digit_t tmp_buf1[INTN_INT64_LEN];
             intn_digit_t tmp_buf2[INTN_INT64_LEN];
-            intn_digit_t *m;
+            const intn_digit_t *m;
             size_t m_len;
             intn_integer_sign_t m_sign;
             term_to_bigint(arg1, tmp_buf1, &m, &m_len, &m_sign);
-            intn_digit_t *n;
+            const intn_digit_t *n;
             size_t n_len;
             intn_integer_sign_t n_sign;
             term_to_bigint(arg2, tmp_buf2, &n, &n_len, &n_sign);
@@ -1722,7 +1722,7 @@ term bif_erlang_bsl_2(Context *ctx, uint32_t fail_label, int live, term arg1, te
         }
 
         intn_digit_t tmp_buf1[INTN_INT64_LEN];
-        intn_digit_t *m;
+        const intn_digit_t *m;
         size_t m_len;
         intn_integer_sign_t m_sign;
         term_to_bigint(arg1, tmp_buf1, &m, &m_len, &m_sign);
@@ -1778,7 +1778,7 @@ term bif_erlang_bsr_2(Context *ctx, uint32_t fail_label, int live, term arg1, te
         }
 
         intn_digit_t tmp_buf1[INTN_INT64_LEN];
-        intn_digit_t *m;
+        const intn_digit_t *m;
         size_t m_len;
         intn_integer_sign_t m_sign;
         term_to_bigint(arg1, tmp_buf1, &m, &m_len, &m_sign);
@@ -1839,7 +1839,7 @@ static term bnot_boxed_helper(Context *ctx, uint32_t fail_label, uint32_t live, 
             #endif
             default: {
                 intn_digit_t tmp_buf1[INTN_INT64_LEN];
-                intn_digit_t *m;
+                const intn_digit_t *m;
                 size_t m_len;
                 intn_integer_sign_t m_sign;
                 term_to_bigint(arg1, tmp_buf1, &m, &m_len, &m_sign);


### PR DESCRIPTION
`args_to_bigint` function was quite unreadable, also add missing `const` qualifier.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
