### PR TITLE
Add few missing `ledc` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for resource managed binaries (`enif_make_resource_binary`)
 - Added initial support for ESP32C5 and ESP32C61
 - Added `Range:size/1`
+- Added missing `ledc` functions for esp32 platform
 
 ### Changed
 

--- a/libs/eavmlib/src/ledc.erl
+++ b/libs/eavmlib/src/ledc.erl
@@ -36,10 +36,14 @@
     fade_func_uninstall/0,
     set_fade_with_time/4,
     set_fade_with_step/5,
+    set_fade_time_and_start/5,
+    set_fade_step_and_start/6,
     fade_start/3,
+    fade_stop/2,
     get_duty/2,
     set_duty/3,
     update_duty/2,
+    set_duty_and_update/4,
     get_freq/2,
     set_freq/3,
     stop/3
@@ -173,6 +177,59 @@ set_fade_with_step(_SpeedMode, _Channel, _TargetDuty, _Scale, _CycleNum) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
+%% @param   SpeedMode       Select the LEDC channel group with specified speed mode.
+%%                          Note that not all targets support high speed mode.
+%% @param   Channel         LEDC channel index (0-7).
+%% @param   TargetDuty      Target duty of fading. (0..(2^duty_resolution)-1)
+%% @param   MaxFadeTimeMs   The maximum time of the fading (ms).
+%% @param   FadeMode        Whether to block until fading done.
+%% @returns ok | {error, ledc_error_code()}
+%% @doc     Set LEDC fade function with a limited time and start fading.
+%%
+%%          Thread-safe version that atomically configures and starts the fade.
+%%          This can safely be called from different processes for different channels.
+%%          Note. Call ledc:fade_func_install/1 once before calling this function.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec set_fade_time_and_start(
+    SpeedMode :: speed_mode(),
+    Channel :: channel(),
+    TargetDuty :: non_neg_integer(),
+    MaxFadeTimeMs :: non_neg_integer(),
+    FadeMode :: fade_mode()
+) ->
+    ok | {error, ledc_error_code()}.
+set_fade_time_and_start(_SpeedMode, _Channel, _TargetDuty, _MaxFadeTimeMs, _FadeMode) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
+%%                      Note that not all targets support high speed mode.
+%% @param   Channel     LEDC channel index (0-7).
+%% @param   TargetDuty  Target duty of fading. (0..(2^duty_resolution)-1)
+%% @param   Scale       Controls the increase or decrease step scale.
+%% @param   CycleNum    increase or decrease the duty every cycle_num cycles
+%% @param   FadeMode    Whether to block until fading done.
+%% @returns ok | {error, ledc_error_code()}
+%% @doc     Set LEDC fade function with step and start fading.
+%%
+%%          Thread-safe version that atomically configures and starts the fade.
+%%          This can safely be called from different processes for different channels.
+%%          Note. Call ledc:fade_func_install/1 once before calling this function.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec set_fade_step_and_start(
+    SpeedMode :: speed_mode(),
+    Channel :: channel(),
+    TargetDuty :: non_neg_integer(),
+    Scale :: non_neg_integer(),
+    CycleNum :: non_neg_integer(),
+    FadeMode :: fade_mode()
+) -> ok | {error, ledc_error_code()}.
+set_fade_step_and_start(_SpeedMode, _Channel, _TargetDuty, _Scale, _CycleNum, _FadeMode) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
 %%                      Note that not all targets support high speed mode.
 %% @param   Channel     LEDC channel index (0-7).
@@ -265,4 +322,45 @@ set_freq(_SpeedMode, _TimerNum, _FreqHz) ->
 -spec stop(SpeedMode :: speed_mode(), Channel :: channel(), IdleLevel :: non_neg_integer()) ->
     ok | {error, ledc_error_code()}.
 stop(_SpeedMode, _Channel, _IdleLevel) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
