### PR TITLE
ESP32: Prepare for esp-idf 6

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 
 # WHOLE_ARCHIVE option is supported only with esp-idf 5.x
 # A link option will be used with esp-idf 4.x
-if (IDF_VERSION_MAJOR EQUAL 5)
+if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
     set(OPTIONAL_WHOLE_ARCHIVE WHOLE_ARCHIVE)
 else()
     set(OPTIONAL_WHOLE_ARCHIVE "")

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -747,7 +747,7 @@ static void start_network(Context *ctx, term pid, term ref, term config)
     // Set up STA mode, if configured
     //
     if (!IS_NULL_PTR(sta_wifi_config)) {
-        if ((err = esp_wifi_set_config(ESP_IF_WIFI_STA, sta_wifi_config)) != ESP_OK) {
+        if ((err = esp_wifi_set_config(WIFI_IF_STA, sta_wifi_config)) != ESP_OK) {
             ESP_LOGE(TAG, "Error setting STA mode config %d", err);
             free(sta_wifi_config);
             if (!IS_NULL_PTR(ap_wifi_config)) {
@@ -766,7 +766,7 @@ static void start_network(Context *ctx, term pid, term ref, term config)
     // Set up AP mode, if configured
     //
     if (!IS_NULL_PTR(ap_wifi_config)) {
-        if ((err = esp_wifi_set_config(ESP_IF_WIFI_AP, ap_wifi_config)) != ESP_OK) {
+        if ((err = esp_wifi_set_config(WIFI_IF_AP, ap_wifi_config)) != ESP_OK) {
             ESP_LOGE(TAG, "Error setting AP mode config %d", err);
             free(ap_wifi_config);
             term error = port_create_error_tuple(ctx, term_from_int(err));

--- a/src/platforms/esp32/components/avm_sys/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_sys/CMakeLists.txt
@@ -33,9 +33,11 @@ set(AVM_SYS_COMPONENT_SRCS
     "../../../../libAtomVM/portnifloader.c"
 )
 
-if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
-    set(ADDITIONAL_COMPONENTS "esp_partition")
-    # available starting from v4.4
+if (IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    set(ADDITIONAL_COMPONENTS "esp_partition" "esp_driver_ledc" "esp_driver_uart")
+    set(ADDITIONAL_PRIV_REQUIRES "esp_hw_support")
+elseif (IDF_VERSION_MAJOR GREATER_EQUAL 5 AND IDF_VERSION_MAJOR LESS 6)
+    set(ADDITIONAL_COMPONENTS "newlib" "esp_partition")
     set(ADDITIONAL_PRIV_REQUIRES "esp_hw_support")
 else()
     set(ADDITIONAL_COMPONENTS "")
@@ -45,7 +47,7 @@ endif()
 idf_component_register(
     SRCS ${AVM_SYS_COMPONENT_SRCS}
     INCLUDE_DIRS "include"
-    REQUIRES "spi_flash" "soc" "newlib" "pthread" "vfs" "mbedtls" ${ADDITIONAL_COMPONENTS}
+    REQUIRES "spi_flash" "soc" "pthread" "vfs" "mbedtls" ${ADDITIONAL_COMPONENTS}
     PRIV_REQUIRES "libatomvm" "esp_timer" ${ADDITIONAL_PRIV_REQUIRES}
 )
 
@@ -54,8 +56,15 @@ target_compile_features(${COMPONENT_LIB} INTERFACE c_std_11)
 idf_component_get_property(soc_dir soc COMPONENT_DIR)
 idf_component_get_property(soc_include_dirs soc INCLUDE_DIRS)
 idf_build_get_property(idf_target IDF_TARGET)
+
+if (IDF_VERSION_MAJOR LESS 6)
 idf_component_get_property(newlib_dir newlib COMPONENT_DIR)
 idf_component_get_property(newlib_include_dirs newlib INCLUDE_DIRS)
+else()
+idf_component_get_property(newlib_dir esp_libc COMPONENT_DIR)
+idf_component_get_property(newlib_include_dirs esp_libc INCLUDE_DIRS)
+endif()
+
 idf_component_get_property(pthread_dir pthread COMPONENT_DIR)
 idf_component_get_property(pthread_include_dirs pthread INCLUDE_DIRS)
 idf_component_get_property(pthread_srcs pthread SRCS)

--- a/src/platforms/esp32/test/main/idf_component.yml
+++ b/src/platforms/esp32/test/main/idf_component.yml
@@ -1,0 +1,7 @@
+dependencies:
+  "espressif/dp83848":
+   version: "~1.0.0"
+   rules:
+    - if: "idf_version >=6.0"
+    - if: target in ["esp32", "esp32p4"]
+    - if: "$CONFIG{ETH_USE_OPENETH} == True"

--- a/src/platforms/esp32/test/main/idf_component.yml.license
+++ b/src/platforms/esp32/test/main/idf_component.yml.license
@@ -1,0 +1,2 @@
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: AtomVM Contributors

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -34,6 +34,12 @@
 #include "sys.h"
 
 #include <driver/sdmmc_host.h>
+
+// Since IDF v6 it's a separate component
+#if ESP_IDF_VERSION_MAJOR >= 6 && CONFIG_ETH_USE_OPENETH
+#include "esp_eth_phy_dp83848.h"
+#endif
+
 #include <esp_eth.h>
 #include <esp_event.h>
 #include <esp_log.h>


### PR DESCRIPTION
Minimal changes. Running this on top of the mbedtls4 branch gives full green simtest CI on v6.0-beta1. Confirmed CI working 5.1-5.5

avm_builtins/CMakeLists.txt:
`EQUAL -> GREATER_EQUAL`
obvious.

avm_builtins/network_driver.c:
Hard deprecations for these.

avm_sys/CMakeLists.txt
IDF6 needs "esp_driver_ledc" "esp_driver_uart" as components.
newlib component has been renamed to esp_libc, and is now default included. so newlib not included idf6+ - and then some workaround for minimal changes with the newlib_dir/newlib_include_dirs

espressif/dp83848
separate component now for the ethernet qemu driver - nicely handled with the idf_component.yml

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
