### PR TITLE
Fix a crash when `gpio:close/0` is called but server was not running

### DIFF
--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -146,7 +146,12 @@ close(GPIO) ->
 %%-----------------------------------------------------------------------------
 -spec stop() -> ok | {error, Reason :: atom()} | error.
 stop() ->
-    close(whereis(gpio)).
+    case whereis(gpio) of
+        undefined ->
+            ok;
+        Port when is_port(Port) ->
+            close(Port)
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @param   GPIO pid that was returned from gpio:start/0


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