+%%                      Note that not all targets support high speed mode.
+%% @param   Channel     LEDC channel index (0-7).
+%% @returns ok | {error, ledc_error_code()}
+%% @doc     Stop LEDC fading.
+%%
+%%          Note. Call ledc:fade_func_install/1 once before calling this function.
+%%          This function is only available on platforms with
+%%          SOC_LEDC_SUPPORT_FADE_STOP (including esp32s2, esp32c3 but not esp32).
+%% @end
+%%-----------------------------------------------------------------------------
+-spec fade_stop(SpeedMode :: speed_mode(), Channel :: channel()) ->
+    ok | {error, ledc_error_code()}.
+fade_stop(_SpeedMode, _Channel) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
+%%                      Note that not all targets support high speed mode.
+%% @param   Channel     LEDC channel index (0-7).
+%% @param   Duty        Set the LEDC duty, the range of setting is [0, (2^duty_resolution)-1].
+%% @param   HPoint      Set the LEDC hpoint value.
+%% @returns ok | {error, ledc_error_code()}
+%% @doc     Set LEDC duty and update immediately (thread-safe).
+%%
+%%          Thread-safe version that atomically sets duty and triggers an update.
+%%          This can safely be called from different processes for different channels.
+%%          Note. Call ledc:fade_func_install/1 once before calling this function.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec set_duty_and_update(
+    SpeedMode :: speed_mode(),
+    Channel :: channel(),
+    Duty :: non_neg_integer(),
+    HPoint :: non_neg_integer()
+) ->
+    ok | {error, ledc_error_code()}.
+set_duty_and_update(_SpeedMode, _Channel, _Duty, _HPoint) ->
     erlang:nif_error(undefined).

--- a/src/platforms/esp32/components/avm_builtins/ledc_nif.c
+++ b/src/platforms/esp32/components/avm_builtins/ledc_nif.c
@@ -31,6 +31,8 @@
 #include "esp32_sys.h"
 
 #include <driver/ledc.h>
+#include <soc/soc_caps.h>
+
 #include <stdlib.h>
 
 //#define ENABLE_TRACE
@@ -223,6 +225,89 @@ static term nif_ledc_fade_start(Context *ctx, int argc, term argv[])
     }
 }
 
+#if SOC_LEDC_SUPPORT_FADE_STOP
+static term nif_ledc_fade_stop(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    term speed_mode = argv[0];
+    VALIDATE_VALUE(speed_mode, term_is_integer);
+    term channel = argv[1];
+    VALIDATE_VALUE(channel, term_is_integer);
+
+    esp_err_t err = ledc_fade_stop(
+        term_to_int(speed_mode),
+        term_to_int(channel));
+    if (UNLIKELY(err != ESP_OK)) {
+        fprintf(stderr, "Unable to ledc_fade_stop. err=%i\n", err);
+        RAISE_ERROR(term_from_int(err));
+    } else {
+        TRACE("ledc_fade_stop\n");
+        return OK_ATOM;
+    }
+}
+#endif
+
+static term nif_ledc_set_fade_time_and_start(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    term speed_mode = argv[0];
+    VALIDATE_VALUE(speed_mode, term_is_integer);
+    term channel = argv[1];
+    VALIDATE_VALUE(channel, term_is_integer);
+    term duty = argv[2];
+    VALIDATE_VALUE(duty, term_is_integer);
+    term fade_time = argv[3];
+    VALIDATE_VALUE(fade_time, term_is_integer);
+    term fade_mode = argv[4];
+    VALIDATE_VALUE(fade_mode, term_is_integer);
+
+    esp_err_t err = ledc_set_fade_time_and_start(
+        term_to_int(speed_mode),
+        term_to_int(channel),
+        term_to_int(duty),
+        term_to_int(fade_time),
+        term_to_int(fade_mode));
+    if (UNLIKELY(err != ESP_OK)) {
+        fprintf(stderr, "Unable to ledc_set_fade_time_and_start. err=%i\n", err);
+        RAISE_ERROR(term_from_int(err));
+    } else {
+        TRACE("ledc_set_fade_time_and_start\n");
+        return OK_ATOM;
+    }
+}
+
+static term nif_ledc_set_fade_step_and_start(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    term speed_mode = argv[0];
+    VALIDATE_VALUE(speed_mode, term_is_integer);
+    term channel = argv[1];
+    VALIDATE_VALUE(channel, term_is_integer);
+    term duty = argv[2];
+    VALIDATE_VALUE(duty, term_is_integer);
+    term scale = argv[3];
+    VALIDATE_VALUE(scale, term_is_integer);
+    term cycle_num = argv[4];
+    VALIDATE_VALUE(cycle_num, term_is_integer);
+    term fade_mode = argv[5];
+    VALIDATE_VALUE(fade_mode, term_is_integer);
+
+    esp_err_t err = ledc_set_fade_step_and_start(
+        term_to_int(speed_mode),
+        term_to_int(channel),
+        term_to_int(duty),
+        term_to_int(scale),
+        term_to_int(cycle_num),
+        term_to_int(fade_mode));
+    if (UNLIKELY(err != ESP_OK)) {
+        fprintf(stderr, "Unable to ledc_set_fade_step_and_start. err=%i\n", err);
+        RAISE_ERROR(term_from_int(err));
+    } else {
+        TRACE("ledc_set_fade_step_and_start\n");
+        return OK_ATOM;
+    }
+}
+
 static term nif_ledc_get_duty(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
@@ -282,6 +367,32 @@ static term nif_ledc_update_duty(Context *ctx, int argc, term argv[])
         RAISE_ERROR(term_from_int(err));
     } else {
         TRACE("ledc_update_duty\n");
+        return OK_ATOM;
+    }
+}
+
+static term nif_ledc_set_duty_and_update(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    term speed_mode = argv[0];
+    VALIDATE_VALUE(speed_mode, term_is_integer);
+    term channel = argv[1];
+    VALIDATE_VALUE(channel, term_is_integer);
+    term duty = argv[2];
+    VALIDATE_VALUE(duty, term_is_integer);
+    term hpoint = argv[3];
+    VALIDATE_VALUE(hpoint, term_is_integer);
+
+    esp_err_t err = ledc_set_duty_and_update(
+        term_to_int(speed_mode),
+        term_to_int(channel),
+        term_to_int(duty),
+        term_to_int(hpoint));
+    if (UNLIKELY(err != ESP_OK)) {
+        fprintf(stderr, "Unable to ledc_set_duty_and_update. err=%i\n", err);
+        RAISE_ERROR(term_from_int(err));
+    } else {
+        TRACE("ledc_set_duty_and_update\n");
         return OK_ATOM;
     }
 }
