### PR TITLE
Add a new CodeQL query to check free of structures

### DIFF
--- a/code-queries/mismatched-free-type.ql
+++ b/code-queries/mismatched-free-type.ql
@@ -1,0 +1,87 @@
+/**
+ * This file is part of AtomVM.
+ *
+ * Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+ *
+ * @name Free of pointer type never used in malloc
+ * @kind problem
+ * @problem.severity error
+ * @id atomvm/mismatched-free-type
+ * @tags correctness
+ * @precision high
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+import cpp
+
+import semmle.code.cpp.dataflow.new.DataFlow
+
+string getMallocedTypeNameDirect(FunctionCall malloc) {
+    malloc.getTarget().hasGlobalName("malloc") and
+    exists(SizeofTypeOperator sizeofExpr |
+        sizeofExpr = malloc.getArgument(0).getAChild*() and
+        result = sizeofExpr.getTypeOperand().stripType().getName()
+    )
+}
+
+string getMallocedTypeNameIndirect(FunctionCall malloc) {
+    malloc.getTarget().hasGlobalName("malloc") and
+    exists(SizeofTypeOperator sizeofExpr, DataFlow::Node source, DataFlow::Node sink |
+        source.asExpr().getAChild*() = sizeofExpr and
+        sink.asExpr() = malloc.getArgument(0) and
+        DataFlow::localFlow(source, sink) and
+        result = sizeofExpr.getTypeOperand().stripType().getName()
+    )
+}
+
+string getCallocedTypeName(FunctionCall calloc) {
+    calloc.getTarget().hasGlobalName("calloc") and
+    exists(SizeofTypeOperator sizeofExpr |
+        sizeofExpr = calloc.getArgument(1).getAChild*() and
+        result = sizeofExpr.getTypeOperand().stripType().getName()
+    )
+}
+
+predicate isAllocatedType(string typeName) {
+    exists(FunctionCall malloc | typeName = getMallocedTypeNameDirect(malloc))
+    or
+    exists(FunctionCall malloc | typeName = getMallocedTypeNameIndirect(malloc))
+    or
+    exists(FunctionCall calloc | typeName = getCallocedTypeName(calloc))
+}
+
+predicate isDoublePointer(Type t) {
+    exists(PointerType pt |
+        pt = t.getUnspecifiedType() and
+        pt.getBaseType().getUnspecifiedType() instanceof PointerType
+    )
+}
+
+string getPointedStructName(Type t) {
+    not isDoublePointer(t) and
+    exists(PointerType pt, Struct s |
+        pt = t.getUnspecifiedType() and
+        s = pt.getBaseType().getUnspecifiedType() and
+        result = s.getName()
+    )
+}
+
+predicate isCastToVoidPtr(Expr e) {
+    exists(CStyleCast cast |
+        cast = e.getConversion*() and
+        cast.getType().getUnspecifiedType().(PointerType).getBaseType() instanceof VoidType
+    )
+}
+
+from FunctionCall freeCall, Expr arg, string freedTypeName
+where
+    freeCall.getTarget().hasGlobalName("free") and
+    arg = freeCall.getArgument(0) and
+    freedTypeName = getPointedStructName(arg.getType()) and
+    not isAllocatedType(freedTypeName) and
+    // Exclude void* which is generic
+    freedTypeName != "" and
+    // Allow suppression via explicit cast to (void *)
+    not isCastToVoidPtr(arg)
+select freeCall, "Freeing pointer of type 'struct " + freedTypeName + "' but no malloc(sizeof(struct " + freedTypeName + ")) or calloc exists in codebase. Cast to (void *) to suppress."

--- a/code-queries/qlpack.yml
+++ b/code-queries/qlpack.yml
@@ -7,6 +7,8 @@
 #
 
 name: atomvm/cpp-atomvmql
+version: 0.0.1
 groups: [cpp]
-libraryPathDependencies: codeql/cpp-all
+dependencies:
+  codeql/cpp-all: "*"
 extractor: cpp

--- a/src/libAtomVM/dist_nifs.c
+++ b/src/libAtomVM/dist_nifs.c
@@ -405,7 +405,7 @@ static term nif_erlang_dist_ctrl_get_data(Context *ctx, int argc, term argv[])
         }
         result = term_from_literal_binary(packet->bytes, packet->size, &ctx->heap, ctx->global);
         list_remove(first);
-        free(first);
+        free(packet);
     }
     synclist_unlock(&conn_obj->pending_packets);
 

--- a/src/libAtomVM/listeners.h
+++ b/src/libAtomVM/listeners.h
@@ -152,7 +152,7 @@ static inline bool process_listener_handler(GlobalContext *glb, listener_event_t
 void sys_listener_destroy(struct ListHead *item)
 {
     EventListener *listener = GET_LIST_ENTRY(item, EventListener, listeners_list_head);
-    free(listener);
+    free((void *) listener);
 }
 #endif /* DOXYGEN_SKIP_SECTION */
 

