### PR TITLE
Fix: crash with function_clause when io:format on binary

### DIFF
--- a/libs/estdlib/src/io.erl
+++ b/libs/estdlib/src/io.erl
@@ -177,8 +177,10 @@ format(IODevice, Format, Data) ->
 %%          formatting capabilities.
 %% @end
 %%-----------------------------------------------------------------------------
--spec fwrite(IODevice :: device(), Format :: string(), Args :: list()) -> string().
-fwrite(IODevice, Format, Args) when is_list(Format) andalso is_list(Args) ->
+-spec fwrite(IODevice :: device(), Format :: format(), Args :: list()) -> ok.
+fwrite(IODevice, Format, Args) when
+    (is_list(Format) orelse is_binary(Format)) andalso is_list(Args)
+->
     Msg =
         try
             io_lib:format(Format, Args)


### PR DESCRIPTION
Elixir users, and presumably various AI, and editors
has a tendency to inadvertently call io:format
with an Elixir string eg a binary:

`:io.format("----->create_net: ok, ip_info=~p~n", [ip_info])`

Which crashes, with function_clause error..

This allows the binary, as the underlying
io_lib:format(Format, Args) handles the Format
being a binary
https://github.com/atomvm/AtomVM/blob/887e71a98f28df52e6d6f41d344cad685092cf2b/libs/estdlib/src/io_lib.erl#L74

Also fixes the spec, including return spec since
put_chars/2 returns ok

Fixes https://github.com/atomvm/AtomVM/issues/2078
- see issue for confusing error/Crash

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
