### PR TITLE
Fix a binary corruption bug occurring with private_append

### DIFF
--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -1093,7 +1093,7 @@ term term_reuse_binary(term src, size_t size, Heap *heap, GlobalContext *glb)
     }
     // Not a refc binary or it's a const refc binary - create a new one
     size_t src_size = term_binary_size(src);
-    term t = term_create_uninitialized_binary(size, heap, glb);
+    term t = term_create_empty_binary(size, heap, glb);
     // Copy the source data (up to the smaller of src_size and size)
     size_t copy_size = src_size < size ? src_size : size;
     memcpy((void *) term_binary_data(t), (void *) term_binary_data(src), copy_size);


### PR DESCRIPTION
When a binary is small enough to be on heap and private_append is used for binary construction, a new binary is created and it needs to be zero'd if further binary construction instructions only set bits.

Fixes #2003

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
