### PR TITLE
ESP32: Example idf_component.yml (nif install method)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ src/platforms/esp32/test/__pycache__/**
 src/platforms/esp32/components/**
 src/platforms/esp32/managed_components/**
 src/platforms/esp32/sdkconfig
+src/platforms/esp32/main/idf_component.yml
+src/platforms/esp32/dependencies.lock
 !src/platforms/esp32/components/avm_builtins/
 !src/platforms/esp32/components/avm_builtins/**
 !src/platforms/esp32/components/avm_sys/

--- a/src/platforms/esp32/main/idf_component.yml.example
+++ b/src/platforms/esp32/main/idf_component.yml.example
@@ -1,0 +1,43 @@
+# This file is an example IDF component manifest for AtomVM on ESP32.
+#
+# Usage:
+# 1) Copy this file to `idf_component.yml` in the same directory:
+#    cp idf_component.yml.example idf_component.yml
+# 2) Edit and uncomment the dependencies you need below.
+# 3) Run `idf.py build` to build the project.
+#
+# Note: `idf_component.yml` is user-specific and is ignored by git.
+#
+# Read more on the IDF component manager here:
+# https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-component-manager.html
+#
+# Do check the readme for each dependency for more information on the install and usage.
+#
+dependencies:
+  # atomgl:
+  #   git: https://github.com/atomvm/atomgl
+  #   version: "main"
+  # atomvm_mqtt_client:
+  #   git: https://github.com/atomvm/atomvm_mqtt_client
+  #   version: "main"
+  # atomvm_esp32cam:
+  #   #NB requires certain sdkconfig options to be set, see the readme
+  #   git: https://github.com/atomvm/atomvm_esp32cam
+  #   version: "main"
+  # atomvm_gps:
+  #   git: https://github.com/atomvm/atomvm_gps
+  #   version: "main"
+  # atomvm_neopixel:
+  #   git: https://github.com/atomvm/atomvm_neopixel
+  #   version: "main"
+  # atomvm_m5:
+  #   git: https://github.com/pguyot/atomvm_m5
+  #   version: "main"
+  # my_nif:
+  #   # example for local development
+  #   # replace with your own nif in same top level directory as AtomVM
+  #   path: ../../../../../my_nif
+  # atomvm_mqtt_client:
+  #   # example for local development
+  #   # where a nif is git cloned in same top level directory as AtomVM
+  #   path: ../../../../../atomvm_mqtt_client

--- a/src/platforms/esp32/main/idf_component.yml.example.license
+++ b/src/platforms/esp32/main/idf_component.yml.example.license
@@ -1,0 +1,2 @@
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: AtomVM Contributors


### PR DESCRIPTION
This is first step in moving towards suggesting/using idf_component.yml as the primary method for installing esp32 nifs, instead of the more cumbersome git clone method, with all it's caveats.

Also examples for development where the nif is in a path.

For correctness, and proper git, one needs to copy the example file to `src/platforms/esp32/main/idf_component.yml` and say uncomment the atomgl section, and `idf.py build`.. and it just works..

Note say commenting out atomgl again, automatically removes it on next build.

So excellent DX.

Next step will be updating docs to reference this method.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
