### PR TITLE
Fix a race condition in spawn / monitor

### DIFF
--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -67,6 +67,7 @@ enum ContextFlags
     Killed = 16,
     Trap = 32,
     Distribution = 64,
+    Spawning = 128,
 };
 
 enum HeapGrowthStrategy

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1398,6 +1398,7 @@ static term nif_erlang_spawn_fun_opt(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(opts_term, term_is_list);
 
     Context *new_ctx = context_new(ctx->global);
+    context_update_flags(new_ctx, ~Spawning, Spawning);
 
     const term *boxed_value = term_to_const_term_ptr(fun_term);
 
@@ -1457,6 +1458,7 @@ term nif_erlang_spawn_opt(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(opts_term, term_is_list);
 
     Context *new_ctx = context_new(ctx->global);
+    context_update_flags(new_ctx, ~Spawning, Spawning);
 
     Module *found_module = globalcontext_get_module(ctx->global, term_to_atom_index(module_term));
     if (UNLIKELY(!found_module)) {

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -351,7 +351,7 @@ static void scheduler_make_ready(Context *ctx)
 {
     GlobalContext *global = ctx->global;
     SMP_SPINLOCK_LOCK(&global->processes_spinlock);
-    if (context_get_flags(ctx, Killed)) {
+    if (context_get_flags(ctx, Killed | Spawning)) {
         SMP_SPINLOCK_UNLOCK(&global->processes_spinlock);
         return;
     }
@@ -406,9 +406,10 @@ static void scheduler_make_ready_from_task(Context *ctx)
 }
 #endif
 
-void scheduler_init_ready(Context *c)
+void scheduler_init_ready(Context *ctx)
 {
-    scheduler_make_ready(c);
+    context_update_flags(ctx, ~Spawning, NoFlags);
+    scheduler_make_ready(ctx);
 }
 
 void scheduler_signal_message(Context *c)


### PR DESCRIPTION
Spawn with dist_monitor could crash with the following scenario:
- a process is spawned with dist monitor from dist nifs
- dist_monitor sends a message to the newly created process because the remote node is no longer reachable
- the process is therefore scheduled, and could terminate
- do_spawn would continue and call `scheduler_init_ready` on a destroyed ctx

The fix consists in adding a new context flag, `Spawning`, which prevents the spawning process from being scheduled until do_spawn calls `scheduler_init_ready`.

This is what happened on CI as commented here:
https://github.com/atomvm/AtomVM/issues/2030#issuecomment-3796133203

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
