### PR TITLE
Fix some errors when compiling C++ code

### DIFF
--- a/src/libAtomVM/bitstring.h
+++ b/src/libAtomVM/bitstring.h
@@ -75,6 +75,8 @@ extern "C" {
 // these values are the same used from opcodes such as bs_get_utf16
 enum BitstringFlags
 {
+    // Big endian & unsigned are the default
+    BigEndianInteger = 0x0,
     LittleEndianInteger = 0x2,
     SignedInteger = 0x4,
     NativeEndianInteger = 0x10,
@@ -369,7 +371,7 @@ static inline bool bitstring_utf8_size(uint32_t c, size_t *out_size)
  * unicode character
  */
 static inline bool bitstring_utf16_size(uint32_t c, size_t *out_size) {
-    return bitstring_utf16_encode(c, NULL, 0, out_size);
+    return bitstring_utf16_encode(c, NULL, BigEndianInteger, out_size);
 }
 
 /**

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -459,7 +459,7 @@ static inline bool globalcontext_is_term_equal_to_atom_string(GlobalContext *glo
  */
 static inline term globalcontext_make_atom(GlobalContext *glb, AtomString atom_string)
 {
-    return globalcontext_insert_atom_maybe_copy(glb, atom_string_data(atom_string), atom_string_len(atom_string), false);
+    return globalcontext_insert_atom_maybe_copy(glb, (const uint8_t *) atom_string_data(atom_string), atom_string_len(atom_string), false);
 }
 
 /**

--- a/src/libAtomVM/intn.h
+++ b/src/libAtomVM/intn.h
@@ -405,7 +405,7 @@ size_t intn_sub_int64(int64_t num1, int64_t num2, intn_digit_t *out, intn_intege
  */
 static inline intn_integer_sign_t intn_muldiv_sign(intn_integer_sign_t s1, intn_integer_sign_t s2)
 {
-    return (intn_integer_sign_t) ((unsigned int) s1 ^ (unsigned int) s2) & IntNNegativeInteger;
+    return (intn_integer_sign_t) (((unsigned int) s1 ^ (unsigned int) s2) & IntNNegativeInteger);
 }
 
 /**


### PR DESCRIPTION
The code currently doesn't compile with C++ source code with gcc and -fpermissive.

```
/__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/intn.h: In function 'intn_integer_sign_t intn_muldiv_sign(intn_integer_sign_t, intn_integer_sign_t)':
/__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/intn.h:408:74: error: invalid conversion from 'int' to 'intn_integer_sign_t' [-fpermissive]
  408 |     return (intn_integer_sign_t) ((unsigned int) s1 ^ (unsigned int) s2) & IntNNegativeInteger;
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
      |                                                                          |
      |                                                                          int
/__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/globalcontext.h: In function 'term globalcontext_make_atom(GlobalContext*, AtomString)':
/__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/globalcontext.h:462:70: error: invalid conversion from 'const void*' to 'const uint8_t*' {aka 'const unsigned char*'} [-fpermissive]
  462 |     return globalcontext_insert_atom_maybe_copy(glb, atom_string_data(atom_string), atom_string_len(atom_string), false);
      |                                                      ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
      |                                                                      |
      |                                                                      const void*
/__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/globalcontext.h:409:92: note:   initializing argument 2 of 'term globalcontext_insert_atom_maybe_copy(GlobalContext*, const uint8_t*, size_t, bool)'
  409 | static inline term globalcontext_insert_atom_maybe_copy(GlobalContext *glb, const uint8_t *atom_data, size_t atom_len, bool copy)
      |                                                                             ~~~~~~~~~~~~~~~^~~~~~~~~
In file included from /__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/jit.h:24,
                 from /__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/context.h:32,
                 from /__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/nifs.h:30,
                 from /__w/atomvm_m5/atomvm_m5/AtomVM/src/platforms/esp32/components/atomvm_m5/nifs/include/atomvm_m5.h:6:
/__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/bitstring.h: In function 'bool bitstring_utf16_size(uint32_t, size_t*)':
/__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/bitstring.h:372:44: error: invalid conversion from 'int' to 'BitstringFlags' [-fpermissive]
  372 |     return bitstring_utf16_encode(c, NULL, 0, out_size);
      |                                            ^
      |                                            |
      |                                            int
/__w/atomvm_m5/atomvm_m5/AtomVM/src/libAtomVM/bitstring.h:310:75: note:   initializing argument 3 of 'bool bitstring_utf16_encode(uint32_t, uint8_t*, BitstringFlags, size_t*)'
  310 | bool bitstring_utf16_encode(uint32_t c, uint8_t *buf, enum BitstringFlags bs_flags, size_t *out_size);
      |                                                       ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
