### PR TITLE
JIT: additional optimizations

### DIFF
--- a/libs/estdlib/src/code_server.erl
+++ b/libs/estdlib/src/code_server.erl
@@ -39,6 +39,7 @@
     atom_resolver/2,
     literal_resolver/2,
     type_resolver/2,
+    import_resolver/2,
     set_native_code/3
 ]).
 
@@ -135,6 +136,15 @@ literal_resolver(_Module, _Index) ->
 type_resolver(_Module, _Index) ->
     erlang:nif_error(undefined).
 
+%% @doc Get an imported function triplet from its index
+%% @return The imported function as {Module, Function, Arity}
+%% @param Module module to get the imported function from
+%% @param Index imported function index in the module
+-spec import_resolver(Module :: module(), Index :: non_neg_integer()) ->
+    {atom(), atom(), non_neg_integer()}.
+import_resolver(_Module, _Index) ->
+    erlang:nif_error(undefined).
+
 %% @doc Associate a native code stream with a module
 %% @return ok
 %% @param Module module to set the native code of
@@ -164,6 +174,9 @@ load(Module) ->
                             code_server:literal_resolver(Module, Index)
                         end,
                         TypeResolver = fun(Index) -> code_server:type_resolver(Module, Index) end,
+                        ImportResolver = fun(Index) ->
+                            code_server:import_resolver(Module, Index)
+                        end,
                         {StreamModule, Stream0} = jit:stream(jit_mmap_size(byte_size(Code))),
                         {BackendModule, BackendState0} = jit:backend(StreamModule, Stream0),
                         {LabelsCount, BackendState1} = jit:compile(
@@ -171,6 +184,7 @@ load(Module) ->
                             AtomResolver,
                             LiteralResolver,
                             TypeResolver,
+                            ImportResolver,
                             BackendModule,
                             BackendState0
                         ),

