### PR TITLE
Fix ATOM_STR lengths found by CodeQL query

### DIFF
--- a/src/libAtomVM/posix_nifs.c
+++ b/src/libAtomVM/posix_nifs.c
@@ -226,7 +226,7 @@ const ErlNifResourceTypeInit posix_fd_resource_type_init = {
 // #define O_NONBLOCK_ATOM_STR ATOM_STR("\xA", "o_nonblock")
 #define O_RSYNC_ATOM_STR ATOM_STR("\x7", "o_rsync")
 #define O_SYNC_ATOM_STR ATOM_STR("\x6", "o_sync")
-#define O_TRUNC_ATOM_STR ATOM_STR("\x8", "o_trunc")
+#define O_TRUNC_ATOM_STR ATOM_STR("\x7", "o_trunc")
 #define O_TTY_INIT_ATOM_STR ATOM_STR("\xA", "o_tty_init")
 
 static term make_posix_fd_resource(Context *ctx, int fd)

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -71,7 +71,7 @@ static NativeHandlerResult socket_consume_mailbox(Context *ctx);
 
 static const char *const tcp_error_atom = "\x9" "tcp_error";
 
-static const char *const netconn_event_internal = ATOM_STR("\x14", "$atomvm_netconn_event_internal");
+static const char *const netconn_event_internal = ATOM_STR("\x1E", "$atomvm_netconn_event_internal");
 static const char *gen_tcp_moniker_atom = ATOM_STR("\xC", "$avm_gen_tcp");
 static const char *native_tcp_module_atom = ATOM_STR("\xC", "gen_tcp_inet");
 static const char *gen_udp_moniker_atom = ATOM_STR("\xC", "$avm_gen_udp");

--- a/src/platforms/esp32/components/avm_builtins/uart_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/uart_driver.c
@@ -85,8 +85,8 @@ static const AtomStringIntPair parity_table[] = {
 
 static const AtomStringIntPair flow_control_table[] = {
     { ATOM_STR("\x4", "none"), UART_HW_FLOWCTRL_DISABLE },
-    { ATOM_STR("\x4", "hardware"), UART_HW_FLOWCTRL_CTS_RTS },
-    { ATOM_STR("\x3", "software"), -1 },
+    { ATOM_STR("\x8", "hardware"), UART_HW_FLOWCTRL_CTS_RTS },
+    { ATOM_STR("\x8", "software"), -1 },
     SELECT_INT_DEFAULT(-1)
 };
 

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -96,7 +96,7 @@ static const char *const esp32_p4_atom = "\x8" "esp32_p4";
 #endif
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
 static const char *const esp32_c5_atom = "\x8" "esp32_c5";
-static const char *const esp32_c61_atom = "\x8" "esp32_c61";
+static const char *const esp32_c61_atom = "\x9" "esp32_c61";
 #endif
 #endif
 static const char *const emb_flash_atom = "\x9" "emb_flash";


### PR DESCRIPTION
Fix five cases of wrong atom string lengths that were not fixed in #2098 as they don't appear in local regular build, but they were found by CI since #2100 was merged.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
