### PR TITLE
Add CodeQL query to check for term use after GC

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -61,10 +61,11 @@ jobs:
       uses: actions/checkout@v4
 
     - name: "Initialize CodeQL"
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
+        build-mode: manual
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql,./code-queries/mismatched-atom-string-length.ql,./code-queries/mismatched-free-type.ql,./code-queries/term-use-after-gc.ql
 
     - name: "Build"
       run: |
@@ -74,4 +75,4 @@ jobs:
         ninja
 
     - name: "Perform CodeQL Analysis"
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -74,7 +74,7 @@ jobs:
       with:
         languages: "cpp"
         build-mode: manual
-        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql,./code-queries/mismatched-atom-string-length.ql,./code-queries/mismatched-free-type.ql,./code-queries/term-use-after-gc.ql
 
     - name: Build with idf.py
       shell: bash

--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -88,11 +88,11 @@ jobs:
       run: git config --global --add safe.directory /__w/AtomVM/AtomVM
 
     - name: "Initialize CodeQL"
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: "cpp"
         build-mode: manual
-        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql,./code-queries/mismatched-atom-string-length.ql,./code-queries/mismatched-free-type.ql,./code-queries/term-use-after-gc.ql
 
     - name: Build
       shell: bash
@@ -105,7 +105,7 @@ jobs:
         ninja
 
     - name: "Perform CodeQL Analysis"
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
 
     - name: Install nvm and nodejs 20
       if: matrix.board != 'pico2'

--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -74,11 +74,11 @@ jobs:
       run: git config --global --add safe.directory /__w/AtomVM/AtomVM
 
     - name: "Initialize CodeQL"
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: 'cpp'
         build-mode: manual
-        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql,./code-queries/mismatched-atom-string-length.ql,./code-queries/mismatched-free-type.ql,./code-queries/term-use-after-gc.ql
 
     - name: Build
       shell: bash
@@ -92,4 +92,4 @@ jobs:
         make -j
 
     - name: "Perform CodeQL Analysis"
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -58,11 +58,11 @@ jobs:
       run: git config --global --add safe.directory /__w/AtomVM/AtomVM
 
     - name: "Initialize CodeQL"
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{matrix.language}}
         build-mode: manual
-        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql,./code-queries/mismatched-atom-string-length.ql,./code-queries/mismatched-free-type.ql,./code-queries/term-use-after-gc.ql
 
     - name: Compile AtomVM and test modules
       run: |
@@ -74,7 +74,7 @@ jobs:
         ninja AtomVM atomvmlib erlang_test_modules test_etest test_alisp test_estdlib hello_world run_script call_cast html5_events wasm_webserver
 
     - name: "Perform CodeQL Analysis"
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
 
     - name: Upload AtomVM and test modules
       uses: actions/upload-artifact@v4

