### PR TITLE
Add lean `proc_lib` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `lists:ukeysort/2`
 - Added support for big integers up to 256-bit (sign + 256-bit magnitude)
 - Added support for big integers in `binary_to_term/1` and `term_to_binary/1,2`
+- Added `proc_lib`
 
 ### Changed
 

--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(ERLANG_MODULES
     maps
     math
     net
+    proc_lib
     file
     logger
     logger_std_h

--- a/libs/estdlib/src/proc_lib.erl
+++ b/libs/estdlib/src/proc_lib.erl
@@ -1,0 +1,269 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of the Erlang/OTP gen_server interface.
+%%
+%% This module implements a strict subset of the Erlang/OTP proc_lib
+%% interface.
+%%-----------------------------------------------------------------------------
+
+-module(proc_lib).
+
+%% Public API
+-export([
+    start/3,
+    start/4,
+    start/5,
+    start_link/3,
+    start_link/4,
+    start_link/5,
+    init_ack/1,
+    init_ack/2,
+
+    initial_call/1,
+    translate_initial_call/1
+]).
+
+-export([
+    init_p/5
+]).
+
+-export_type([
+    start_spawn_option/0
+]).
+
+-include_lib("kernel/include/logger.hrl").
+
+%% @doc Restricted set of spawn options. `monitor' is not supported.
+-type start_spawn_option() ::
+    {min_heap_size, pos_integer()}
+    | {max_heap_size, pos_integer()}
+    | {atomvm_heap_growth, erlang:atomvm_heap_growth_strategy()}
+    | link.
+
+%% @equiv start_link(Module, Function, Args, infinity)
+-spec start(module(), atom(), [any()]) -> any().
+start(Module, Function, Args) ->
+    start(Module, Function, Args, infinity).
+
+%% @equiv start(Module, Function, Args, Timeout, [])
+-spec start(module(), atom(), [any()], timeout()) -> any().
+start(Module, Function, Args, Timeout) ->
+    start(Module, Function, Args, Timeout, []).
+
+%%-----------------------------------------------------------------------------
+%% @param   Module the module in which the callbacks are defined
+%% @param   Function to call for initialization
+%% @param   Args arguments to pass to the function
+%% @param   Timeout timeout for the initialization to be done
+%% @param   SpawnOpts options passed to spawn. `monitor' is not allowed.
+%% @doc     Start a new process synchronously. Wait for the process to call
+%%          `init_ack/1,2' or `init_fail/2,3'.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start(module(), atom(), [any()], timeout(), [start_spawn_option()]) -> any().
+start(Module, Function, Args, Timeout, SpawnOpts) ->
+    start0(Module, Function, Args, Timeout, SpawnOpts, false).
+
+%% @equiv start_link(Module, Function, Args, infinity)
+-spec start_link(module(), atom(), [any()]) -> any().
+start_link(Module, Function, Args) ->
+    start_link(Module, Function, Args, infinity).
+
+%% @equiv start_link(Module, Function, Args, Timeout, [])
+-spec start_link(module(), atom(), [any()], timeout()) -> any().
+start_link(Module, Function, Args, Timeout) ->
+    start_link(Module, Function, Args, Timeout, []).
+
+%%-----------------------------------------------------------------------------
+%% @param   Module the module in which the callbacks are defined
+%% @param   Function to call for initialization
+%% @param   Args arguments to pass to the function
+%% @param   Timeout timeout for the initialization to be done
+%% @param   SpawnOpts options passed to spawn_link. `monitor' is not allowed.
+%% @doc     Start a new process synchronously and atomically link it.
+%%          Wait for the process to call `init_ack/1,2' or `init_fail/2,3'.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start_link(module(), atom(), [any()], timeout(), [start_spawn_option()]) -> any().
+start_link(Module, Function, Args, Timeout, SpawnOpts) ->
+    start0(Module, Function, Args, Timeout, [link | SpawnOpts], true).
+
+%% @private
+start0(Module, Function, Args, Timeout, SpawnOpts, Link) ->
+    case lists:member(monitor, SpawnOpts) of
+        true -> error(badarg);
+        false -> ok
+    end,
+    Parent = self(),
+    Ancestors =
+        case get('$ancestors') of
+            A when is_list(A) -> A;
+            _ -> []
+        end,
+    {Pid, Monitor} = spawn_opt(?MODULE, init_p, [Parent, Ancestors, Module, Function, Args], [
+        monitor | SpawnOpts
+    ]),
+    receive
+        {ack, Pid, Result} ->
+            erlang:demonitor(Monitor, [flush]),
+            Result;
+        {'DOWN', Monitor, process, Pid, Reason} when Link ->
+            receive
+                {'EXIT', Pid, _} -> ok
+            after 0 -> ok
+            end,
+            receive
+                {'DOWN', Monitor, process, Pid, _} -> ok
+            end,
+            {error, Reason};
+        {'DOWN', Monitor, process, Pid, Reason} ->
+            {error, Reason}
+    after Timeout ->
+        if
+            Link ->
+                unlink(Pid),
+                exit(Pid, kill),
+                receive
+                    {'EXIT', Pid, _} -> ok
+                after 0 -> ok
+                end;
+            true ->
+                exit(Pid, kill)
+        end,
+        receive
+            {'DOWN', Monitor, process, Pid, _} -> ok
+        end,
+        {error, timeout}
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Result result sent back to parent
+%% @doc     Callback to signal that initialization succeeded.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec init_ack(any()) -> ok.
+init_ack(Result) ->
+    [Parent | _] = get('$ancestors'),
+    init_ack(Parent, Result).
+
+%%-----------------------------------------------------------------------------
+%% @param   Parent parent process
+%% @param   Result result sent back to parent
+%% @doc     Callback to signal that initialization succeeded.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec init_ack(pid(), any()) -> ok.
+init_ack(Parent, Result) ->
+    Parent ! {ack, self(), Result},
+    ok.
+
+%% @private
+-spec init_p(pid(), [pid()], atom(), atom(), [any()]) -> any().
+init_p(Parent, Ancestors, Module, Function, Args) ->
+    put('$ancestors', [Parent | Ancestors]),
+    put('$initial_call', {Module, Function, length(Args)}),
+    try
+        apply(Module, Function, Args)
+    catch
+        Class:Reason:Stacktrace ->
+            exit_p(Class, Reason, Stacktrace)
+    end.
+
+%% @private
+exit_p(Class, Reason, Stacktrace) ->
+    MFA = get('$initial_call'),
+    crash_report(Class, Reason, MFA, Stacktrace),
+    exit_raise(Class, Reason, Stacktrace).
+
+%% @private
+exit_raise(error, Reason, Stacktrace) ->
+    erlang:raise(exit, {Reason, Stacktrace}, Stacktrace);
+exit_raise(exit, Reason, Stacktrace) ->
+    erlang:raise(exit, Reason, Stacktrace);
+exit_raise(throw, Reason, Stacktrace) ->
+    erlang:raise(exit, {{nocatch, Reason}, Stacktrace}, Stacktrace).
+
+%% @private
+crash_report(exit, normal, _, _) ->
+    ok;
+crash_report(exit, shutdown, _, _) ->
+    ok;
+crash_report(exit, {shutdown, _}, _, _) ->
+    ok;
+crash_report(Class, Reason, MFA, Stacktrace) ->
+    {ICM, ICF, ICA} =
+        case MFA of
+            {M, F, A} when is_atom(M), is_atom(F), is_integer(A) -> {M, F, A};
+            _ -> {proc_lib, init_p, 5}
+        end,
+    {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
+    {links, Links} = process_info(self(), links),
+    {total_heap_size, TotalHeapSize} = process_info(self(), total_heap_size),
+    {stack_size, StackSize} = process_info(self(), stack_size),
+    ?LOG_ERROR(
+        "=CRASH REPORT====\n"
+        "  crasher:\n"
+        "   initial call: ~s:~s/~B\n"
+        "   pid: ~p\n"
+        "   exception error: ~p\n"
+        "   ancestors: ~w\n"
+        "   message_queue_len: ~B\n"
+        "   links: ~w\n"
+        "   total_heap_size: ~B\n"
+        "   stack_size: ~B\n"
+        "   stack_trace: ~p\n",
+        [
+            ICM,
+            ICF,
+            ICA,
+            self(),
+            {Class, Reason},
+            get('$ancestors'),
+            MessageQueueLen,
+            Links,
+            TotalHeapSize,
+            StackSize,
+            Stacktrace
+        ]
+    ).
+
+%%-----------------------------------------------------------------------------
+%% @param   Process process to get the initial call for
+%% @return  `false' until we support `process_info(Pid, dictionary)'
+%% @doc     Get the initial call for a given process or `false'
+%%          if it's not available. Arguments are replaced with atoms.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec initial_call(pid()) -> {module(), atom(), [atom()]} | false.
+initial_call(_Process) ->
+    false.
+
+%%-----------------------------------------------------------------------------
+%% @param   Process process to get the initial call for
+%% @return  `{proc_lib, init_p, 5}' until we support `process_info(Pid, dictionary)'
+%% @doc     Get the initial call for a given process or `{proc_lib, init_p, 5}'
+%%          if it's not available.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec translate_initial_call(pid()) -> {module(), atom(), non_neg_integer()}.
+translate_initial_call(_Process) ->
+    {proc_lib, init_p, 5}.

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -40,6 +40,7 @@ set(ERLANG_MODULES
     test_net
     test_net_kernel
     test_os
+    test_proc_lib
     test_sets
     test_spawn
     test_ssl

--- a/tests/libs/estdlib/test_proc_lib.erl
+++ b/tests/libs/estdlib/test_proc_lib.erl
@@ -1,0 +1,168 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_proc_lib).
+
+-export([test/0]).
+-export([init_ok/1, init_crash/1, init_initial_call_ancestors/1]).
+
+test() ->
+    ok = test_start_sync(),
+    ok = test_start_monitor_badarg(),
+    ok = test_start_link_sync(),
+    ok = test_start_link_opt_sync(),
+    ok = test_start_timeout(),
+    ok = test_start_crash(),
+    ok = test_initial_call_and_ancestors(),
+    ok.
+
+test_start_sync() ->
+    Parent = self(),
+    Ret = proc_lib:start(?MODULE, init_ok, [Parent]),
+    ok = Ret,
+    {ok, Pid} =
+        receive
+            {Process, inited} -> {ok, Process}
+        after 0 -> fail
+        end,
+    true = is_process_alive(Pid),
+    {links, []} = process_info(Pid, links),
+    exit(Pid, normal),
+    ok.
+
+test_start_monitor_badarg() ->
+    Parent = self(),
+    ok =
+        try
+            proc_lib:start(?MODULE, init_ok, [Parent], infinity, [monitor]),
+            unexpected
+        catch
+            error:badarg ->
+                ok
+        end,
+    ok.
+
+test_start_link_sync() ->
+    Parent = self(),
+    Ret = proc_lib:start_link(?MODULE, init_ok, [Parent]),
+    ok = Ret,
+    {ok, Pid} =
+        receive
+            {Process, inited} -> {ok, Process}
+        after 0 -> fail
+        end,
+    true = is_process_alive(Pid),
+    {links, [Parent]} = process_info(Pid, links),
+    unlink(Pid),
+    exit(Pid, normal),
+    ok.
+
+test_start_link_opt_sync() ->
+    Parent = self(),
+    Ret = proc_lib:start(?MODULE, init_ok, [Parent], infinity, [link]),
+    ok = Ret,
+    {ok, Pid} =
+        receive
+            {Process, inited} -> {ok, Process}
+        after 0 -> fail
+        end,
+    true = is_process_alive(Pid),
+    {links, [Parent]} = process_info(Pid, links),
+    unlink(Pid),
+    exit(Pid, normal),
+    ok.
+
+test_start_timeout() ->
+    Parent = self(),
+    Ret = proc_lib:start(?MODULE, init_ok, [Parent], 100),
+    {error, timeout} = Ret,
+    ok.
+
+test_start_crash() ->
+    case erlang:system_info(machine) of
+        "ATOM" ->
+            {ok, _Pid} = logger_manager:start_link(#{});
+        "BEAM" ->
+            ok
+    end,
+    RetError = proc_lib:start(?MODULE, init_crash, [{error, badarg, []}]),
+    {error, {badarg, ErrorSt}} = RetError,
+    % BEAM returns [] as the stacktrace, AtomVM (currently) returns a
+    % full stacktrace if stacktraces are enabled or undefined if
+    % stacktraces are disabled
+    case erlang:system_info(machine) of
+        "ATOM" when ErrorSt =:= undefined ->
+            ok;
+        "ATOM" ->
+            true = is_list(ErrorSt);
+        "BEAM" ->
+            [] = ErrorSt
+    end,
+    RetExit = proc_lib:start(?MODULE, init_crash, [{exit, tested, []}]),
+    {error, tested} = RetExit,
+    RetThrow = proc_lib:start(?MODULE, init_crash, [{throw, tested, []}]),
+    {error, {{nocatch, tested}, ThrowSt}} = RetThrow,
+    case erlang:system_info(machine) of
+        "ATOM" when ThrowSt =:= undefined ->
+            ok;
+        "ATOM" ->
+            true = is_list(ThrowSt);
+        "BEAM" ->
+            [] = ThrowSt
+    end,
+
+    case erlang:system_info(machine) of
+        "ATOM" ->
+            logger_manager:stop();
+        "BEAM" ->
+            ok
+    end,
+    ok.
+
+test_initial_call_and_ancestors() ->
+    Parent = self(),
+    ImaginaryAncestor = spawn(fun() ->
+        receive
+            quit -> ok
+        end
+    end),
+    put('$ancestors', [ImaginaryAncestor]),
+    Ret = proc_lib:start(?MODULE, init_initial_call_ancestors, [Parent]),
+    {ok, {?MODULE, init_initial_call_ancestors, 1}, [Parent, ImaginaryAncestor]} = Ret,
+    exit(ImaginaryAncestor, normal),
+    ok.
+
+init_ok(Parent) ->
+    ok =
+        receive
+            timer -> fail
+        after 500 -> ok
+        end,
+    Parent ! {self(), inited},
+    proc_lib:init_ack(Parent, ok),
+    receive
+        quit -> ok
+    end.
+
+init_crash({Class, Reason, Stacktrace}) ->
+    erlang:raise(Class, Reason, Stacktrace).
+
+init_initial_call_ancestors(Parent) ->
+    proc_lib:init_ack(Parent, {ok, get('$initial_call'), get('$ancestors')}).

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -75,6 +75,7 @@ get_non_networking_tests(_OTPVersion) ->
         test_io_lib,
         test_logger,
         test_maps,
+        test_proc_lib,
         test_proplists,
         test_queue,
         test_timer,


### PR DESCRIPTION
Implement most used `proc_lib` functions, including all functions used by Elixir. Some features are not available yet as
`process_info(Pid, dictionary)` is not implemented.

Also, `gen_*` are not using `proc_lib` yet, we need to introduce `gen` first.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
