### PR TITLE
Start phasing out old OTP versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(Erlang)
 find_package(Elixir)
 find_package(Gleam)
 
+option(AVM_ENABLE_OLD_OTP_VERSIONS "Enable OTP version < 26" ON)
 option(AVM_DISABLE_FP "Disable floating point support." OFF)
 option(AVM_DISABLE_SMP "Disable SMP." OFF)
 option(AVM_DISABLE_TASK_DRIVER "Disable task driver support." OFF)

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -199,6 +199,12 @@ if(AVM_SELECT_IN_TASK)
     target_compile_definitions(libAtomVM PUBLIC AVM_SELECT_IN_TASK)
 endif()
 
+# Start phasing out old OTP versions
+if(NOT AVM_ENABLE_OLD_OTP_VERSIONS)
+target_compile_definitions(libAtomVM PUBLIC MINIMUM_OTP_COMPILER_VERSION=26)
+target_compile_definitions(libAtomVM PUBLIC MAXIMUM_OTP_COMPILER_VERSION=29)
+endif()
+
 include(CheckIncludeFile)
 CHECK_INCLUDE_FILE(stdatomic.h STDATOMIC_INCLUDE)
 include(CheckCSourceCompiles)

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -49,8 +49,12 @@
 
 // These constants can be used to reduce the size of the VM for a specific
 // range of compiler versions
+#ifndef MINIMUM_OTP_COMPILER_VERSION
 #define MINIMUM_OTP_COMPILER_VERSION 21
-#define MAXIMUM_OTP_COMPILER_VERSION 26
+#endif
+#ifndef MAXIMUM_OTP_COMPILER_VERSION
+#define MAXIMUM_OTP_COMPILER_VERSION 29
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/platforms/emscripten/CMakeLists.txt
+++ b/src/platforms/emscripten/CMakeLists.txt
@@ -29,6 +29,7 @@ if (NOT CMAKE_TOOLCHAIN_FILE)
 endif ()
 
 # Options that make sense for this platform
+option(AVM_ENABLE_OLD_OTP_VERSIONS "Enable OTP version < 26" ON)
 option(AVM_DISABLE_SMP "Disable SMP." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)

--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -80,6 +80,7 @@ if (-std=gnu99 IN_LIST c_compile_options )
 endif()
 
 # Options that make sense for this platform
+option(AVM_ENABLE_OLD_OTP_VERSIONS "Enable OTP version < 26" OFF)
 option(AVM_DISABLE_SMP "Disable SMP." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)

--- a/src/platforms/rp2/CMakeLists.txt
+++ b/src/platforms/rp2/CMakeLists.txt
@@ -58,6 +58,7 @@ set(HAVE_EXECVE "" CACHE INTERNAL "Have symbol execve" FORCE)
 set(HAVE_GETCWD "" CACHE INTERNAL "Have symbol getcwd" FORCE)
 
 # Options that make sense for this platform
+option(AVM_ENABLE_OLD_OTP_VERSIONS "Enable OTP version < 26" OFF)
 option(AVM_DISABLE_SMP "Disable SMP support." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)

--- a/src/platforms/stm32/CMakeLists.txt
+++ b/src/platforms/stm32/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Options that make sense for this platform
+option(AVM_ENABLE_OLD_OTP_VERSIONS "Enable OTP version < 26" OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." ON)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)


### PR DESCRIPTION
Start disabling them on MCU targets.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
