### PR TITLE
Remove unused file

### DIFF
--- a/tests/valgrind-suppressions.sup.license
+++ b/tests/valgrind-suppressions.sup.license
@@ -1,2 +1,0 @@
-SPDX-License-Identifier: CC0-1.0
-SPDX-FileCopyrightText: AtomVM Contributors


### PR DESCRIPTION
Remove valgrind-suppressions.sup.license.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