--- a/libs/jit/src/jit_aarch64_asm.erl
+++ b/libs/jit/src/jit_aarch64_asm.erl
@@ -948,6 +948,8 @@ sub(Rd, Rn, Imm) when is_atom(Rd), is_atom(Rn), is_integer(Imm), Imm >= 0, Imm =
     RdNum = reg_to_num(Rd),
     RnNum = reg_to_num(Rn),
     <<(16#D1000000 bor ((Imm band 16#FFF) bsl 10) bor (RnNum bsl 5) bor RdNum):32/little>>;
+sub(_Rd, _Rn, Imm) when is_integer(Imm) ->
+    error({unencodable_immediate, Imm});
 sub(Rd, Rn, Rm) when is_atom(Rd), is_atom(Rn), is_atom(Rm) ->
     sub(Rd, Rn, Rm, {lsl, 0}).
 

--- a/libs/jit/src/jit_x86_64_asm.erl
+++ b/libs/jit/src/jit_x86_64_asm.erl
@@ -35,6 +35,8 @@
     jnz_rel8/1,
     jge/1,
     jge_rel8/1,
+    jle/1,
+    jle_rel8/1,
     jmp/1,
     jmp_rel8/1,
     jmp_rel32/1,
@@ -360,6 +362,14 @@ jge(Offset) when Offset >= -126 andalso Offset =< 129 ->
 jge_rel8(Offset) when Offset >= -126 andalso Offset =< 129 ->
     {1, jge(Offset)}.
 
+jle(Offset) when Offset >= -126 andalso Offset =< 129 ->
+    % Use short jump (matches assembler behavior)
+    AdjustedOffset = Offset - 2,
+    <<16#7E, AdjustedOffset>>.
+
+jle_rel8(Offset) when Offset >= -126 andalso Offset =< 129 ->
+    {1, jle(Offset)}.
+
 jmp(Offset) when Offset >= -126 andalso Offset =< 129 ->
     % Use short jump (matches assembler behavior)
     AdjustedOffset = Offset - 2,
@@ -489,6 +499,7 @@ subq(Imm, Reg) when ?IS_SINT8_T(Imm), is_atom(Reg) ->
         {1, Index} -> <<16#49, 16#83, (16#E8 + Index), Imm>>
     end;
 subq(Imm, rax) when ?IS_SINT32_T(Imm) ->
+    % Special short encoding for sub imm32, %rax
     <<16#48, 16#2D, Imm:32/little>>;
 subq(Imm, Reg) when ?IS_SINT32_T(Imm), is_atom(Reg) ->
     {REX_B, MODRM_RM} = x86_64_x_reg(Reg),

--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -1380,7 +1380,7 @@ static term jit_bitstring_extract_integer(
         }
         return t;
     } else if ((offset % 8 == 0) && (n % 8 == 0) && (n <= INTN_MAX_UNSIGNED_BITS_SIZE)) {
-        term bs_bin = ((term) bin_ptr) | TERM_PRIMARY_BOXED;
+        term bs_bin = (term) (((uintptr_t) bin_ptr) | TERM_PRIMARY_BOXED);
         unsigned long capacity = term_binary_size(bs_bin);
         if (8 * capacity - offset < (unsigned long) n) {
             return FALSE_ATOM;
@@ -1421,7 +1421,7 @@ static term jit_bitstring_extract_float(Context *ctx, term *bin_ptr, size_t offs
 
 static size_t jit_term_sub_binary_heap_size(term *bin_ptr, size_t size)
 {
-    term binary = ((term) bin_ptr) | TERM_PRIMARY_BOXED;
+    term binary = (term) (((uintptr_t) bin_ptr) | TERM_PRIMARY_BOXED);
     TRACE("jit_term_sub_binary_heap_size: binary=%p size=%d\n", (void *) binary, (int) size);
     return term_sub_binary_heap_size(binary, size);
 }

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -183,6 +183,7 @@ code_server:code_chunk/1, IF_HAVE_JIT(&code_server_code_chunk_nif)
 code_server:atom_resolver/2, IF_HAVE_JIT(&code_server_atom_resolver_nif)
 code_server:literal_resolver/2, IF_HAVE_JIT(&code_server_literal_resolver_nif)
 code_server:type_resolver/2, IF_HAVE_JIT(&code_server_type_resolver_nif)
+code_server:import_resolver/2, IF_HAVE_JIT(&code_server_import_resolver_nif)
 code_server:set_native_code/3, IF_HAVE_JIT(&code_server_set_native_code_nif)
 console:print/1, &console_print_nif
 base64:encode/1, &base64_encode_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -638,6 +638,8 @@ compile_erlang(reraise_raiser)
 compile_erlang(stacktrace_function_args)
 compile_erlang(test_multi_value_comprehension)
 
+compile_erlang(test_inline_arith)
+
 if(Erlang_VERSION VERSION_GREATER_EQUAL "23")
     set(OTP23_OR_GREATER_TESTS
         test_op_bs_start_match_asm.beam
@@ -1169,6 +1171,8 @@ set(erlang_test_beams
     test_lists_member.beam
     test_lists_keymember.beam
     test_lists_keyfind.beam
+
+    test_inline_arith.beam
 
     test_code_server_nifs.beam
 

--- a/tests/erlang_tests/test_inline_arith.erl
+++ b/tests/erlang_tests/test_inline_arith.erl
@@ -1,0 +1,64 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_inline_arith).
+
+-export([start/0, add_small/1, sub_small/1, add_large/1, sub_large/1]).
+
+% Test inline addition with safe ranges - SHOULD BE INLINED
+add_small(X) when is_integer(X), X >= 0, X < 100 ->
+    X + 20.
+
+% Test inline subtraction with safe ranges - SHOULD BE INLINED
+sub_small(X) when is_integer(X), X >= 50, X < 150 ->
+    X - 30.
+
+% Test addition with large range - SHOULD NOT BE INLINED (uses BIF)
+add_large(X) when is_integer(X), X >= 0, X < (1 bsl 60) ->
+    X + 1.
+
+% Test subtraction with large range - SHOULD NOT BE INLINED (uses BIF)
+sub_large(X) when is_integer(X), X >= -(1 bsl 60), X < 100 ->
+    X - 1.
+
+start() ->
+    % Test safe addition - should be inlined
+    20 = ?MODULE:add_small(0),
+    50 = ?MODULE:add_small(30),
+    119 = ?MODULE:add_small(99),
+
+    % Test safe subtraction - should be inlined
+    20 = ?MODULE:sub_small(50),
+    70 = ?MODULE:sub_small(100),
+    119 = ?MODULE:sub_small(149),
+
+    % Test large addition - not inlined, uses BIF (but should still work correctly)
+    % Using values near the upper bound but within the guard range
+    1 = ?MODULE:add_large(0),
+    100000001 = ?MODULE:add_large(100000000),
+    (1 bsl 59) = ?MODULE:add_large((1 bsl 59) - 1),
+
+    % Test large subtraction - not inlined, uses BIF (but should still work correctly)
+    % Using values near the lower bound but within the guard range
+    -1 = ?MODULE:sub_large(0),
+    -100000001 = ?MODULE:sub_large(-100000000),
+    -(1 bsl 59) - 1 = ?MODULE:sub_large(-(1 bsl 59)),
+
+    0.

--- a/tests/libs/jit/jit_aarch64_tests.erl
+++ b/tests/libs/jit/jit_aarch64_tests.erl
@@ -829,6 +829,82 @@ if_block_test_() ->
                     >>,
                     ?assertEqual(dump_to_bin(Dump), Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {100, '<', RegA},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	f9401807 	ldr	x7, [x0, #48]\n"
+                        "   4:	f9401c08 	ldr	x8, [x0, #56]\n"
+                        "   8:	f10190ff 	cmp	x7, #0x64\n"
+                        "   c:	5400004d 	b.le	0x14\n"
+                        "  10:	91000908 	add	x8, x8, #0x2"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {100, '<', {free, RegA}},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	f9401807 	ldr	x7, [x0, #48]\n"
+                        "   4:	f9401c08 	ldr	x8, [x0, #56]\n"
+                        "   8:	f10190ff 	cmp	x7, #0x64\n"
+                        "   c:	5400004d 	b.le	0x14\n"
+                        "  10:	91000908 	add	x8, x8, #0x2"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {RegA, '<', 100},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	f9401807 	ldr	x7, [x0, #48]\n"
+                        "   4:	f9401c08 	ldr	x8, [x0, #56]\n"
+                        "   8:	f10190ff 	cmp	x7, #0x64\n"
+                        "   c:	5400004a 	b.ge	0x14  // b.tcont\n"
+                        "  10:	91000908 	add	x8, x8, #0x2"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {{free, RegA}, '<', 100},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	f9401807 	ldr	x7, [x0, #48]\n"
+                        "   4:	f9401c08 	ldr	x8, [x0, #56]\n"
+                        "   8:	f10190ff 	cmp	x7, #0x64\n"
+                        "   c:	5400004a 	b.ge	0x14  // b.tcont\n"
+                        "  10:	91000908 	add	x8, x8, #0x2"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end)
             ]
         end}.

--- a/tests/libs/jit/jit_riscv32_tests.erl
+++ b/tests/libs/jit/jit_riscv32_tests.erl
@@ -1076,6 +1076,82 @@ if_block_test_() ->
                     >>,
                     ?assertEqual(dump_to_bin(Dump), Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {100, '<', RegA},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	01852f83          	lw	t6,24(a0)\n"
+                        "   4:	01c52f03          	lw	t5,28(a0)\n"
+                        "   8:	06400e93          	li	t4,100\n"
+                        "   c:	01fed363          	bge	t4,t6,0x12\n"
+                        "  10:	0f09                	addi	t5,t5,2"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {100, '<', {free, RegA}},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	01852f83          	lw	t6,24(a0)\n"
+                        "   4:	01c52f03          	lw	t5,28(a0)\n"
+                        "   8:	06400e93          	li	t4,100\n"
+                        "   c:	01fed363          	bge	t4,t6,0x12\n"
+                        "  10:	0f09                	addi	t5,t5,2"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {1024, '<', RegA},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	01852f83          	lw	t6,24(a0)\n"
+                        "   4:	01c52f03          	lw	t5,28(a0)\n"
+                        "   8:	40000e93          	li	t4,1024\n"
+                        "   c:	01fed363          	bge	t4,t6,0x12\n"
+                        "  10:	0f09                	addi	t5,t5,2"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {1024, '<', {free, RegA}},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	01852f83          	lw	t6,24(a0)\n"
+                        "   4:	01c52f03          	lw	t5,28(a0)\n"
+                        "   8:	40000e93          	li	t4,1024\n"
+                        "   c:	01fed363          	bge	t4,t6,0x12\n"
+                        "  10:	0f09                	addi	t5,t5,2"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end)
             ]
         end}.

--- a/tests/libs/jit/jit_tests.erl
+++ b/tests/libs/jit/jit_tests.erl
@@ -112,6 +112,7 @@ compile_minimal_x86_64_test() ->
         fun(_) -> undefined end,
         fun(_) -> undefined end,
         fun(_) -> any end,
+        fun(_) -> undefined end,
         jit_x86_64,
         Stream2
     ),
@@ -159,10 +160,11 @@ compile_stream_for_backend(Backend, CodeChunk, AtomChunk, TypeChunk) ->
     AtomResolver = jit_precompile:atom_resolver(AtomChunk),
     LiteralResolver = fun(_) -> test_literal end,
     TypeResolver = jit_precompile:type_resolver(TypeChunk),
+    ImportResolver = fun(_) -> {test, test, 2} end,
 
     % Compile with typed register support
     {LabelsCount, Stream3} = jit:compile(
-        CodeChunk, AtomResolver, LiteralResolver, TypeResolver, Backend, Stream2
+        CodeChunk, AtomResolver, LiteralResolver, TypeResolver, ImportResolver, Backend, Stream2
     ),
     Backend:stream(Stream3).
 

--- a/tests/libs/jit/jit_x86_64_asm_tests.erl
+++ b/tests/libs/jit/jit_x86_64_asm_tests.erl
@@ -866,6 +866,19 @@ jge_rel8_test_() ->
         )
     ].
 
+jle_test_() ->
+    [
+        ?_assertAsmEqual(<<16#7e, 16#f4>>, "jle .-10", jit_x86_64_asm:jle(-10))
+    ].
+
+jle_rel8_test_() ->
+    [
+        ?_assertEqual(
+            {1, jit_tests_common:asm(x86_64, <<16#7e, 16#05>>, "jle .+7")},
+            jit_x86_64_asm:jle_rel8(7)
+        )
+    ].
+
 jmp_rel8_test_() ->
     [
         ?_assertEqual(
@@ -966,6 +979,46 @@ subq_test_() ->
             <<16#48, 16#2D, 16#88, 16#A9, 16#CB, 16#ED>>,
             "subq $-0x12345678,%rax",
             jit_x86_64_asm:subq(-16#12345678, rax)
+        ),
+        % 8-bit immediate forms
+        ?_assertAsmEqual(
+            <<16#48, 16#83, 16#e8, 16#0a>>, "subq $10, %rax", jit_x86_64_asm:subq(10, rax)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#83, 16#e9, 16#05>>, "subq $5, %rcx", jit_x86_64_asm:subq(5, rcx)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#83, 16#ea, 16#08>>, "subq $8, %r10", jit_x86_64_asm:subq(8, r10)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#83, 16#eb, 16#7f>>, "subq $127, %r11", jit_x86_64_asm:subq(127, r11)
+        ),
+        % 32-bit immediate, special short form for %rax
+        ?_assertAsmEqual(
+            <<16#48, 16#2d, 16#00, 16#01, 16#00, 16#00>>,
+            "subq $256, %rax",
+            jit_x86_64_asm:subq(256, rax)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#2d, 16#00, 16#04, 16#00, 16#00>>,
+            "subq $1024, %rax",
+            jit_x86_64_asm:subq(1024, rax)
+        ),
+        % 32-bit immediate forms for other registers
+        ?_assertAsmEqual(
+            <<16#48, 16#81, 16#e9, 16#00, 16#01, 16#00, 16#00>>,
+            "subq $256, %rcx",
+            jit_x86_64_asm:subq(256, rcx)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#81, 16#ea, 16#00, 16#04, 16#00, 16#00>>,
+            "subq $1024, %r10",
+            jit_x86_64_asm:subq(1024, r10)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#81, 16#eb, 16#00, 16#10, 16#00, 16#00>>,
+            "subq $4096, %r11",
+            jit_x86_64_asm:subq(4096, r11)
         )
     ].
 

--- a/tests/libs/jit/jit_x86_64_tests.erl
+++ b/tests/libs/jit/jit_x86_64_tests.erl
@@ -789,6 +789,166 @@ if_block_test_() ->
                     >>,
                     ?assertEqual(dump_to_bin(Dump), Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {100, '<', RegA},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+                        "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11\n"
+                        "   8:	48 83 f8 64          	cmp    $0x64,%rax\n"
+                        "   c:	7e 04                	jle    0x12\n"
+                        "   e:	49 83 c3 02          	add    $0x2,%r11"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {100, '<', {free, RegA}},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+                        "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11\n"
+                        "   8:	48 83 f8 64          	cmp    $0x64,%rax\n"
+                        "   c:	7e 04                	jle    0x12\n"
+                        "   e:	49 83 c3 02          	add    $0x2,%r11"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {RegA, '<', 100},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+                        "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11\n"
+                        "   8:	48 83 f8 64          	cmp    $0x64,%rax\n"
+                        "   c:	7d 04                	jge    0x12\n"
+                        "   e:	49 83 c3 02          	add    $0x2,%r11"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {{free, RegA}, '<', 100},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+                        "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11\n"
+                        "   8:	48 83 f8 64          	cmp    $0x64,%rax\n"
+                        "   c:	7d 04                	jge    0x12\n"
+                        "   e:	49 83 c3 02          	add    $0x2,%r11"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {RegA, '<', 16#100000000},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+                        "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11\n"
+                        "   8:	49 ba 00 00 00 00 01 	movabs $0x100000000,%r10\n"
+                        "   f:	00 00 00 \n"
+                        "  12:	4c 39 d0             	cmp    %r10,%rax\n"
+                        "  15:	7d 04                	jge    0x1b\n"
+                        "  17:	49 83 c3 02          	add    $0x2,%r11"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {{free, RegA}, '<', 16#100000000},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+                        "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11\n"
+                        "   8:	49 ba 00 00 00 00 01 	movabs $0x100000000,%r10\n"
+                        "   f:	00 00 00 \n"
+                        "  12:	4c 39 d0             	cmp    %r10,%rax\n"
+                        "  15:	7d 04                	jge    0x1b\n"
+                        "  17:	49 83 c3 02          	add    $0x2,%r11"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {16#100000000, '<', RegA},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+                        "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11\n"
+                        "   8:	49 ba 00 00 00 00 01 	movabs $0x100000000,%r10\n"
+                        "   f:	00 00 00 \n"
+                        "  12:	4c 39 d0             	cmp    %r10,%rax\n"
+                        "  15:	7e 04                	jle    0x1b\n"
+                        "  17:	49 83 c3 02          	add    $0x2,%r11"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
+                end),
+                ?_test(begin
+                    State1 = ?BACKEND:if_block(
+                        State0,
+                        {16#100000000, '<', {free, RegA}},
+                        fun(BSt0) ->
+                            ?BACKEND:add(BSt0, RegB, 2)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State1),
+                    Dump = <<
+                        "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+                        "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11\n"
+                        "   8:	49 ba 00 00 00 00 01 	movabs $0x100000000,%r10\n"
+                        "   f:	00 00 00 \n"
+                        "  12:	4c 39 d0             	cmp    %r10,%rax\n"
+                        "  15:	7e 04                	jle    0x1b\n"
+                        "  17:	49 83 c3 02          	add    $0x2,%r11"
+                    >>,
+                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end)
             ]
         end}.

--- a/tests/test.c
+++ b/tests/test.c
@@ -622,6 +622,8 @@ struct Test tests[] = {
     TEST_CASE_COND(test_reraise, 0, SKIP_STACKTRACES),
     TEST_CASE_COND(stacktrace_function_args, 0, SKIP_STACKTRACES),
 
+    TEST_CASE(test_inline_arith),
+
     // TEST CRASHES HERE: TEST_CASE(memlimit),
 
     { NULL, 0, false, false }


### PR DESCRIPTION
Make imported functions available to JIT compiler
Optimize +/2 and -/2 as well as < and > using types.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
