### PR TITLE
Add debug symbols to clang builds

### DIFF
--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -134,7 +134,7 @@ target_compile_features(libAtomVM PUBLIC c_std_11)
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(libAtomVM PUBLIC -Wall ${MAYBE_PEDANTIC_FLAG} ${MAYBE_WERROR_FLAG} -Wextra -ggdb -Werror=incompatible-pointer-types)
 elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
-    target_compile_options(libAtomVM PUBLIC -Wall ${MAYBE_PEDANTIC_FLAG} -Wno-gnu-zero-variadic-macro-arguments --extra-warnings -Werror=incompatible-pointer-types ${MAYBE_WERROR_FLAG})
+    target_compile_options(libAtomVM PUBLIC -Wall ${MAYBE_PEDANTIC_FLAG} -Wno-gnu-zero-variadic-macro-arguments --extra-warnings -Werror=incompatible-pointer-types ${MAYBE_WERROR_FLAG} -g)
 endif()
 
 if (ENABLE_REALLOC_GC)

--- a/src/platforms/generic_unix/CMakeLists.txt
+++ b/src/platforms/generic_unix/CMakeLists.txt
@@ -25,6 +25,8 @@ set_target_properties(AtomVM PROPERTIES RUNTIME_OUTPUT_DIRECTORY ../../ ENABLE_E
 target_compile_features(AtomVM PUBLIC c_std_11)
 if(CMAKE_COMPILER_IS_GNUCC)
     target_compile_options(AtomVM PUBLIC -Wall -pedantic -Wextra -ggdb)
+elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    target_compile_options(AtomVM PUBLIC -Wall -pedantic -Wextra -g)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")


### PR DESCRIPTION
Some CI failures involve generating a core dump, and we are missing the symbols if the binary was compiled with Clang. Just add symbols to these builds as we have symbols with gcc builds.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
