### PR TITLE
NIFs: fix bug in erlang:fun_info/2

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4123,9 +4123,14 @@ static term nif_erlang_fun_info_2(Context *ctx, int argc, term argv[])
             RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(2), 2, (term[]){ key, value }, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    term roots[2] = { key, value };
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(2), 2, roots, MEMORY_CAN_SHRINK)
+            != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
+    key = roots[0];
+    value = roots[1];
+
     term fun_info_tuple = term_alloc_tuple(2, &ctx->heap);
     term_put_tuple_element(fun_info_tuple, 0, key);
     term_put_tuple_element(fun_info_tuple, 1, value);


### PR DESCRIPTION
`memory_ensure_free_with_roots(..., 2, (term[]){ key, value }, ...)` is a bad pattern.
In this example, after GC, roots should be read since `key` and `value` now may point to invalid terms, but that anonymous array cannot be accessed, so actual `key` and `value` cannot be read.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
