### PR TITLE
Change `gen:call/4` signature to match OTP's

### DIFF
--- a/libs/estdlib/src/gen.erl
+++ b/libs/estdlib/src/gen.erl
@@ -36,9 +36,18 @@
 -type server_ref() :: atom() | pid().
 -type from() :: {pid(), reference()}.
 
-%% @private
+%%-----------------------------------------------------------------------------
+%% @doc     Perform a call on a gen server. This API not documented by OTP,
+%% yet Elixir uses it, so this function matches the current OTP-28 behavior.
+%% @end
+%% @param ServerRef the server to call
+%% @param Label the label for the message, typically `system' or `$gen_call'
+%% @param Request the message to send
+%% @param Timeout timeout for sending the message
+%% @returns `{ok, Result}' or raises an exit exception
+%%-----------------------------------------------------------------------------
 -spec call(ServerRef :: server_ref(), Label :: atom(), Request :: term(), Timeout :: timeout()) ->
-    Reply :: term() | {error, Reason :: term()}.
+    {ok, Reply :: term()} | {error, Reason :: term()}.
 call(ServerRef, Label, Request, Timeout) ->
     MonitorRef = monitor(process, ServerRef),
     ok =
@@ -59,7 +68,7 @@ call(ServerRef, Label, Request, Timeout) ->
             exit(Atom);
         {MonitorRef, Reply} ->
             demonitor(MonitorRef, [flush]),
-            Reply
+            {ok, Reply}
     after Timeout ->
         % If Timeout is small enough (0), the error message might be timeout
         % instead of noproc as there could be a race condition with the monitor.

--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -422,8 +422,8 @@ call(ServerRef, Request) ->
 -spec call(ServerRef :: server_ref(), Request :: term(), TimeoutMs :: timeout()) ->
     Reply :: term() | {error, Reason :: term()}.
 call(ServerRef, Request, TimeoutMs) ->
-    try
-        gen:call(ServerRef, '$gen_call', Request, TimeoutMs)
+    try gen:call(ServerRef, '$gen_call', Request, TimeoutMs) of
+        {ok, Result} -> Result
     catch
         exit:Reason ->
             exit({Reason, {?MODULE, ?FUNCTION_NAME, [ServerRef, Request, TimeoutMs]}})

--- a/libs/estdlib/src/gen_statem.erl
+++ b/libs/estdlib/src/gen_statem.erl
@@ -210,8 +210,8 @@ call(ServerRef, Request) ->
 -spec call(ServerRef :: server_ref(), Request :: term(), Timeout :: timeout()) ->
     Reply :: term() | {error, Reason :: term()}.
 call(ServerRef, Request, Timeout) ->
-    try
-        gen:call(ServerRef, '$gen_call', Request, Timeout)
+    try gen:call(ServerRef, '$gen_call', Request, Timeout) of
+        {ok, Reply} -> Reply
     catch
         exit:Reason ->
             exit({Reason, {?MODULE, ?FUNCTION_NAME, [ServerRef, Request]}})

--- a/libs/estdlib/src/sys.erl
+++ b/libs/estdlib/src/sys.erl
@@ -130,7 +130,8 @@ change_code(Name, Module, OldVsn, Extra) ->
     Timeout :: timeout()
 ) -> ok | {error, any()}.
 change_code(Name, Module, OldVsn, Extra, Timeout) ->
-    gen:call(Name, system, {change_code, Module, OldVsn, Extra}, Timeout).
+    {ok, Reply} = gen:call(Name, system, {change_code, Module, OldVsn, Extra}, Timeout),
+    Reply.
 
 %% @equiv get_state(Name, 5000)
 -spec get_state(Name :: name()) -> any().
@@ -147,7 +148,8 @@ get_state(Name) ->
 %%-----------------------------------------------------------------------------
 -spec get_state(Name :: name(), timeout()) -> any().
 get_state(Name, Timeout) ->
-    case gen:call(Name, system, get_state, Timeout) of
+    {ok, Reply} = gen:call(Name, system, get_state, Timeout),
+    case Reply of
         {ok, State} -> State;
         {error, Reason} -> error(Reason)
     end.
@@ -168,7 +170,8 @@ get_status(Name) ->
 -spec get_status(Name :: name(), Timeout :: timeout()) ->
     {status, pid(), {module, module()}, [SItem :: any()]}.
 get_status(Name, Timeout) ->
-    gen:call(Name, system, get_status, Timeout).
+    {ok, Reply} = gen:call(Name, system, get_status, Timeout),
+    Reply.
 
 %% @equiv replace_state(Name, StateFun, 5000)
 -spec replace_state(Name :: name(), StateFun :: fun((any()) -> any())) -> ok.
@@ -185,7 +188,8 @@ replace_state(Name, StateFun) ->
 %%-----------------------------------------------------------------------------
 -spec replace_state(Name :: name(), StateFun :: fun((any()) -> any()), Timeout :: timeout()) -> ok.
 replace_state(Name, StateFun, Timeout) ->
-    case gen:call(Name, system, {replace_state, StateFun}, Timeout) of
+    {ok, Reply} = gen:call(Name, system, {replace_state, StateFun}, Timeout),
+    case Reply of
         {ok, State} -> State;
         {error, Reason} -> error(Reason)
     end.
@@ -204,7 +208,8 @@ resume(Name) ->
 %%-----------------------------------------------------------------------------
 -spec resume(Name :: name(), Timeout :: timeout()) -> ok.
 resume(Name, Timeout) ->
-    gen:call(Name, system, resume, Timeout).
+    {ok, ok} = gen:call(Name, system, resume, Timeout),
+    ok.
 
 %% @equiv suspend(Name, 5000)
 -spec suspend(Name :: name()) -> ok.
@@ -221,7 +226,8 @@ suspend(Name) ->
 %%-----------------------------------------------------------------------------
 -spec suspend(Name :: name(), Timeout :: timeout()) -> ok.
 suspend(Name, Timeout) ->
-    gen:call(Name, system, suspend, Timeout).
+    {ok, ok} = gen:call(Name, system, suspend, Timeout),
+    ok.
 
 %% @equiv terminate(Name, Reason, 5000)
 -spec terminate(Name :: name(), Reason :: any()) -> ok.
@@ -238,7 +244,8 @@ terminate(Name, Reason) ->
 %%-----------------------------------------------------------------------------
 -spec terminate(Name :: name(), Reason :: any(), Timeout :: timeout()) -> ok.
 terminate(Name, Reason, Timeout) ->
-    gen:call(Name, system, {terminate, Reason}, Timeout).
+    {ok, ok} = gen:call(Name, system, {terminate, Reason}, Timeout),
+    ok.
 
 %% @equiv trace(Name, Flag, 5000)
 -spec trace(Name :: name(), Flag :: boolean()) -> ok.
@@ -255,7 +262,8 @@ trace(Name, Flag) ->
 %%-----------------------------------------------------------------------------
 -spec trace(Name :: name(), Flag :: boolean(), Timeout :: timeout()) -> ok.
 trace(Name, Flag, Timeout) ->
-    gen:call(Name, system, {debug, {trace, Flag}}, Timeout).
+    {ok, ok} = gen:call(Name, system, {debug, {trace, Flag}}, Timeout),
+    ok.
 
 %%-----------------------------------------------------------------------------
 %% Process Implementation Functions


### PR DESCRIPTION
Elixir calls this undocumented function, so ensure we have the same signature even if it's slightly less efficient.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
