### PR TITLE
CI: esp32-build: update latest esp-idf

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -52,7 +52,7 @@ jobs:
          - 'v5.2.6'
          - 'v5.3.4'
          - 'v5.4.3'
-         - 'v5.5.1'
+         - 'v5.5.2'
 
         exclude:
         - esp-idf-target: "esp32c3"

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        idf-version: ["5.5.1"]
+        idf-version: ["5.5.2"]
         cc: ["clang-14"]
         cxx: ["clang++-14"]
         cflags: ["-O3"]

--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -80,7 +80,7 @@ jobs:
             "esp32c6",
             "esp32h2"
           ]
-        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.6", "v5.2.6", "v5.3.4", "v5.4.3", "v5.5.1"]')) || fromJSON('["v5.5.1"]') }}
+        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.6", "v5.2.6", "v5.3.4", "v5.4.3", "v5.5.2"]')) || fromJSON('["v5.5.2"]') }}
         exclude:
           - esp-idf-target: "esp32p4"
             idf-version: "v5.1.6"


### PR DESCRIPTION
Just update v5.5.1 -> v5.5.2. No other updates are available.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
