### PR TITLE
Fix eunit report format to be properly parsed by Unity

### DIFF
--- a/libs/etest/src/eunit.erl
+++ b/libs/etest/src/eunit.erl
@@ -222,7 +222,7 @@ report(Progress, Identification) ->
     ModuleString =
         case lists:keyfind(module, 1, Identification) of
             false -> "";
-            {module, Module} -> io_lib:format("~s:", [Module])
+            {module, Module} -> atom_to_list(Module)
         end,
     TestCaseString =
         case lists:keyfind(test_case, 1, Identification) of
@@ -231,8 +231,8 @@ report(Progress, Identification) ->
         end,
     LineString =
         case lists:keyfind(line, 1, Identification) of
-            false -> "";
-            {line, Line} -> io_lib:format("~B:", [Line])
+            false -> "0";
+            {line, Line} -> integer_to_list(Line)
         end,
     TitleString =
         case lists:keyfind(title, 1, Identification) of
@@ -247,7 +247,7 @@ report(Progress, Identification) ->
             {exit, Reason} -> io_lib:format(":FAIL:exited with ~p", [Reason]);
             timeout -> ":FAIL:timeout"
         end,
-    io:format("~s:~s ~s~s~s\n", [
+    io:format("~s:~s:~s~s~s\n", [
         ModuleString, LineString, TestCaseString, TitleString, ProgressString
     ]).
 


### PR DESCRIPTION
`eunit` reports could not be parsed by Unity test framework used by espressif qemu test environment and as a result test failures were not reported.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
