### PR TITLE
CI: build-and-test.yaml: increase minimum Elixir version to 1.11

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -201,7 +201,7 @@ jobs:
           cxx: "c++"
           cflags: ""
           otp: "21"
-          elixir_version: "1.7"
+          elixir_version: "1.11"
           rebar3_version: "3.15.2"
           compiler_pkgs: "g++"
 
@@ -210,7 +210,7 @@ jobs:
           cxx: "c++"
           cflags: ""
           otp: "22"
-          elixir_version: "1.8"
+          elixir_version: "1.11"
           rebar3_version: "3.18.0"
           compiler_pkgs: "g++"
 


### PR DESCRIPTION
Recent Range.ex fixes require a newer Elixir compiler.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
