### PR TITLE
Add `lists:ukeysort/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `erlang:list_to_bitstring`
 - Reimplemented `lists:keyfind`, `lists:keymember` and `lists:member` as NIFs
 - Added `AVM_PRINT_PROCESS_CRASH_DUMPS` option
+- Added `lists:ukeysort/2`
 
 ### Changed
 

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -63,6 +63,7 @@
     merge/2, merge/3,
     split/2,
     usort/1, usort/2,
+    ukeysort/2,
     dropwhile/2,
     duplicate/2,
     sublist/2,
@@ -774,6 +775,29 @@ unique([X, Y | Tail], Fun) ->
         false ->
             [X | unique([Y | Tail], Fun)]
     end.
+
+%%-----------------------------------------------------------------------------
+%% @param   N           the position in the tuple to compare (1..tuple_size)
+%% @param   L           the list to sort
+%% @returns The list L sorted by Nth element with duplicates removed
+%% @doc     Sort a list of tuples by Nth element and remove duplicates.
+%%          Two tuples compare equal if their Nth elements compare equal.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec ukeysort(N :: pos_integer(), L :: [tuple()]) -> [tuple()].
+ukeysort(N, TupleList) ->
+    Sorted = keysort(N, TupleList),
+    unique_key(Sorted, N).
+
+%% @private
+unique_key([], _N) ->
+    [];
+unique_key([X], _N) ->
+    [X];
+unique_key([X, Y | Tail], N) when element(N, X) =:= element(N, Y) ->
+    unique_key([X | Tail], N);
+unique_key([X, Y | Tail], N) ->
+    [X | unique_key([Y | Tail], N)].
 
 %%-----------------------------------------------------------------------------
 %% @param   Pred the predicate to check against elements in List1

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -49,6 +49,7 @@ test() ->
     ok = test_sort(),
     ok = test_split(),
     ok = test_usort(),
+    ok = test_ukeysort(),
     ok = test_dropwhile(),
     ok = test_duplicate(),
     ok = test_filtermap(),
@@ -377,6 +378,47 @@ test_usort() ->
     ?ASSERT_ERROR(lists:usort(1), function_clause),
     ?ASSERT_ERROR(lists:usort(fun(A, B) -> A > B end, 1), function_clause),
     ?ASSERT_ERROR(lists:usort(1, [1]), function_clause),
+    ok.
+
+test_ukeysort() ->
+    % Empty list
+    ?ASSERT_MATCH(lists:ukeysort(1, []), []),
+
+    % Single element
+    ?ASSERT_MATCH(lists:ukeysort(1, [{1, a}]), [{1, a}]),
+
+    % No duplicates
+    ?ASSERT_MATCH(lists:ukeysort(1, [{2, foo}, {1, bar}]), [{1, bar}, {2, foo}]),
+
+    % With duplicates - first occurrence kept (stable sort)
+    ?ASSERT_MATCH(lists:ukeysort(1, [{2, foo}, {1, bar}, {2, baz}]), [{1, bar}, {2, foo}]),
+    ?ASSERT_MATCH(lists:ukeysort(1, [{1, first}, {1, second}, {1, third}]), [{1, first}]),
+
+    % Mixed duplicates
+    ?ASSERT_MATCH(
+        lists:ukeysort(1, [{3, a}, {2, b}, {1, c}, {2, d}, {3, e}]),
+        [{1, c}, {2, b}, {3, a}]
+    ),
+
+    % Sorting on second element
+    ?ASSERT_MATCH(lists:ukeysort(2, [{foo, 2}, {bar, 1}]), [{bar, 1}, {foo, 2}]),
+    ?ASSERT_MATCH(
+        lists:ukeysort(2, [{a, 2}, {b, 1}, {c, 2}]),
+        [{b, 1}, {a, 2}]
+    ),
+
+    % Already sorted
+    ?ASSERT_MATCH(lists:ukeysort(1, [{1, a}, {2, b}, {3, c}]), [{1, a}, {2, b}, {3, c}]),
+
+    % Reverse sorted
+    ?ASSERT_MATCH(lists:ukeysort(1, [{3, a}, {2, b}, {1, c}]), [{1, c}, {2, b}, {3, a}]),
+
+    % Stability test - when keys are equal, first element is kept
+    ?ASSERT_MATCH(
+        lists:ukeysort(1, [{2, first}, {1, x}, {2, second}, {2, third}]),
+        [{1, x}, {2, first}]
+    ),
+
     ok.
 
 test_dropwhile() ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
