### PR TITLE
clang-format -i src/libAtomVM/term.h

### DIFF
--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1080,7 +1080,7 @@ static inline term term_from_int28(int32_t value)
  * @param value the value that will be converted to a term.
  * @return a term that encapsulates the integer value.
  */
-static inline term term_from_int32(int32_t value) __attribute__ ((deprecated ("term_from_int32 is unsafe and will be removed")));
+static inline term term_from_int32(int32_t value) __attribute__((deprecated("term_from_int32 is unsafe and will be removed")));
 static inline term term_from_int32(int32_t value)
 {
 #if TERM_BITS == 32
@@ -1102,7 +1102,7 @@ static inline term term_from_int32(int32_t value)
 #endif
 }
 
-static inline term term_from_int64(int64_t value) __attribute__ ((deprecated ("term_from_int64 is unsafe and will be removed")));
+static inline term term_from_int64(int64_t value) __attribute__((deprecated("term_from_int64 is unsafe and will be removed")));
 static inline term term_from_int64(int64_t value)
 {
 #if TERM_BITS == 32


### PR DESCRIPTION
Fix formatting error introduced with
092f4c5c6b482025d2402caa135b9e321b1529af.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
