### PR TITLE
Fix is_adc_resource after resources were made refs

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/adc_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/adc_driver.c
@@ -126,7 +126,7 @@ static bool is_adc_resource(GlobalContext *global, term t)
     bool ret = term_is_tuple(t)
         && term_get_tuple_arity(t) == 3
         && globalcontext_is_term_equal_to_atom_string(global, term_get_tuple_element(t, 0), ATOM_STR("\x4", "$adc"))
-        && term_is_binary(term_get_tuple_element(t, 1))
+        && term_is_resource_reference(term_get_tuple_element(t, 1))
         && term_is_reference(term_get_tuple_element(t, 2));
 
     return ret;

--- a/src/platforms/esp32/components/avm_builtins/dac_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/dac_driver.c
@@ -76,7 +76,7 @@ static term error_return_tuple(Context *ctx, term term)
 
 static term get_channel_resource(Context *ctx, term t, ErlNifResourceType *res_type, struct AnyChannelResource **res)
 {
-    bool likely_valid = (term_is_tuple(t) && term_get_tuple_arity(t) == 3 && globalcontext_is_term_equal_to_atom_string(ctx->global, term_get_tuple_element(t, 0), ATOM_STR("\x4", "$dac")) && term_is_binary(term_get_tuple_element(t, 1)) && term_is_reference(term_get_tuple_element(t, 2)));
+    bool likely_valid = (term_is_tuple(t) && term_get_tuple_arity(t) == 3 && globalcontext_is_term_equal_to_atom_string(ctx->global, term_get_tuple_element(t, 0), ATOM_STR("\x4", "$dac")) && term_is_resource_reference(term_get_tuple_element(t, 1)) && term_is_reference(term_get_tuple_element(t, 2)));
 
     if (likely_valid) {
         if (UNLIKELY(!enif_get_resource(erl_nif_env_from_context(ctx), term_get_tuple_element(t, 1), res_type, (void **) res))) {

--- a/src/platforms/esp32/components/avm_builtins/i2c_resource.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_resource.c
@@ -90,7 +90,7 @@ static bool is_i2c_resource(GlobalContext *global, term t)
     bool ret = term_is_tuple(t)
         && term_get_tuple_arity(t) == 3
         && globalcontext_is_term_equal_to_atom_string(global, term_get_tuple_element(t, 0), I2C_ATOMSTR)
-        && term_is_binary(term_get_tuple_element(t, 1))
+        && term_is_resource_reference(term_get_tuple_element(t, 1))
         && term_is_reference(term_get_tuple_element(t, 2));
 
     return ret;


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
