### PR TITLE
Remove useless optimization

### DIFF
--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -222,13 +222,12 @@ static int serialize_term(uint8_t *buf, term t, GlobalContext *glb)
                 }
                 return INTEGER_EXT_SIZE;
             } else {
-                bool is_negative;
-                avm_uint64_t unsigned_val = int64_safe_unsigned_abs_set_flag(val, &is_negative);
+                avm_uint64_t unsigned_val = int64_safe_unsigned_abs(val);
                 uint8_t num_bytes = get_num_bytes(unsigned_val);
                 if (buf != NULL) {
                     buf[0] = SMALL_BIG_EXT;
                     buf[1] = num_bytes;
-                    buf[2] = is_negative ? 0x01 : 0x00;
+                    buf[2] = val < 0 ? 0x01 : 0x00;
                     write_bytes(buf + 3, unsigned_val);
                 }
                 return SMALL_BIG_EXT_BASE_SIZE + num_bytes;

--- a/src/libAtomVM/intn.h
+++ b/src/libAtomVM/intn.h
@@ -917,9 +917,8 @@ static inline void intn_from_uint64(uint64_t absu64, intn_digit_t out[])
  */
 static inline void intn_from_int64(int64_t i64, intn_digit_t out[], intn_integer_sign_t *out_sign)
 {
-    bool is_negative;
-    uint64_t absu64 = int64_safe_unsigned_abs_set_flag(i64, &is_negative);
-    *out_sign = is_negative ? IntNNegativeInteger : IntNPositiveInteger;
+    uint64_t absu64 = int64_safe_unsigned_abs(i64);
+    *out_sign = i64 < 0 ? IntNNegativeInteger : IntNPositiveInteger;
     intn_from_uint64(absu64, out);
 }
 

--- a/src/libAtomVM/utils.h
+++ b/src/libAtomVM/utils.h
@@ -622,60 +622,6 @@ static inline uint64_t int64_safe_unsigned_abs(int64_t i64)
 }
 
 /**
- * @brief Get absolute value as uint32_t and sign of 32-bit integer
- *
- * Computes the absolute value of a signed 32-bit integer (\c int32_t) as
- * unsigned (\c uint32_t) and sets a flag indicating whether the original
- * value was negative. Combines sign extraction and absolute value computation
- * for efficiency. Commonly used when serializing integers where the sign is
- * stored separately from the magnitude.
- *
- * @param i32 Signed integer to process
- * @param[out] is_negative Set to true if i32 is negative, false otherwise
- * @return Absolute value as unsigned 32-bit integer (\c uint32_t)
- *
- * @pre is_negative != NULL
- *
- * @note Useful for integer formatting and parsing operations
- * @note Handles \c INT32_MIN correctly
- *
- * @see int32_safe_unsigned_abs() for absolute value without sign flag
- * @see int32_is_negative() for sign checking only
- */
-static inline uint32_t int32_safe_unsigned_abs_set_flag(int32_t i32, bool *is_negative)
-{
-    *is_negative = i32 < 0;
-    return int32_safe_unsigned_abs(i32);
-}
-
-/**
- * @brief Get absolute value as uint64_t and sign of 64-bit integer
- *
- * Computes the absolute value of a signed 64-bit integer (\c int64_t) as
- * unsigned (\c uint64_t) and sets a flag indicating whether the original
- * value was negative. Combines sign extraction and absolute value computation
- * for efficiency. Commonly used when serializing integers where the sign is
- * stored separately from the magnitude.
- *
- * @param i64 Signed integer to process
- * @param[out] is_negative Set to true if i64 is negative, false otherwise
- * @return Absolute value as unsigned 64-bit integer (\c uint64_t)
- *
- * @pre is_negative != NULL
- *
- * @note Useful for integer formatting and parsing operations
- * @note Handles \c INT64_MIN correctly
- *
- * @see int64_safe_unsigned_abs() for absolute value without sign flag
- * @see int64_is_negative() for sign checking only
- */
-static inline uint64_t int64_safe_unsigned_abs_set_flag(int64_t i64, bool *is_negative)
-{
-    *is_negative = i64 < 0;
-    return int64_safe_unsigned_abs(i64);
-}
-
-/**
  * @brief Perform arithmetic right shift on 32-bit signed integer (\c int32_t)
  *
  * Performs a portable arithmetic right shift that preserves sign extension


### PR DESCRIPTION
Remove redundant functions from utils.h.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
