### PR TITLE
Handle elixirc parallel compilation

### DIFF
--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -63,7 +63,7 @@ jobs:
     - name: "Install deps"
       shell: freebsd {0}
       run: |
-        pkg install -y curl cmake gperf erlang elixir rebar3 mbedtls3
+        pkg install -y curl cmake gperf erlang elixir rebar3 mbedtls3 ninja
 
     - name: "Add hostname to /etc/hosts for distribution tests"
       shell: freebsd {0}
@@ -108,19 +108,19 @@ jobs:
         cd build
         cmake .. -DMBEDTLS_ROOT_DIR=/usr/local -DAVM_WARNINGS_ARE_ERRORS=ON
 
-    - name: "Build: run make"
+    - name: "Build: compile"
       shell: freebsd {0}
       run: |
         cd $GITHUB_WORKSPACE;
         cd build
-        make -j `sysctl -n hw.ncpu`
+        cmake --build .
 
     - name: "Build: run dialyzer"
       shell: freebsd {0}
       run: |
         cd $GITHUB_WORKSPACE;
         cd build
-        make -j `sysctl -n hw.ncpu`
+        cmake --build . -t dialyzer
 
     - name: "Test: test-erlang"
       shell: freebsd {0}
@@ -197,7 +197,7 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE;
         cd build
-        make install
+        cmake --build . -t install
         atomvm examples/erlang/hello_world.avm
         atomvm -v
         atomvm -h

--- a/CMakeModules/BuildElixir.cmake
+++ b/CMakeModules/BuildElixir.cmake
@@ -29,7 +29,7 @@ macro(pack_archive avm_name)
             COMMAND sh -c "mv ${CMAKE_CURRENT_BINARY_DIR}/beams.tmp.${module_name}/Elixir.*.beam ${CMAKE_CURRENT_BINARY_DIR}/beams/"
             COMMAND rmdir ${CMAKE_CURRENT_BINARY_DIR}/beams.tmp.${module_name}
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.ex
-            COMMENT "Compiling ${module_name}.ex (core)"
+            COMMENT "Compiling ${module_name}.ex"
             VERBATIM
         )
         set(BEAMS ${BEAMS} ${CMAKE_CURRENT_BINARY_DIR}/beams/Elixir.${module_name}.beam)


### PR DESCRIPTION
Ensure that modules are not partially written when elixirc tries to access them by compiling modules to a temporary directory and moving them to the beams directory next.

This fixes one of the esp32 flappiness as it could fail on CI with ninja.

Also convert FreeBSD builds to ninja to workaround the weird truncation issue we are having with make builds.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