--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -352,10 +352,10 @@ static inline void memory_destroy_heap_fragment(HeapFragment *fragment)
 {
     while (fragment->next) {
         HeapFragment *next = fragment->next;
-        free(fragment);
+        free((void *) fragment);
         fragment = next;
     }
-    free(fragment);
+    free((void *) fragment);
 }
 
 /**

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -461,7 +461,8 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
         while (!list_is_empty(&line_refs)) {
             struct ListHead *item = line_refs.next;
             list_remove(item);
-            free(item);
+            struct LineRefOffset *previous_ref_offset = GET_LIST_ENTRY(item, struct LineRefOffset, head);
+            free(previous_ref_offset);
         }
 #endif
 #ifndef AVM_NO_JIT
@@ -1093,7 +1094,8 @@ void module_insert_line_ref_offset(Module *mod, struct ListHead *line_refs, uint
         while (!list_is_empty(line_refs)) {
             struct ListHead *item = line_refs->next;
             list_remove(item);
-            free(item);
+            struct LineRefOffset *previous_ref_offset = GET_LIST_ENTRY(item, struct LineRefOffset, head);
+            free(previous_ref_offset);
             num_refs++;
         }
         fprintf(stderr, "Warning: Unable to allocate space for an additional line ref offset (we had %zu).  Line information in stacktraces may be missing\n", num_refs);

--- a/src/libAtomVM/resources.c
+++ b/src/libAtomVM/resources.c
@@ -400,7 +400,8 @@ int enif_monitor_process(ErlNifEnv *env, void *obj, const ErlNifPid *target_pid,
     Context *target = globalcontext_get_process_lock(env->global, *target_pid);
     if (IS_NULL_PTR(target)) {
         free(resource_monitor);
-        free(monitor);
+        struct ResourceContextMonitor *resource_context_monitor = CONTAINER_OF(monitor, struct ResourceContextMonitor, monitor);
+        free(resource_context_monitor);
         return 1;
     }
 

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -458,7 +458,7 @@ static void mapped_file_avm_pack_destructor(struct AVMPackData *obj, GlobalConte
 
     struct MappedFileAVMPack *mmapped_avm = CONTAINER_OF(obj, struct MappedFileAVMPack, base);
     mapped_file_close(mmapped_avm->mapped);
-    free(obj);
+    free(mmapped_avm);
 }
 
 Module *sys_load_module_from_file(GlobalContext *global, const char *path)


### PR DESCRIPTION
Some structures in the code are never malloc'd or calloc'd because they are abstract types (struct ListHead or struct Monitor). Add a new CodeQL query to report and detect them. Fix correct (because of alignment) but dangerous cases with temporary variable that holds the allocated structure and that are likely to be optimized out by compiler. Also fix two bugs where resource pointers were freed in error paths while they shouldn't have.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
