### PR TITLE
Fix last minute typo in `code_server.erl`

### DIFF
--- a/libs/estdlib/src/code_server.erl
+++ b/libs/estdlib/src/code_server.erl
@@ -204,7 +204,7 @@ load(Module) ->
 %% Currently, the only live stream backend that needs estimate is mmap
 %% and it should not be passed a value too large to not slow down valgrind too
 %% much during tests. A factor of 32 is more than enough, the largest observed
-%% ration is 21 for aarch64 and Elixir code. Also apply a minimum of 128 kb
+%% ratio is 21 for aarch64 and Elixir code. Also apply a minimum of 128 kb
 %% which shouldn't affect valgrind too much.
 %% jit_stream_flash and jit_stream_binary ignore the size parameter.
 %% @return size in bytes


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
