### PR TITLE
Fix deprecated xTaskGetAffinity-> xTaskGetCoreID

### DIFF
--- a/src/platforms/esp32/components/avm_sys/smp.c
+++ b/src/platforms/esp32/components/avm_sys/smp.c
@@ -66,7 +66,11 @@ static void *scheduler_thread_entry_point(void *arg)
 {
     g_sub_main_thread = true;
     void *result = (void *) scheduler_entry_point((GlobalContext *) arg);
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
+    BaseType_t core = xTaskGetCoreID(NULL);
+#else
     BaseType_t core = xTaskGetAffinity(NULL);
+#endif
     if (core != -1) {
         uint32_t desired = 1;
         uint32_t expected = 3;

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -236,7 +236,11 @@ void sys_init_platform(GlobalContext *glb)
     // other cores, supposing it's pinned to core 0.
     esp_pthread_cfg_t esp_pthread_cfg = esp_pthread_get_default_config();
     esp_pthread_cfg.prio = uxTaskPriorityGet(NULL);
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
+    BaseType_t affinity = xTaskGetCoreID(NULL);
+#else
     BaseType_t affinity = xTaskGetAffinity(NULL);
+#endif
     if (affinity == -1) {
         esp_pthread_cfg.pin_to_core = tskNO_AFFINITY;
     } else {


### PR DESCRIPTION
```
warning: 'xTaskGetAffinity' is deprecated: This function is deprecated and will be removed in ESP-IDF 6.0. Please use xTaskGetCoreID() instead. [-Wdeprecated-declarations]
   69 |     BaseType_t core = xTaskGetAffinity(NULL);
      |     ^~~~~~~~~~
In file included from /opt/esp/idf/components/freertos/FreeRTOS-Kernel/include/freertos/FreeRTOS.h:1533,
                 from /__w/AtomVM/AtomVM/src/platforms/esp32/components/avm_sys/smp.c:32:
/opt/esp/idf/components/freertos/esp_additions/include/freertos/idf_additions.h:639:12: note: declared here
  639 | BaseType_t xTaskGetAffinity( TaskHandle_t xTask )
      |            ^~~~~~~~~~~~~~~~
[1055/1091] Building C object esp-idf/avm_sys/CMakeFiles/__idf_avm_sys.dir/platform_defaultatoms.c.obj
[1056/1091] Building C object esp-idf/avm_sys/CMakeFiles/__idf_avm_sys.dir/jit_stream_flash.c.obj
[1057/1091] Building C object esp-idf/avm_sys/CMakeFiles/__idf_avm_sys.dir/platform_nifs.c.obj
[1058/1091] Building C object esp-idf/avm_sys/CMakeFiles/__idf_avm_sys.dir/sys.c.obj
/__w/AtomVM/AtomVM/src/platforms/esp32/components/avm_sys/sys.c: In function 'sys_init_platform':
/__w/AtomVM/AtomVM/src/platforms/esp32/components/avm_sys/sys.c:239:5: warning: 'xTaskGetAffinity' is deprecated: This function is deprecated and will be removed in ESP-IDF 6.0. Please use xTaskGetCoreID() instead. [-Wdeprecated-declarations]
  239 |     BaseType_t affinity = xTaskGetAffinity(NULL);
      |     ^~~~~~~~~~
In file included from /opt/esp/idf/components/freertos/FreeRTOS-Kernel/include/freertos/FreeRTOS.h:1533,
                 from /__w/AtomVM/AtomVM/src/platforms/esp32/components/avm_sys/include/esp32_sys.h:25,
                 from /__w/AtomVM/AtomVM/src/platforms/esp32/components/avm_sys/sys.c:22:
/opt/esp/idf/components/freertos/esp_additions/include/freertos/idf_additions.h:639:12: note: declared here
  639 | BaseType_t xTaskGetAffinity( TaskHandle_t xTask )
      |            ^~~~~~~~~~~~~~~~
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
