### PR TITLE
Fix a bug with `jit_raise` when calling `stacktrace_create_raw`

### DIFF
--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -296,7 +296,7 @@ static Context *jit_raise(Context *ctx, JITState *jit_state, int offset, term st
     TRACE("jit_raise: ctx->process_id = %" PRId32 ", offset = %d\n", ctx->process_id, offset);
     ctx->x[0] = stacktrace_exception_class(stacktrace);
     ctx->x[1] = exc_value;
-    ctx->x[2] = stacktrace_create_raw(ctx, jit_state->module, offset, stacktrace);
+    ctx->x[2] = stacktrace_create_raw(ctx, jit_state->module, offset, ctx->x[0]);
     return jit_handle_error(ctx, jit_state, 0);
 }
 

--- a/tests/erlang_tests/test_exception_classes.erl
+++ b/tests/erlang_tests/test_exception_classes.erl
@@ -32,6 +32,7 @@ start() ->
     ok = test_raise_error(),
     ok = test_raise_exit(),
     ok = test_raise_badarg(),
+    ok = test_double_reraise(),
     0.
 
 test_exit() ->
@@ -119,5 +120,21 @@ test_raise_badarg() ->
         badarg = erlang:raise(bar, foo, []),
         ok
     catch
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_double_reraise() ->
+    try
+        try
+            try
+                exit(foo)
+            catch
+                error:_ -> should_not_happen
+            end
+        catch
+            error:_ -> should_not_happen
+        end
+    catch
+        exit:foo -> ok;
         C:V -> {unexpected, ?LINE, C, V}
     end.


### PR DESCRIPTION
The JIT implementation of `OP_RAISE` through `jit_raise` didn't match the non-JIT implementation. Add a test that goes through this path.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
