### PR TITLE
CI: Expand crypto tests - fix badarg signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `binary_to_integer` and `list_to_integer` do not raise anymore `overflow` error, they raise
 instead `badarg`.
 - Resources are now references instead of empty binaries.
+- Badarg error return from calling crypto:crypto_one_time with invalid arguments now matches OTP24+.
 
 ### Fixed
 

--- a/src/libAtomVM/otp_crypto.c
+++ b/src/libAtomVM/otp_crypto.c
@@ -477,7 +477,7 @@ static term nif_crypto_crypto_one_time(Context *ctx, int argc, term argv[])
 
     } else {
         if (UNLIKELY(!bool_to_mbedtls_operation(flag_or_options, &operation))) {
-            error_atom = BADARG_ATOM;
+            error_atom = make_crypto_error(__FILE__, __LINE__, "Options are not a boolean or a proper list", ctx);
             goto raise_error;
         }
     }

--- a/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
@@ -169,7 +169,7 @@ test_crypto_one_time() ->
     true = is_list(Message2),
 
     % Invalid opts
-    badarg = get_error(fun() ->
+    {badarg, {File3, Line3}, Message3} = get_error(fun() ->
         crypto:crypto_one_time(
             aes_128_ctr,
             <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
@@ -178,6 +178,9 @@ test_crypto_one_time() ->
             {bad}
         )
     end),
+    true = is_list(File3),
+    true = is_integer(Line3),
+    true = is_list(Message3),
 
     ok.
 

--- a/tests/erlang_tests/test_crypto.erl
+++ b/tests/erlang_tests/test_crypto.erl
@@ -23,6 +23,14 @@
 
 start() ->
     ok = test_hash(),
+    OTPVersion = get_otp_version(),
+    case OTPVersion =:= atomvm orelse OTPVersion >= 24 of
+        true ->
+            ok = test_crypto_one_time(),
+            ok = test_available_ciphers();
+        false ->
+            ok
+    end,
     0.
 
 test_hash() ->
@@ -90,4 +98,128 @@ expect(Error, F) ->
                 _ when Error == E ->
                     ok
             end
+    end.
+
+test_crypto_one_time() ->
+    <<50, 136, 204, 108, 55>> = crypto:crypto_one_time(
+        aes_128_ctr,
+        <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
+        <<1:120, 5:8>>,
+        <<"Hello">>,
+        true
+    ),
+
+    % No padding is used so output will be truncated
+    <<231, 108, 83, 104, 188, 131, 182, 65, 2, 128, 78, 162, 210, 149, 128, 248>> = crypto:crypto_one_time(
+        aes_128_cbc, <<1:128>>, <<0:128>>, <<"First bytesSecond bytes">>, true
+    ),
+
+    % Previous test, but with iolist
+    <<231, 108, 83, 104, 188, 131, 182, 65, 2, 128, 78, 162, 210, 149, 128, 248>> = crypto:crypto_one_time(
+        aes_128_cbc,
+        <<1:128>>,
+        <<0:128>>,
+        [<<"First ">>, $b, $y, <<"tes">>, [<<"Second ">>, <<"bytes">>]],
+        true
+    ),
+
+    <<117, 16, 152, 235, 154, 151, 58, 120, 64, 65, 33, 201, 242, 240, 41, 177>> = crypto:crypto_one_time(
+        aes_256_cbc, <<5, 1:240, 7>>, <<1:120, 7:8>>, <<"Test">>, [
+            {encrypt, true}, {padding, pkcs_padding}
+        ]
+    ),
+
+    <<218, 189, 18, 174, 31, 123, 37, 254, 119, 34, 71, 35, 219, 0, 185, 153>> = crypto:crypto_one_time(
+        aes_256_ecb, <<5, 1:240, 7>>, <<"Test1234567890ab">>, [{encrypt, true}]
+    ),
+
+    {badarg, {File, Line}, Message} = get_error(fun() ->
+        crypto:crypto_one_time(bad, <<1:128>>, <<0:128>>, <<"Test">>, true)
+    end),
+    true = is_list(File),
+    true = is_integer(Line),
+    true = is_list(Message),
+
+    % Invalid key
+    {badarg, {File1, Line1}, Message1} = get_error(fun() ->
+        crypto:crypto_one_time(
+            aes_128_ctr,
+            <<>>,
+            <<1:120, 5:8>>,
+            <<"Hello">>,
+            true
+        )
+    end),
+    true = is_list(File1),
+    true = is_integer(Line1),
+    true = is_list(Message1),
+
+    % Invalid IV
+    {badarg, {File2, Line2}, Message2} = get_error(fun() ->
+        crypto:crypto_one_time(
+            aes_128_ctr,
+            <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
+            <<5>>,
+            <<"Hello">>,
+            true
+        )
+    end),
+    true = is_list(File2),
+    true = is_integer(Line2),
+    true = is_list(Message2),
+
+    % Invalid opts - we match behaviour OTP24+
+    {badarg, {File3, Line3}, Message3} = get_error(fun() ->
+        crypto:crypto_one_time(
+            aes_128_ctr,
+            <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
+            <<1:120, 5:8>>,
+            <<"Hello">>,
+            {bad}
+        )
+    end),
+    true = is_list(File3),
+    true = is_integer(Line3),
+    true = is_list(Message3),
+
+    ok.
+
+test_available_ciphers() ->
+    <<171, 29, 253, 3, 110, 255, 225, 168, 40, 2, 92, 101, 18, 22, 104, 89>> =
+        crypto:crypto_one_time(aes_128_cbc, <<1:128>>, <<2:128>>, <<3:128>>, false),
+    <<33, 51, 81, 23, 26, 72, 178, 26, 115, 82, 208, 26, 225, 24, 76, 245>> =
+        crypto:crypto_one_time(aes_256_cbc, <<1:256>>, <<2:128>>, <<3:128>>, false),
+    <<149, 146, 215, 117, 124, 68, 24, 44, 51, 164, 46, 233, 81, 71, 162, 220>> =
+        crypto:crypto_one_time(aes_128_ctr, <<1:128>>, <<2:128>>, <<3:128>>, false),
+    <<89, 151, 109, 175, 200, 98, 75, 207, 80, 33, 65, 131, 194, 29, 141, 242>> =
+        crypto:crypto_one_time(aes_256_ctr, <<1:256>>, <<2:128>>, <<3:128>>, false),
+    <<149, 146, 215, 117, 124, 68, 24, 44, 51, 164, 46, 233, 81, 71, 162, 220>> =
+        crypto:crypto_one_time(aes_128_cfb128, <<1:128>>, <<2:128>>, <<3:128>>, false),
+    <<89, 151, 109, 175, 200, 98, 75, 207, 80, 33, 65, 131, 194, 29, 141, 242>> =
+        crypto:crypto_one_time(aes_256_cfb128, <<1:256>>, <<2:128>>, <<3:128>>, false),
+    <<51, 126, 5, 238, 121, 110, 153, 245, 229, 187, 6, 58, 119, 97, 242, 197>> =
+        crypto:crypto_one_time(aes_128_ecb, <<1:128>>, <<2:128>>, false),
+    <<9, 134, 59, 77, 138, 44, 15, 97, 69, 171, 187, 23, 29, 143, 25, 227>> =
+        crypto:crypto_one_time(aes_256_ecb, <<1:256>>, <<2:128>>, false),
+    % Erlang/OTP also allows to call aes_*_ecb with an iv
+    <<171, 29, 253, 3, 110, 255, 225, 168, 40, 2, 92, 101, 18, 22, 104, 91>> =
+        crypto:crypto_one_time(aes_128_ecb, <<1:128>>, <<2:128>>, <<3:128>>, false),
+    <<33, 51, 81, 23, 26, 72, 178, 26, 115, 82, 208, 26, 225, 24, 76, 247>> =
+        crypto:crypto_one_time(aes_256_ecb, <<1:256>>, <<2:128>>, <<3:128>>, false),
+    ok.
+
+get_error(F) ->
+    try
+        F(),
+        fail
+    catch
+        _:E -> E
+    end.
+
+get_otp_version() ->
+    case erlang:system_info(machine) of
+        "BEAM" ->
+            list_to_integer(erlang:system_info(otp_release));
+        _ ->
+            atomvm
     end.


### PR DESCRIPTION
This is in preparation of mbedtls4 - the standard
crypto tests were a bit limited
(compared to the esp32 ones).

Sync tests/erlang_tests/test_crypto.erl with the
more comprehensive ESP32 test suite.

Fix and align the error return from calling crypto_one_time with badargs to match otp24+ behaviour. Fails BEAM otp<24 - so guarded the relevant tests..

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
