### PR TITLE
Add stub for `io:set_ops/1,2`

### DIFF
--- a/doc/src/stubbed-functions.md
+++ b/doc/src/stubbed-functions.md
@@ -25,13 +25,11 @@ ignored
 
 The following functions are currently stubbed in AtomVM and always return a fixed value:
 
-<!--
-### Foo Bar Functions
+### I/O Functions
 
 | Module | Function | Return Value | Notes |
 |--------|----------|--------------|-------|
-| `erlang` | `foo/0` | `[]` | Not applicable on AtomVM |
--->
+| `io` | `set_ops/1,2` | `ok` | Standard IO options are currently ignored |
 
 ## Important Considerations
 

--- a/libs/estdlib/src/io.erl
+++ b/libs/estdlib/src/io.erl
@@ -43,6 +43,8 @@
     columns/1,
     getopts/0,
     getopts/1,
+    setopts/1,
+    setopts/2,
     printable_range/0
 ]).
 
@@ -110,6 +112,26 @@ getopts(standard_io) ->
         {stderr, true},
         {stdin, true}
     ].
+
+%%-----------------------------------------------------------------------------
+%% @equiv setopts(standard_io, Opts)
+%% @doc Set options for standard I/O
+%% @end
+%%-----------------------------------------------------------------------------
+-spec setopts(Opts :: [getopt()]) -> ok | {error, Reason :: any()}.
+setopts(Opts) ->
+    setopts(standard_io, Opts).
+
+%%-----------------------------------------------------------------------------
+%% @param IODevice IO device to set options for
+%% @param Opts Options to set
+%% @doc Set options for a given IODevice. Currently a no-op stub.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec setopts(IODevice :: device(), Opts :: [getopt()]) -> ok | {error, Reason :: any()}.
+setopts(_IODevice, _Opts) ->
+    %% TODO: Actually implement option setting when needed
+    ok.
 
 %%-----------------------------------------------------------------------------
 %% @doc Returns the user-requested range of printable Unicode characters.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
