### PR TITLE
CI: Fix freebsd nxdomain failure

### DIFF
--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -65,6 +65,11 @@ jobs:
       run: |
         pkg install -y curl cmake gperf erlang elixir rebar3 mbedtls3
 
+    - name: "Add hostname to /etc/hosts for distribution tests"
+      shell: freebsd {0}
+      run: |
+        echo "127.0.0.1 $(hostname)" >> /etc/hosts
+
     - name: "System info"
       shell: freebsd {0}
       run: |


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
