### PR TITLE
CI: Fix macos mbedtls

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -40,19 +40,23 @@ jobs:
       matrix:
         os: ["macos-14", "macos-15", "macos-15-intel", "macos-26"]
         otp: ["24", "25", "26", "27", "28"]
+        mbedtls: ["mbedtls@3"]
         cmake_opts_other: [""]
 
         include:
         - os: "macos-15-intel"
           otp: "28"
+          mbedtls: "mbedtls@3"
           cmake_opts_other: "-DAVM_DISABLE_JIT=OFF"
 
         - os: "macos-14"
           otp: "28"
+          mbedtls: "mbedtls@3"
           cmake_opts_other: "-DAVM_DISABLE_JIT=OFF"
 
         - os: "macos-15"
           otp: "28"
+          mbedtls: "mbedtls@3"
           cmake_opts_other: "-DAVM_DISABLE_JIT=OFF"
 
     steps:
@@ -64,13 +68,13 @@ jobs:
 
     - name: "Install deps"
       if: matrix.otp != '24' && matrix.otp != '25'
-      run: brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam mbedtls rebar3
+      run: brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam ${{ matrix.mbedtls }} rebar3
 
     - name: "Install deps"
       if: matrix.otp == '24' || matrix.otp == '25'
       run: |
         brew update
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam mbedtls
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam ${{ matrix.mbedtls }}
         wget https://github.com/erlang/rebar3/releases/download/3.23.0/rebar3
         chmod +x rebar3
         for bin_dir in {/usr/local,/opt/homebrew}/opt/erlang@{24,25}/bin/ ; do
@@ -86,6 +90,23 @@ jobs:
           echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
           dscacheutil -q host -a name $(hostname -f)
         done
+
+    - name: "Setup mbedtls@3 environment"
+      if: matrix.mbedtls == 'mbedtls@3'
+      run: |
+        # Detect Homebrew prefix (Apple Silicon vs Intel)
+        if [ -d "/opt/homebrew/opt/mbedtls@3" ]; then
+          MBEDTLS_PREFIX="/opt/homebrew/opt/mbedtls@3"
+        elif [ -d "/usr/local/opt/mbedtls@3" ]; then
+          MBEDTLS_PREFIX="/usr/local/opt/mbedtls@3"
+        else
+          echo "Error: mbedtls@3 not found in expected locations"
+          exit 1
+        fi
+        echo "MBEDTLS_PREFIX=${MBEDTLS_PREFIX}" >> $GITHUB_ENV
+        echo "LDFLAGS=-L${MBEDTLS_PREFIX}/lib" >> $GITHUB_ENV
+        echo "CPPFLAGS=-I${MBEDTLS_PREFIX}/include" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=${MBEDTLS_PREFIX}/lib/pkgconfig" >> $GITHUB_ENV
 
     # Builder info
     - name: "System info"
@@ -106,7 +127,7 @@ jobs:
       working-directory: build
       run: |
         export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
-        cmake -DAVM_WARNINGS_ARE_ERRORS=ON ${{ matrix.cmake_opts_other }} -G Ninja ..
+        cmake -DAVM_WARNINGS_ARE_ERRORS=ON ${MBEDTLS_PREFIX:+-DCMAKE_PREFIX_PATH="$MBEDTLS_PREFIX"} ${{ matrix.cmake_opts_other }} -G Ninja ..
 
     - name: "Build: run ninja"
       working-directory: build

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -115,7 +115,24 @@ jobs:
 
     - name: "Install deps (macOS)"
       if: runner.os == 'macOS'
-      run: brew update && brew install gperf erlang@${{ matrix.otp }} mbedtls rebar3
+      run: brew update && brew install gperf erlang@${{ matrix.otp }} mbedtls@3 rebar3
+
+    - name: "macOS setup mbedtls@3 environment"
+      if: runner.os == 'macOS'
+      run: |
+        # Detect Homebrew prefix (Apple Silicon vs Intel)
+        if [ -d "/opt/homebrew/opt/mbedtls@3" ]; then
+          MBEDTLS_PREFIX="/opt/homebrew/opt/mbedtls@3"
+        elif [ -d "/usr/local/opt/mbedtls@3" ]; then
+          MBEDTLS_PREFIX="/usr/local/opt/mbedtls@3"
+        else
+          echo "Error: mbedtls@3 not found in expected locations"
+          exit 1
+        fi
+        echo "MBEDTLS_PREFIX=${MBEDTLS_PREFIX}" >> $GITHUB_ENV
+        echo "LDFLAGS=-L${MBEDTLS_PREFIX}/lib" >> $GITHUB_ENV
+        echo "CPPFLAGS=-I${MBEDTLS_PREFIX}/include" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=${MBEDTLS_PREFIX}/lib/pkgconfig" >> $GITHUB_ENV
 
     # Build
     - name: "Build: create build dir"
@@ -131,7 +148,7 @@ jobs:
       working-directory: build
       run: |
         export PATH="${{ matrix.path_prefix }}$PATH"
-        cmake -G Ninja ${{ matrix.cmake_opts }} ..
+        cmake -G Ninja ${MBEDTLS_PREFIX:+-DCMAKE_PREFIX_PATH="$MBEDTLS_PREFIX"} ${{ matrix.cmake_opts }} ..
 
     - name: "Touch files to benefit from cache"
       working-directory: build


### PR DESCRIPTION
MacOS ci now defaults to mbed-tls 4, which we don't support currently..

Tested here https://github.com/petermm/AtomVM/tree/mbedtls-4-support for matrix.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
