### PR TITLE
Fix a concurrency bug in `OP_WAIT_TIMEOUT`

### DIFF
--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -45,6 +45,7 @@ void mailbox_init(Mailbox *mbx)
     mbx->inner_last = NULL;
     mbx->receive_pointer = NULL;
     mbx->receive_pointer_prev = NULL;
+    mbx->receive_has_match_clauses = false;
 }
 
 // Convert a mailbox message (struct Message or struct TermSignal) to a heap

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -178,6 +178,10 @@ typedef struct
     // Receive pointers are on inner list items.
     MailboxMessage *receive_pointer;
     MailboxMessage *receive_pointer_prev;
+    // Set by loop_rec, cleared by remove_message and timeout.
+    // Used by wait_timeout to know if there are match clauses to try
+    // when signal processing moved messages to the inner list.
+    bool receive_has_match_clauses;
 } Mailbox;
 
 // TODO: a lot of this code depends on Context * and should be decoupled


### PR DESCRIPTION
Fix a bug that could explain some CI flappiness. If a message arrived before first execution of op_wait_timeout, the timer would be configured and the wait would time out unless another message arrived.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
