### PR TITLE
CI: Include .ex (and .hrl) files in cache key

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -475,7 +475,7 @@ jobs:
       id: cache
       with:
         path: 'build/tests/**/*.beam'
-        key: ${{ matrix.otp }}-${{ hashFiles('**/build-and-test.yaml', 'tests/**/*.erl') }}-${{ matrix.jit_target_arch }}
+        key: ${{ matrix.otp }}-${{ hashFiles('**/build-and-test.yaml', 'tests/**/*.{erl,hrl,ex}') }}-${{ matrix.jit_target_arch }}
 
     - name: "Build: run cmake"
       working-directory: build


### PR DESCRIPTION
Otherwise changes to elixir tests are not picked up, and CI results are untrustworthy.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
