### PR TITLE
Dump largest refc binaries on oom crashes

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -1300,7 +1300,7 @@ COLD_FUNC void context_dump(Context *ctx)
         fprintf(stderr, "process_count = %zu\n", process_count);
         fprintf(stderr, "ports_count = %zu\n", ports_count);
         fprintf(stderr, "atoms_count = %zu\n", atom_table_count(glb->atom_table));
-        fprintf(stderr, "refc_binary_total_size = %zu\n", refc_binary_total_size(ctx));
+        refc_binary_dump_info(ctx);
     }
     fprintf(stderr, "\n\n**End Of Crash Report**\n");
 }

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -142,6 +142,16 @@ term refc_binary_create_binary_info(Context *ctx);
  */
 size_t refc_binary_total_size(Context *ctx);
 
+/**
+ * @brief Dump detailed information about reference counted binaries
+ *
+ * @details This function prints diagnostic information including the count,
+ * total size, and details about the top 5 largest binaries including
+ * their first bytes. Used for debugging memory issues.
+ * @param ctx the context
+ */
+COLD_FUNC void refc_binary_dump_info(Context *ctx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