@@ -387,6 +498,20 @@ static const struct Nif ledc_fade_start_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_ledc_fade_start
 };
+#if SOC_LEDC_SUPPORT_FADE_STOP
+static const struct Nif ledc_fade_stop_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_ledc_fade_stop
+};
+#endif
+static const struct Nif ledc_set_fade_time_and_start_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_ledc_set_fade_time_and_start
+};
+static const struct Nif ledc_set_fade_step_and_start_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_ledc_set_fade_step_and_start
+};
 static const struct Nif ledc_get_duty_nif =
 {
     .base.type = NIFFunctionType,
@@ -401,6 +526,10 @@ static const struct Nif ledc_update_duty_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_ledc_update_duty
+};
+static const struct Nif ledc_set_duty_and_update_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_ledc_set_duty_and_update
 };
 static const struct Nif ledc_get_freq_nif =
 {
@@ -448,6 +577,20 @@ const struct Nif *ledc_nif_get_nif(const char *nifname)
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &ledc_fade_start_nif;
     }
+#if SOC_LEDC_SUPPORT_FADE_STOP
+    if (strcmp("ledc:fade_stop/2", nifname) == 0 || strcmp("Elixir.LEDC:fade_stop/2", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &ledc_fade_stop_nif;
+    }
+#endif
+    if (strcmp("ledc:set_fade_time_and_start/5", nifname) == 0 || strcmp("Elixir.LEDC:set_fade_time_and_start/5", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &ledc_set_fade_time_and_start_nif;
+    }
+    if (strcmp("ledc:set_fade_step_and_start/6", nifname) == 0 || strcmp("Elixir.LEDC:set_fade_step_and_start/6", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &ledc_set_fade_step_and_start_nif;
+    }
     if (strcmp("ledc:get_duty/2", nifname) == 0 || strcmp("Elixir.LEDC:get_duty/2", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &ledc_get_duty_nif;
@@ -459,6 +602,10 @@ const struct Nif *ledc_nif_get_nif(const char *nifname)
     if (strcmp("ledc:update_duty/2", nifname) == 0 || strcmp("Elixir.LEDC:update_duty/2", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &ledc_update_duty_nif;
+    }
+    if (strcmp("ledc:set_duty_and_update/4", nifname) == 0 || strcmp("Elixir.LEDC:set_duty_and_update/4", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &ledc_set_duty_and_update_nif;
     }
     if (strcmp("ledc:get_freq/2", nifname) == 0 || strcmp("Elixir.LEDC:get_freq/2", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);


### PR DESCRIPTION
Add ledc thread-safe functions:
- `ledc:set_fade_time_and_start/5`
- `ledc:set_fade_step_and_start/6`
- `ledc:set_duty_and_update/6`

Also add `ledc:fade_stop/2` on platforms that have it (esp32c3 for example)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
