### PR TITLE
Fix term/non-term func CodeQL alerts with casts and proper types

### DIFF
--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -1304,7 +1304,7 @@ static term jit_bitstring_extract_integer(
     if (n <= 64) {
         union maybe_unsigned_int64 value;
         bool status = bitstring_extract_integer(
-            ((term) bin_ptr) | TERM_PRIMARY_BOXED, offset, n, bs_flags, &value);
+            (term) (((uintptr_t) bin_ptr) | TERM_PRIMARY_BOXED), offset, n, bs_flags, &value);
         if (UNLIKELY(!status)) {
             return FALSE_ATOM;
         }
@@ -1336,13 +1336,13 @@ static term jit_bitstring_extract_float(Context *ctx, term *bin_ptr, size_t offs
     bool status;
     switch (n) {
         case 16:
-            status = bitstring_extract_f16(((term) bin_ptr) | TERM_PRIMARY_BOXED, offset, n, bs_flags, &value);
+            status = bitstring_extract_f16((term) (((uintptr_t) bin_ptr) | TERM_PRIMARY_BOXED), offset, n, bs_flags, &value);
             break;
         case 32:
-            status = bitstring_extract_f32(((term) bin_ptr) | TERM_PRIMARY_BOXED, offset, n, bs_flags, &value);
+            status = bitstring_extract_f32((term) (((uintptr_t) bin_ptr) | TERM_PRIMARY_BOXED), offset, n, bs_flags, &value);
             break;
         case 64:
-            status = bitstring_extract_f64(((term) bin_ptr) | TERM_PRIMARY_BOXED, offset, n, bs_flags, &value);
+            status = bitstring_extract_f64((term) (((uintptr_t) bin_ptr) | TERM_PRIMARY_BOXED), offset, n, bs_flags, &value);
             break;
         default:
             status = false;

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -2927,7 +2927,7 @@ wait_timeout_trap_handler:
                 // Redo the offset computation and refetch the label
                 int label;
                 DECODE_LABEL(label, pc)
-                int timeout;
+                term timeout;
                 DECODE_COMPACT_TERM(timeout, pc)
                 TRACE("wait_timeout_trap_handler, label: %i\n", label);
                 PROCESS_SIGNAL_MESSAGES();
@@ -4464,8 +4464,8 @@ wait_timeout_trap_handler:
                 DECODE_COMPACT_TERM(src, pc);
                 term arg2;
                 DECODE_COMPACT_TERM(arg2, pc);
-                term flags;
-                DECODE_LITERAL(flags, pc);
+                uint32_t flags_value;
+                DECODE_LITERAL(flags_value, pc);
 
                 #ifdef IMPL_CODE_LOADER
                     TRACE("bs_skip_utf16/5\n");
@@ -4481,7 +4481,7 @@ wait_timeout_trap_handler:
 
                     int32_t val = 0;
                     size_t out_size = 0;
-                    bool is_valid = bitstring_match_utf16(src_bin, (size_t) offset_bits, &val, &out_size, flags);
+                    bool is_valid = bitstring_match_utf16(src_bin, (size_t) offset_bits, &val, &out_size, flags_value);
 
                     if (!is_valid) {
                         pc = mod->labels[fail];
@@ -4576,8 +4576,8 @@ wait_timeout_trap_handler:
                 DECODE_COMPACT_TERM(src, pc);
                 term arg2;
                 DECODE_COMPACT_TERM(arg2, pc);
-                term flags;
-                DECODE_LITERAL(flags, pc);
+                uint32_t flags_value;
+                DECODE_LITERAL(flags_value, pc);
 
                 #ifdef IMPL_CODE_LOADER
                     TRACE("bs_skip_utf32/5\n");
@@ -4592,7 +4592,7 @@ wait_timeout_trap_handler:
                     avm_int_t offset_bits = term_get_match_state_offset(src);
 
                     int32_t val = 0;
-                    bool is_valid = bitstring_match_utf32(src_bin, (size_t) offset_bits, &val, flags);
+                    bool is_valid = bitstring_match_utf32(src_bin, (size_t) offset_bits, &val, flags_value);
 
                     if (!is_valid) {
                         pc = mod->labels[fail];


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
