### PR TITLE
Fix deep_sleep_hold with esp-idf >= 5.4

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -723,7 +723,9 @@ static term nif_gpio_hold_dis(Context *ctx, int argc, term argv[])
     return hold_dis(argv[0]);
 }
 
-#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2) && SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP)
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) \
+    || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 0) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2) && SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) \
+    || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP)
 static term nif_gpio_deep_sleep_hold_en(Context *ctx, int argc, term argv[])
 {
     UNUSED(ctx);
@@ -785,7 +787,9 @@ static const struct Nif gpio_hold_dis_nif =
     .nif_ptr = nif_gpio_hold_dis
 };
 
-#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2) && SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP)
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) \
+    || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 0) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2) && SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) \
+    || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP)
 static const struct Nif gpio_deep_sleep_hold_en_nif = {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_gpio_deep_sleep_hold_en
@@ -844,7 +848,9 @@ const struct Nif *gpio_nif_get_nif(const char *nifname)
         return &gpio_hold_dis_nif;
     }
 
-#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2) && SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP)
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) \
+    || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 0) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2) && SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP) \
+    || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 2) && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP)
     if (strcmp("gpio:deep_sleep_hold_en/0", nifname) == 0 || strcmp("Elixir.GPIO:deep_sleep_hold_en/0", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &gpio_deep_sleep_hold_en_nif;


### PR DESCRIPTION
`esp:deep_sleep_hold_en/0` and `esp:deep_sleep_hold_dis/0` nifs were disabled with esp-idf greater than 5.4 because macros used by esp-idf to define if they exist changed (5.3.2+ was an exception).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
