### PR TITLE
Fix crash when firing resource monitor, typically for distribution

### DIFF
--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -212,7 +212,7 @@ struct ResourceContextMonitor
 {
     struct Monitor monitor;
     uint64_t ref_ticks;
-    void *resource_obj;
+    struct ResourceType *resource_type;
 };
 
 struct LinkRemoteMonitor

--- a/src/libAtomVM/resources.h
+++ b/src/libAtomVM/resources.h
@@ -158,18 +158,21 @@ term select_event_make_notification(void *rsrc_obj, uint64_t ref_ticks, bool is_
  * the resource still exists.
  * @param resource_type type holding the list of monitors
  * @param env environment for calling the down handler
- * @param resource resource that monitored the process
  * @param process_id id of the process monitored
  * @param ref_ticks reference of the monitor
  */
-void resource_type_fire_monitor(struct ResourceType *resource_type, ErlNifEnv *env, void *resource, int32_t process_id, uint64_t ref_ticks);
+void resource_type_fire_monitor(struct ResourceType *resource_type, ErlNifEnv *env, int32_t process_id, uint64_t ref_ticks);
 
 /**
- * @brief Remove monitor from list of monitors.
+ * @brief Get a resource from a resource monitor
+ * @details verifies using resource monitors that the resource still exists
+ * and increases the refcount by creating a term for it in the provided heap
  * @param resource_type type holding the list of monitors
  * @param ref_ticks reference of the monitor
+ * @param heap heap to create the resource term into
+ * @return a resource term or invalid if the resource is gone
  */
-void resource_type_demonitor(struct ResourceType *resource_type, uint64_t ref_ticks);
+term resource_monitor_to_resource(struct ResourceType *resource_type, uint64_t ref_ticks, Heap *heap);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
There was a race condition where a context being monitored by a resource is being terminated at the same time as the resource. The resource message to unmonitor would be lost by the process and the process tried nevertheless to fire the monitor, causing a crash (worst case) or a valgrind error (best case).

Fixes #1985 and #1883

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
