### PR TITLE
Add receive timeouts to avoid the 20-30 mins global timeouts

### DIFF
--- a/tests/libs/estdlib/test_tcp_socket.erl
+++ b/tests/libs/estdlib/test_tcp_socket.erl
@@ -197,6 +197,8 @@ start_echo_server(_Port) ->
     receive
         ready ->
             ok
+    after 10000 ->
+        error({timeout, ?MODULE, ?LINE})
     end,
 
     {ListenSocket, ActualPort}.
@@ -568,6 +570,8 @@ test_abandon_select() ->
     receive
         done ->
             ok
+    after 10000 ->
+        error({timeout, ?MODULE, ?LINE})
     end,
 
     erlang:garbage_collect(),


### PR DESCRIPTION
Example:

https://github.com/atomvm/AtomVM/actions/runs/20328642536/job/58398869314#step:31:1

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
