### PR TITLE
Fix small warning in `test_raw_raise.erl`

### DIFF
--- a/tests/erlang_tests/test_raw_raise.erl
+++ b/tests/erlang_tests/test_raw_raise.erl
@@ -51,7 +51,7 @@ do_raise() ->
 
 do_catch2() ->
     try ?MODULE:do_raise_not_error() of
-        X -> 0
+        _ -> 0
     catch
         _:_ -> 1
     end.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
