### PR TITLE
armv6m: Reduce heuristic threshold for maybe_flush_literal_pool

### DIFF
--- a/libs/jit/src/jit_armv6m.erl
+++ b/libs/jit/src/jit_armv6m.erl
@@ -2771,9 +2771,10 @@ maybe_flush_literal_pool(
     % Determine the offset of the last item.
     Offset = StreamModule:offset(Stream0),
     {Addr, _, _} = lists:last(LP),
-    % Heuristically set the threshold at 900
+    % Heuristically set the threshold at 512 (half the range of ldr inst.).
+    % bigint.beam currently requires 663 or lower to compile.
     if
-        Offset - Addr > 900 ->
+        Offset - Addr > 512 ->
             NbLiterals = length(LP),
             Continuation = NbLiterals * 4 + 4 - (Offset rem 4),
             Stream1 = StreamModule:append(Stream0, jit_armv6m_asm:b(Continuation)),

--- a/tests/libs/jit/jit_armv6m_tests.erl
+++ b/tests/libs/jit/jit_armv6m_tests.erl
@@ -3055,27 +3055,27 @@ move_to_native_register_test_() ->
                             ?BACKEND:free_native_registers(AccSt4, [RegA])
                         end,
                         State0,
-                        lists:seq(1025, 1140)
+                        lists:seq(1025, 1090)
                     ),
                     State2 = ?BACKEND:flush(State1),
                     Stream = ?BACKEND:stream(State2),
-                    {_, LoadAndBranch0} = split_binary(Stream, 16#38a),
+                    {_, LoadAndBranch0} = split_binary(Stream, 16#210),
                     {LoadAndBranch, _} = split_binary(LoadAndBranch0, 10),
                     LoadAndBranchDump = <<
-                        " 38a:   4f62            ldr     r7, [pc, #392]  ; (0x514)\n"
-                        " 38c:   e0c4            b.n     0x518\n"
-                        " 38e:   ffff .dword\n\n"
-                        " 392:   0401 .dword\n\n"
-                        " 394:   0000 .dword"
+                        " 210:	4f38      	ldr	r7, [pc, #224]	; (0x2f4)\n"
+                        " 212:	e071      	b.n	0x2f8\n"
+                        " 214:  0401        .dword 0x0401\n\n"
+                        " 216:  0000        .dword 0x0000\n\n"
+                        " 218:  0402        .dword 0x0402\n\n"
                     >>,
                     ?assertEqual(dump_to_bin(LoadAndBranchDump), LoadAndBranch),
-                    {_, Continuation0} = split_binary(Stream, 16#518),
+                    {_, Continuation0} = split_binary(Stream, 16#2f8),
                     {Continuation, _} = split_binary(Continuation0, 8),
                     ContinuationDump = <<
-                        " 518:   19ff            adds    r7, r7, r7\n"
-                        " 51a:   19ff            adds    r7, r7, r7\n"
-                        " 51c:   19ff            adds    r7, r7, r7\n"
-                        " 51e:   278e            movs    r7, #142        ; 0x8e"
+                        " 2f8:   19ff       adds    r7, r7, r7\n"
+                        " 2fa:   19ff       adds    r7, r7, r7\n"
+                        " 2fc:   19ff       adds    r7, r7, r7\n"
+                        " 2fe:   4f02       ldr	    r7, [pc, #8]	; (0x308)"
                     >>,
                     ?assertEqual(dump_to_bin(ContinuationDump), Continuation)
                 end),
@@ -3091,26 +3091,28 @@ move_to_native_register_test_() ->
                             ?BACKEND:free_native_registers(AccSt4, [RegA])
                         end,
                         State1,
-                        lists:seq(1025, 1140)
+                        lists:seq(1025, 1090)
                     ),
                     State3 = ?BACKEND:flush(State2),
                     Stream = ?BACKEND:stream(State3),
-                    {_, LoadAndBranch0} = split_binary(Stream, 16#38c),
-                    {LoadAndBranch, _} = split_binary(LoadAndBranch0, 8),
+                    {_, LoadAndBranch0} = split_binary(Stream, 16#212),
+                    {LoadAndBranch, _} = split_binary(LoadAndBranch0, 10),
                     LoadAndBranchDump = <<
-                        " 38c:   4e61            ldr     r6, [pc, #388]  ; (0x514)\n"
-                        " 38e:   e0c3            b.n     0x518\n"
-                        " 390:   0401            lsls    r1, r0, #16\n"
-                        " 392:   0000            movs    r0, r0"
+                        " 212:   4e39       ldr	r6, [pc, #228]	; (0x2f8)\n"
+                        " 214:   e072       b.n	0x2fc\n"
+                        % padding
+                        " 216:   ffff       .dword 0xffff\n\n"
+                        " 218:   0401       .dword 0x401\n\n"
+                        " 21a:   0000       .dword 0x000"
                     >>,
                     ?assertEqual(dump_to_bin(LoadAndBranchDump), LoadAndBranch),
-                    {_, Continuation0} = split_binary(Stream, 16#518),
+                    {_, Continuation0} = split_binary(Stream, 16#2fc),
                     {Continuation, _} = split_binary(Continuation0, 8),
                     ContinuationDump = <<
-                        " 518:   19b6            adds    r6, r6, r6\n"
-                        " 51a:   19b6            adds    r6, r6, r6\n"
-                        " 51c:   19b6            adds    r6, r6, r6\n"
-                        " 51e:   268e            movs    r6, #142        ; 0x8e"
+                        " 2fc:   19b6       adds    r6, r6, r6\n"
+                        " 2fe:   19b6       adds    r6, r6, r6\n"
+                        " 300:   19b6       adds    r6, r6, r6\n"
+                        " 302:   4e02      	ldr     r6, [pc, #8]	; (0x30c)"
                     >>,
                     ?assertEqual(dump_to_bin(ContinuationDump), Continuation)
                 end)


### PR DESCRIPTION
Literal pools need to be within 1024 bytes because of limited range of
ldr reg, [pc, #imm] instruction. A pool is emitted when mov_immediate is
called and the pool reference is farther than a given threshold. Emitting
the pool in such a condition requires a branch over the pool, and is
therefore less efficient than the usual pool flush that happens when a
branch is emitted (tail calls).

This threshold was set to 900 but new test module bigint.beam wouldn't
compile. This commit changes the threshold to 512 which works (the test
actually requires 663).

The optimal threshold value depends on the pattern usage of mov_immediate.
If regular code hits the bug, we may need to change the heuristic and emit the
pool based on other conditions.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
