### PR TITLE
ESP32: Avoid ESP_IDF_VERSION_MINOR in prep for esp-idf 6

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -310,7 +310,7 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
                 break;
             }
 
-#if ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 2
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
             case WIFI_EVENT_HOME_CHANNEL_CHANGE: {
                 wifi_event_home_channel_change_t *chan_data = (wifi_event_home_channel_change_t *) event_data;
                 ESP_LOGD(TAG, "WIFI_EVENT home channel changed from %u to %u.", chan_data->old_chan, chan_data->new_chan);

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -324,7 +324,7 @@ TEST_CASE("test_monotonic_time", "[test_run]")
 
 #if !CONFIG_IDF_TARGET_ESP32C3 && CONFIG_ETH_USE_OPENETH
 // this test is failing on v5.0.7 due to some kind of problem with atomvm:posix_open
-#if ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 1
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0))
 TEST_CASE("test_mount", "[test_run]")
 {
     term ret_value = avm_test_case("test_mount.beam");


### PR DESCRIPTION
tiniest of preparation for esp-idf 6.0, avoiding any surprises due to version guards.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
