### PR TITLE
Add missing `AVM_PRINT_PROCESS_CRASH_DUMPS` to JIT

### DIFF
--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -207,9 +207,11 @@ static Context *jit_handle_error(Context *ctx, JITState *jit_state, int offset)
     }
 
     // Do not print crash dump if reason is normal or shutdown.
+#ifdef AVM_PRINT_PROCESS_CRASH_DUMPS
     if (ctx->x[0] != LOWERCASE_EXIT_ATOM || (ctx->x[1] != NORMAL_ATOM && ctx->x[1] != SHUTDOWN_ATOM)) {
         context_dump(ctx);
     }
+#endif
 
     if (ctx->x[0] == LOWERCASE_EXIT_ATOM) {
         ctx->exit_reason = ctx->x[1];


### PR DESCRIPTION
This new option silences crash dumps with emulated builds.
It was ignored with JIT.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
