### PR TITLE
Fix double close with posix files

### DIFF
--- a/src/libAtomVM/posix_nifs.c
+++ b/src/libAtomVM/posix_nifs.c
@@ -173,7 +173,7 @@ static void posix_fd_dtor(ErlNifEnv *caller_env, void *obj)
     UNUSED(caller_env);
 
     struct PosixFd *fd_obj = (struct PosixFd *) obj;
-    if (fd_obj->fd) {
+    if (fd_obj->fd != CLOSED_FD) {
         close(fd_obj->fd);
         fd_obj->fd = CLOSED_FD;
     }


### PR DESCRIPTION
Fix a bug where posix files would be closed twice, generating valgrind warnings

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
