### PR TITLE
Fix race condition in `sys_poll_events_with_poll` on unix

### DIFF
--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -264,6 +264,7 @@ static inline void sys_poll_events_with_poll(GlobalContext *glb, int timeout_ms)
                     fd_index++;
                 }
             }
+            platform->listeners_poll_count = listeners_new_count;
             synclist_unlock(&glb->listeners);
         } else {
             // Else we can reuse the previous list
@@ -281,12 +282,11 @@ static inline void sys_poll_events_with_poll(GlobalContext *glb, int timeout_ms)
                 fd_index++;
             }
         }
+        platform->select_events_poll_count = select_events_new_count;
         synclist_unlock(&glb->select_events);
 
         listeners_poll_count = listeners_new_count;
         select_events_poll_count = select_events_new_count;
-        platform->listeners_poll_count = listeners_new_count;
-        platform->select_events_poll_count = select_events_new_count;
     }
 
     poll_count += listeners_poll_count + select_events_poll_count;


### PR DESCRIPTION
Ensure `listeners_poll_count` and `select_events_poll_count` are only updated with locks acquired. This avoids a race condition where `listeners_poll_count` would be marked clean while it was marked dirty with `sys_register_listener` at the same time. It could explain some timeout issues with tests.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
