### PR TITLE
Bump test_node timeout to reduce flappiness

### DIFF
--- a/tests/erlang_tests/test_node.erl
+++ b/tests/erlang_tests/test_node.erl
@@ -53,7 +53,7 @@ test_node_distribution() ->
     ok =
         receive
             {'DOWN', MonitorRef, process, NetKernelPid, normal} -> ok
-        after 1000 -> timeout
+        after 5000 -> timeout
         end,
     case node() of
         nonode@nohost ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
