### PR TITLE
Add `esp:timer_get_time/0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `proc_lib`
 - Added gen_server support for timeout tuples in callback return actions introduced in OTP-28.
 - Added `sys`
+- Added `esp:timer_get_time/0`
 
 ### Changed
 

--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -61,7 +61,8 @@
     task_wdt_deinit/0,
     task_wdt_add_user/1,
     task_wdt_reset_user/1,
-    task_wdt_delete_user/1
+    task_wdt_delete_user/1,
+    timer_get_time/0
 ]).
 
 -deprecated([
@@ -676,4 +677,14 @@ task_wdt_reset_user(_UserHandle) ->
 %%-----------------------------------------------------------------------------
 -spec task_wdt_delete_user(UserHandle :: task_wdt_user_handle()) -> ok | {error, any()}.
 task_wdt_delete_user(_UserHandle) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns integer
+%% @doc     Get time in microseconds since boot or wakeup from deep sleep
+%%          Available with ESP-IDF 5.0 or higher.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec timer_get_time() -> integer().
+timer_get_time() ->
     erlang:nif_error(undefined).

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -34,6 +34,7 @@
 
 #include "esp_log.h"
 #include "esp_mac.h"
+#include "esp_timer.h"
 #include <esp_partition.h>
 #include <esp_sleep.h>
 #include <esp_system.h>
@@ -834,6 +835,14 @@ static term nif_esp_task_wdt_delete_user(Context *ctx, int argc, term argv[])
 }
 #endif
 
+static term nif_esp_timer_get_time(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argv);
+    UNUSED(argc);
+
+    return term_make_maybe_boxed_int64(esp_timer_get_time(), &ctx->heap);
+}
+
 //
 // NIF structures and dispatch
 //
@@ -980,6 +989,12 @@ static const struct Nif esp_task_wdt_delete_user_nif =
 };
 #endif
 
+static const struct Nif esp_timer_get_time_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_esp_timer_get_time
+};
+
 const struct Nif *platform_nifs_get_nif(const char *nifname)
 {
     if (strcmp("atomvm:random/0", nifname) == 0) {
@@ -1106,6 +1121,10 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
         return &esp_task_wdt_delete_user_nif;
     }
 #endif
+    if (strcmp("esp:timer_get_time/0", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &esp_timer_get_time_nif;
+    }
     const struct Nif *nif = nif_collection_resolve_nif(nifname);
     if (nif) {
         return nif;

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -59,6 +59,7 @@ function(compile_erlang module_name)
 endfunction()
 
 compile_erlang(test_esp_partition)
+compile_erlang(test_esp_timer_get_time)
 compile_erlang(test_file)
 compile_erlang(test_wifi_example)
 compile_erlang(test_list_to_atom)
@@ -78,6 +79,7 @@ compile_erlang(test_tz)
 
 set(erlang_test_beams
     test_esp_partition.beam
+    test_esp_timer_get_time.beam
     test_file.beam
     test_wifi_example.beam
     test_list_to_atom.beam

--- a/src/platforms/esp32/test/main/test_erl_sources/test_esp_timer_get_time.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_esp_timer_get_time.erl
@@ -1,0 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 schnittchen <schnittchen@das-labor.org>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_esp_timer_get_time).
+
+-export([start/0]).
+
+start() ->
+    T = esp:timer_get_time(),
+    test_non_neg_int(T).
+
+test_non_neg_int(X) when is_integer(X) andalso X >= 0 ->
+    ok;
+test_non_neg_int(_X) ->
+    error.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -186,6 +186,12 @@ TEST_CASE("test_esp_partition", "[test_run]")
     TEST_ASSERT(term_to_int(ret_value) == 0);
 }
 
+TEST_CASE("test_esp_timer_get_time", "[test_run]")
+{
+    term ret_value = avm_test_case("test_esp_timer_get_time.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+}
+
 // SDMMC works all esp-idf versions for esp32 - still no support c3.
 // only run in QEMU (eg. OPENETH configured)
 #if !CONFIG_IDF_TARGET_ESP32C3 && CONFIG_ETH_USE_OPENETH


### PR DESCRIPTION
I hope this addition is welcome. It's incomplete because I would like to get early feedback.

Originally I wanted to simply expose `esp_timer_get_time`, but integer size restrictions make this tricky, so I decided to divide by 10^6 to be able to get the seconds since boot (or wakeup from sleep). This function should be useful at least for monitoring purposes.

If you suggest a nice way to expose the full int64_t precision, I'll happily change the implementation (and name).

This is my first contribution and my first NIF code. Next up I would like to add support for ESP32's DAC, but let's start simple.


These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later