### PR TITLE
Fix static_assert in header

### DIFF
--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -37,6 +37,15 @@
 #include <stdint.h>
 #include <stdio.h>
 
+// intn doesn't depend on term
+_Static_assert(
+    (int) TermPositiveInteger == (int) IntNPositiveInteger, "term/intn definition mismatch");
+_Static_assert(
+    (int) TermNegativeInteger == (int) IntNNegativeInteger, "term/intn definition mismatch");
+
+// Make sure avm_int_t can always fit into size_t
+_Static_assert(SIZE_MAX >= AVM_INT_MAX, "SIZE_MAX < AVM_INT_MAX is an unsupported configuration.");
+
 enum TermTypeIndex {
     TERM_TYPE_INDEX_INVALID = 0,
     TERM_TYPE_INDEX_INTEGER = 1,

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1476,12 +1476,6 @@ static inline bool term_is_bigint(term t)
         && (term_boxed_size(t) > (INTN_INT64_LEN * sizeof(intn_digit_t)) / sizeof(term));
 }
 
-// intn doesn't depend on term
-_Static_assert(
-    (int) TermPositiveInteger == (int) IntNPositiveInteger, "term/intn definition mismatch");
-_Static_assert(
-    (int) TermNegativeInteger == (int) IntNNegativeInteger, "term/intn definition mismatch");
-
 /**
  * @brief Extract multi-precision integer data from boxed term
  *

--- a/src/libAtomVM/term_typedef.h
+++ b/src/libAtomVM/term_typedef.h
@@ -86,8 +86,6 @@ typedef uint64_t avm_uint64_t;
     #error "term size must be either 32 bit or 64 bit."
 #endif
 
-_Static_assert(SIZE_MAX >= AVM_INT_MAX, "SIZE_MAX < AVM_INT_MAX is an unsupported configuration.");
-
 #define UNICODE_CHAR_MAX 0x10FFFF
 
 #define MIN_NOT_BOXED_INT (AVM_INT_MIN >> 4)


### PR DESCRIPTION
Avoid accidental `_Static_assert` when a header is included from a C++ source.

Continuation of #1933

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