--- a/code-queries/term-use-after-gc.ql
+++ b/code-queries/term-use-after-gc.ql
@@ -1,0 +1,309 @@
+/**
+ * This file is part of AtomVM.
+ *
+ * Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+ *
+ * @name Use of term variable after garbage collection
+ * @kind problem
+ * @problem.severity error
+ * @id atomvm/term-use-after-gc
+ * @tags correctness
+ * @precision high
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+import cpp
+
+import semmle.code.cpp.controlflow.SSA
+import semmle.code.cpp.controlflow.Dominance
+
+predicate isTermType(Type t) {
+    t.getName() = "term"
+    or
+    (
+        t instanceof TypedefType
+        and isTermType(t.(TypedefType).getBaseType())
+    )
+    or
+    (
+        t instanceof SpecifiedType
+        and isTermType(t.(SpecifiedType).getBaseType())
+    )
+}
+
+class GCCall extends FunctionCall {
+    GCCall() {
+        this.getTarget().hasName("memory_ensure_free_with_roots")
+        or this.getTarget().hasName("memory_ensure_free_opt")
+        or this.getTarget().hasName("memory_ensure_free")
+    }
+}
+
+predicate isImmediateCreatingCall(FunctionCall fc) {
+    fc.getTarget().hasName([
+        "term_from_int", "term_from_int4", "term_from_int11", "term_from_int28",
+        "term_from_int64", "term_nil", "term_from_atom_index",
+        "term_from_local_process_id", "term_port_from_local_process_id",
+        "term_from_catch_label", "term_invalid_term",
+        "module_get_atom_term_by_id", "globalcontext_make_atom",
+        "term_pid_or_port_from_context",
+        "posix_errno_to_term"
+    ])
+}
+
+predicate isImmediateExpr(Expr e) {
+    isImmediateCreatingCall(e)
+    or
+    (
+        e.isInMacroExpansion() and
+        e.isConstant() and
+        exists(MacroInvocation mi |
+            e = mi.getAGeneratedElement() and
+            (mi.toString().matches("%_ATOM") or mi.toString().matches("TERM_%"))
+        )
+    )
+    or
+    (
+        e instanceof EnumConstantAccess and
+        e.(EnumConstantAccess).getTarget().toString().matches("%_ATOM")
+    )
+}
+
+/**
+ * Holds if CFG node `a` is strictly before `b` in the dominance ordering:
+ * either `a`'s basic block strictly dominates `b`'s basic block,
+ * or they are in the same basic block and `a` comes first.
+ */
+predicate strictlyBeforeInDomTree(ControlFlowNode a, ControlFlowNode b) {
+    bbStrictlyDominates(a.getBasicBlock(), b.getBasicBlock())
+    or
+    exists(BasicBlock bb, int ia, int ib |
+        bb = a.getBasicBlock() and
+        bb = b.getBasicBlock() and
+        bb.getNode(ia) = a and
+        bb.getNode(ib) = b and
+        ia < ib
+    )
+}
+
+/**
+ * Holds if the variable has its address taken anywhere (e.g. `&v` passed
+ * as root to `memory_ensure_free_with_roots`). Such variables are updated
+ * in-place by the GC and remain valid.
+ */
+predicate isAddressTaken(StackVariable v) {
+    exists(AddressOfExpr aoe |
+        aoe.getOperand().(VariableAccess).getTarget() = v
+    )
+}
+
+/**
+ * List of functions that check whether a term is an immediate type.
+ */
+predicate isImmediateTypeCheckFunction(string name) {
+    name = [
+        "term_is_atom", "term_is_int", "term_is_integer",
+        "term_is_nil", "term_is_local_pid", "term_is_local_port",
+        "term_is_local_pid_or_port"
+    ]
+}
+
+/**
+ * Holds if there is a call to a function that checks whether a term is
+ * an immediate type (atom, integer, nil, pid, port) on variable `v`
+ * before the GC call. The pattern is typically:
+ *   VALIDATE_VALUE(v, term_is_atom)  -- expands to: if (!term_is_atom(v)) RAISE_ERROR(...)
+ * After such a check, v is known to be immediate and safe across GC.
+ */
+predicate hasImmediateTypeGuard(StackVariable v, GCCall gcCall) {
+    exists(FunctionCall typeCheck |
+        isImmediateTypeCheckFunction(typeCheck.getTarget().getName()) and
+        typeCheck.getArgument(0).(VariableAccess).getTarget() = v and
+        strictlyBeforeInDomTree(typeCheck, gcCall)
+    )
+}
+
+/**
+ * Holds if the value assigned to the SSA definition is from a variable
+ * that has an immediate type guard before the GC call. This handles patterns
+ * like: if (!term_is_atom(x)) RAISE_ERROR(...); y = x; GC; use(y);
+ */
+predicate hasIndirectImmediateTypeGuard(SsaDefinition ssaDef, StackVariable v, GCCall gcCall) {
+    // Direct: defining value is a variable access to a guarded variable
+    exists(Expr defValue |
+        defValue = ssaDef.getAnUltimateDefiningValue(v) and
+        exists(StackVariable sourceVar |
+            defValue.(VariableAccess).getTarget() = sourceVar and
+            hasImmediateTypeGuard(sourceVar, gcCall)
+        )
+    )
+    or
+    // Array access: defining value and guard argument are same array element
+    // Handles: VALIDATE_VALUE(argv[0], term_is_atom); module = argv[0];
+    exists(Expr defValue, FunctionCall typeCheck |
+        defValue = ssaDef.getAnUltimateDefiningValue(v) and
+        isImmediateTypeCheckFunction(typeCheck.getTarget().getName()) and
+        strictlyBeforeInDomTree(typeCheck, gcCall) and
+        exists(ArrayExpr defArr, ArrayExpr checkArr |
+            defArr = defValue and
+            checkArr = typeCheck.getArgument(0) and
+            defArr.getArrayBase().(VariableAccess).getTarget() =
+                checkArr.getArrayBase().(VariableAccess).getTarget() and
+            defArr.getArrayOffset().getValue() = checkArr.getArrayOffset().getValue()
+        )
+    )
+}
+
+/**
+ * Helper: holds if `neq` is of the form `v != IMM` where IMM is immediate.
+ */
+predicate isNEAgainstImmediate(NEExpr neq, StackVariable v) {
+    (neq.getLeftOperand().(VariableAccess).getTarget() = v and isImmediateExpr(neq.getRightOperand()))
+    or
+    (neq.getRightOperand().(VariableAccess).getTarget() = v and isImmediateExpr(neq.getLeftOperand()))
+}
+
+/**
+ * Holds if the variable is validated against immediate values before the GC
+ * call via a negative validation pattern like:
+ *   if (v != IMM) { RAISE_ERROR/return; }   (no else branch)
+ * or:
+ *   if (v != IMM1 && v != IMM2) { RAISE_ERROR/return; }   (no else branch)
+ * After such a check, code only continues if v is one of the immediate values.
+ * Only matches if-statements WITHOUT an else branch, ensuring the GC is on
+ * the fall-through path where the condition is false (i.e., v IS the immediate).
+ */
+predicate hasComparisonGuard(StackVariable v, GCCall gcCall) {
+    exists(IfStmt ifStmt |
+        strictlyBeforeInDomTree(ifStmt, gcCall) and
+        // No else branch: the then-branch exits, code continues only if false
+        not exists(ifStmt.getElse()) and
+        // Condition involves v != IMM
+        exists(NEExpr neq |
+            (
+                neq = ifStmt.getCondition()
+                or
+                neq = ifStmt.getCondition().(LogicalAndExpr).getAnOperand()
+                or
+                neq = ifStmt.getCondition().(LogicalAndExpr).getAnOperand().(LogicalAndExpr).getAnOperand()
+            ) and
+            isNEAgainstImmediate(neq, v)
+        )
+    )
+}
+
+/**
+ * Holds if expression `e` is known to produce an immediate value,
+ * including through ternary expressions where both branches are immediate.
+ */
+predicate isKnownImmediateExpr(Expr e) {
+    isImmediateExpr(e)
+    or
+    (
+        e instanceof ConditionalExpr and
+        isKnownImmediateExpr(e.(ConditionalExpr).getThen()) and
+        isKnownImmediateExpr(e.(ConditionalExpr).getElse())
+    )
+}
+
+/**
+ * Holds if expression `e` is known to be an immediate at a call site,
+ * either directly or through SSA tracing of a local variable.
+ */
+predicate isKnownImmediateAtCallSite(Expr e) {
+    isKnownImmediateExpr(e)
+    or
+    exists(SsaDefinition argDef, StackVariable argVar |
+        e.(VariableAccess).getTarget() = argVar and
+        argDef.getAUse(argVar) = e and
+        forall(Expr defVal | defVal = argDef.getAnUltimateDefiningValue(argVar) |
+            isKnownImmediateExpr(defVal)
+        )
+    )
+}
+
+/**
+ * Holds if the variable is a parameter of a static function and all call
+ * sites pass an immediate expression for that argument. Since the function
+ * is static, all callers are visible within the translation unit.
+ */
+predicate isStaticParamAlwaysImmediate(StackVariable v) {
+    exists(Parameter p |
+        p = v and
+        p.getFunction().isStatic() and
+        forall(FunctionCall fc | fc.getTarget() = p.getFunction() |
+            isKnownImmediateAtCallSite(fc.getArgument(p.getIndex()))
+        )
+    )
+}
+
+/**
+ * Holds if the GC call has a NOLINT(term-use-after-gc) suppression comment
+ * on the same line or the line before
+ */
+predicate hasSuppressionComment(GCCall gcCall) {
+    exists(Comment c |
+        c.getLocation().getFile() = gcCall.getLocation().getFile() and
+        (
+            c.getLocation().getStartLine() = gcCall.getLocation().getStartLine() or
+            c.getLocation().getStartLine() = gcCall.getLocation().getStartLine() - 1
+        ) and
+        c.getContents().matches("%NOLINT(term-use-after-gc)%")
+    )
+}
+
+/**
+ * Holds if the variable is used as the source argument (second argument) of
+ * memory_copy_term_tree after the GC call. This means the GC was done to
+ * make room for copying the term into the context's heap, and the term
+ * itself lives on a different heap (e.g. ETS table, mailbox) that is
+ * unaffected by the GC. All uses of the same variable after this GC call
+ * are safe.
+ */
+predicate isCopiedFromExternalHeap(SsaDefinition ssaDef, StackVariable v, GCCall gcCall) {
+    exists(FunctionCall copyCall, VariableAccess copyArg |
+        copyCall.getTarget().hasName("memory_copy_term_tree") and
+        copyArg = copyCall.getArgument(1) and
+        copyArg.(VariableAccess).getTarget() = v and
+        ssaDef.getAUse(v) = copyArg and
+        strictlyBeforeInDomTree(gcCall, copyCall)
+    )
+}
+
+/**
+ * Holds if the GC call operates on a different Context than the primary
+ * "ctx" parameter. This handles cases like do_spawn() where GC runs on
+ * new_ctx but variables come from ctx.
+ */
+predicate gcOnDifferentContext(GCCall gcCall) {
+    exists(Variable gcCtxVar |
+        gcCall.getArgument(0).(VariableAccess).getTarget() = gcCtxVar and
+        gcCtxVar.getName() != "ctx" and
+        exists(Parameter p |
+            p.getFunction() = gcCall.getEnclosingFunction() and
+            p.getName() = "ctx"
+        )
+    )
+}
+
+from SsaDefinition ssaDef, StackVariable v, GCCall gcCall, VariableAccess use
+where
+    isTermType(v.getType()) and
+    not isAddressTaken(v) and
+    ssaDef.getAVariable() = v and
+    ssaDef.getAUse(v) = use and
+    strictlyBeforeInDomTree(ssaDef.getDefinition(), gcCall) and
+    strictlyBeforeInDomTree(gcCall, use) and
+    not isImmediateExpr(ssaDef.getAnUltimateDefiningValue(v)) and
+    not hasImmediateTypeGuard(v, gcCall) and
+    not hasIndirectImmediateTypeGuard(ssaDef, v, gcCall) and
+    not hasComparisonGuard(v, gcCall) and
+    not isCopiedFromExternalHeap(ssaDef, v, gcCall) and
+    not isStaticParamAlwaysImmediate(v) and
+    not gcOnDifferentContext(gcCall) and
+    not hasSuppressionComment(gcCall)
+select use,
+    "Term variable '" + v.getName() +
+        "' may hold a stale value after GC call $@. Defined $@.",
+    gcCall, "here", ssaDef.getDefinition(), "here"

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4027,7 +4027,7 @@ static term nif_erlang_exit(Context *ctx, int argc, term argv[])
                 self_is_signaled = target == ctx;
             } else {
                 if (target->trap_exit) {
-                    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(3)) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(3), 1, &reason, MEMORY_NO_SHRINK) != MEMORY_GC_OK)) {
                         globalcontext_get_process_unlock(glb, target);
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }

--- a/src/libAtomVM/stacktrace.c
+++ b/src/libAtomVM/stacktrace.c
@@ -169,6 +169,7 @@ term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term e
     // {num_frames, num_aux_terms, filename_lens, num_mods, [{module, offset}, ...]}
     size_t requested_size = TUPLE_SIZE(6) + num_frames * (2 + TUPLE_SIZE(2));
     // We need to preserve x0 and x1 that contain information on the current exception
+    // NOLINT(term-use-after-gc) exception_class is always an atom
     if (UNLIKELY(memory_ensure_free_with_roots(ctx, requested_size, 2, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         fprintf(stderr, "WARNING: Unable to allocate heap space for raw stacktrace\n");
         return OUT_OF_MEMORY_ATOM;


### PR DESCRIPTION
Fix a bug reported by the query in nif_erlang_exit where the term reason could not be an immediate and wasn't added to roots

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
