### PR TITLE
Change TRACE macro to also output newline, if anything

### DIFF
--- a/src/libAtomVM/trace.h
+++ b/src/libAtomVM/trace.h
@@ -23,7 +23,7 @@
 
 #ifndef TRACE
 #ifdef ENABLE_TRACE
-#define TRACE printf
+#define TRACE(...) do { printf(__VA_ARGS__); printf("\n"); } while(0)
 #define DEBUG_FAIL_NULL(expr) assert((expr) != NULL)
 #else
 #define TRACE(...)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
