### PR TITLE
Doc: distributed-erlang.md: fix example file path

### DIFF
--- a/doc/src/distributed-erlang.md
+++ b/doc/src/distributed-erlang.md
@@ -17,7 +17,7 @@ Distribution is currently available on all platforms with TCP/IP communication, 
 Two examples are provided:
 
 - disterl in `examples/erlang/disterl.erl`: distribution on Unix systems
-- epmd\_disterl in `examples/esp32/epmd_disterl.erl`: distribution on ESP32 devices
+- epmd\_disterl in `examples/erlang/esp32/epmd_disterl.erl`: distribution on ESP32 devices
 
 ## Starting and stopping distribution
 


### PR DESCRIPTION
Add missing `/erlang`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
