### PR TITLE
Enable/Make AVM_PRINT_PROCESS_CRASH_DUMPS work on embedded platforms

### DIFF
--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -85,5 +85,6 @@ option(AVM_DISABLE_SMP "Disable SMP." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
+option(AVM_PRINT_PROCESS_CRASH_DUMPS "Print crash reports when processes die with non-standard reasons" ON)
 
 add_subdirectory(tools)

--- a/src/platforms/rp2/CMakeLists.txt
+++ b/src/platforms/rp2/CMakeLists.txt
@@ -67,6 +67,7 @@ option(AVM_WAIT_BOOTSEL_ON_EXIT "Wait in BOOTSEL rather than shutdown on exit" O
 option(AVM_REBOOT_ON_NOT_OK "Reboot Pico if result is not ok" OFF)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
 option(AVM_DISABLE_JIT "Disable just in time compilation." ON)
+option(AVM_PRINT_PROCESS_CRASH_DUMPS "Print crash reports when processes die with non-standard reasons" ON)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^cortex-m.+$")
     # We only have armv6m for now, which all cortex-m should support
     if (NOT AVM_DISABLE_JIT)

--- a/src/platforms/stm32/CMakeLists.txt
+++ b/src/platforms/stm32/CMakeLists.txt
@@ -36,6 +36,7 @@ option(AVM_ENABLE_LOG_LINES "Include source and line info for all enbled levels"
 option(AVM_CONFIG_REBOOT_ON_NOT_OK "Reboot when application exits with non 'ok' return" OFF)
 option(AVM_DISABLE_GPIO_NIFS "Disable GPIO nifs (input and output)" OFF)
 option(AVM_DISABLE_GPIO_PORT_DRIVER "Disable GPIO 'port' driver (input, output, and interrupts)" OFF)
+option(AVM_PRINT_PROCESS_CRASH_DUMPS "Print crash reports when processes die with non-standard reasons" ON)
 
 set(AVM_DISABLE_SMP ON FORCE)
 set(AVM_DISABLE_TASK_DRIVER ON FORCE)


### PR DESCRIPTION
AVM_PRINT_PROCESS_CRASH_DUMPS was introduced with bcfdcc69d (PR #1799), but the option hasn't been exposed / set on embedded targets (such as esp32, stm32 and rp2).

The reason is that esp32 CMakeLists.txt doesn't include the root CMakeLists.txt, and the libAtomVM one doesn't have that option defined (it is defined on the root CMakeLists.txt), so that option didn't have a default value.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
