### PR TITLE
Fix JIT bs_get_binary2 with compile-time integer size

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -1348,10 +1348,12 @@ first_pass(<<?OP_BS_GET_BINARY2, Rest0/binary>>, MMod, MSt0, State0) ->
                 {MSt11, SizeReg};
             is_integer(Size) ->
                 % SizeReg is binary size
-                % SizeVal is a constant
-                MSt11 = MMod:sub(MSt10, SizeReg, Size bsl 4),
+                % Size is a tagged integer: (N bsl 4) bor 0xF
+                % SizeBytes is the raw byte count
+                SizeBytes = Size bsr 4,
+                MSt11 = MMod:sub(MSt10, SizeReg, SizeBytes),
                 MSt12 = cond_jump_to_label({{free, SizeReg}, '<', BSOffsetReg1}, Fail, MMod, MSt11),
-                {MSt12, Size bsl 4};
+                {MSt12, SizeBytes};
             true ->
                 {MSt11, SizeValReg} = MMod:move_to_native_register(MSt10, Size),
                 MSt12 = MMod:if_else_block(

--- a/libs/jit/src/jit_x86_64_asm.erl
+++ b/libs/jit/src/jit_x86_64_asm.erl
@@ -483,6 +483,16 @@ addq(SrcReg, DestReg) when is_atom(SrcReg), is_atom(DestReg) ->
     {REX_B, MODRM_RM} = x86_64_x_reg(DestReg),
     <<?X86_64_REX(1, REX_R, 0, REX_B), 16#01, 3:2, MODRM_REG:3, MODRM_RM:3>>.
 
+subq(Imm, Reg) when ?IS_SINT8_T(Imm), is_atom(Reg) ->
+    case x86_64_x_reg(Reg) of
+        {0, Index} -> <<16#48, 16#83, (16#E8 + Index), Imm>>;
+        {1, Index} -> <<16#49, 16#83, (16#E8 + Index), Imm>>
+    end;
+subq(Imm, rax) when ?IS_SINT32_T(Imm) ->
+    <<16#48, 16#2D, Imm:32/little>>;
+subq(Imm, Reg) when ?IS_SINT32_T(Imm), is_atom(Reg) ->
+    {REX_B, MODRM_RM} = x86_64_x_reg(Reg),
+    <<?X86_64_REX(1, 0, 0, REX_B), 16#81, 3:2, 5:3, MODRM_RM:3, Imm:32/little>>;
 subq(RegA, RegB) when is_atom(RegA), is_atom(RegB) ->
     {REX_R, MODRM_REG} = x86_64_x_reg(RegA),
     {REX_B, MODRM_RM} = x86_64_x_reg(RegB),

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -540,6 +540,7 @@ compile_erlang(test_function_exported)
 compile_erlang(test_list_to_tuple)
 
 compile_erlang(bs_context_byte_size)
+compile_erlang(bs_get_binary_fixed_size)
 compile_erlang(bs_context_to_binary_with_offset)
 compile_erlang(bs_restore2_start_offset)
 compile_erlang(test_refc_binaries)
@@ -613,6 +614,9 @@ compile_assembler(test_op_bs_start_match_asm)
 compile_erlang(test_op_bs_create_bin)
 compile_assembler(test_op_bs_create_bin_asm)
 
+compile_erlang(bs_get_binary_fixed_size)
+compile_assembler(bs_get_binary2_all_asm)
+
 compile_erlang(bigint)
 compile_erlang(bigint_stress)
 
@@ -624,6 +628,7 @@ compile_erlang(test_lists_keyfind)
 if(Erlang_VERSION VERSION_GREATER_EQUAL "23")
     set(OTP23_OR_GREATER_TESTS
         test_op_bs_start_match_asm.beam
+        bs_get_binary2_all_asm.beam
     )
 else()
     set(OTP23_OR_GREATER_TESTS)
@@ -1074,6 +1079,7 @@ set(erlang_test_beams
     test_list_to_tuple.beam
 
     bs_context_byte_size.beam
+    bs_get_binary_fixed_size.beam
     bs_context_to_binary_with_offset.beam
     bs_restore2_start_offset.beam
     bs_append_extra_words.beam

--- a/tests/erlang_tests/bs_get_binary2_all_asm.S
+++ b/tests/erlang_tests/bs_get_binary2_all_asm.S
@@ -1,0 +1,56 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% BEAM assembly file to test bs_get_binary2 opcode with {atom, all}.
+%% Modern OTP compilers never generate bs_get_binary2 with all -- they use
+%% bs_get_tail or bs_skip_bits2 instead.  This file exercises the JIT code
+%% path at jit.erl line 1347 (Size =:= ?ALL_ATOM).
+
+{module, bs_get_binary2_all_asm}.
+
+{exports, [
+    {extract_all_after_skip1, 1}
+]}.
+
+{attributes, []}.
+
+{labels, 5}.
+
+%% extract_all_after_skip1(Bin) ->
+%%   Skip 1 byte, then get the remaining bytes using
+%%   bs_get_binary2 with {atom, all}.
+%%   Returns the extracted binary, or the atom 'error' on failure.
+{function, extract_all_after_skip1, 1, 2}.
+{label, 1}.
+{func_info, {atom, bs_get_binary2_all_asm}, {atom, extract_all_after_skip1}, 1}.
+{label, 2}.
+{bs_start_match4, {atom, no_fail}, 1, {x, 0}, {x, 0}}.
+{test, bs_skip_bits2,
+      {f, 3},
+      [{x, 0}, {integer, 8}, 1, {field_flags, [unsigned, big]}]}.
+{test, bs_get_binary2,
+      {f, 3},
+      1,
+      [{x, 0}, {atom, all}, 8, {field_flags, [unsigned, big]}],
+      {x, 0}}.
+return.
+{label, 3}.
+{move, {atom, error}, {x, 0}}.
+return.

--- a/tests/erlang_tests/bs_get_binary_fixed_size.erl
+++ b/tests/erlang_tests/bs_get_binary_fixed_size.erl
@@ -1,0 +1,85 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(bs_get_binary_fixed_size).
+
+%% Force the compiler to use bs_get_binary2 opcode instead of the
+%% newer bs_match opcode (OTP 25+). On older OTP this is ignored.
+%% The no_bs_match option was removed in OTP 29.
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE =< 28).
+-compile([no_bs_match]).
+-endif.
+-endif.
+
+-export([start/0]).
+
+start() ->
+    Bin = id(<<1, 2, 3, 4, 5, 6, 7, 8>>),
+    ok = test_match_4(Bin),
+    ok = test_match_3(Bin),
+    %% bs_get_binary2_all_asm uses bs_start_match4 which requires OTP 23+
+    HasAsmModule =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                erlang:system_info(otp_release) >= "23";
+            "ATOM" ->
+                ?OTP_RELEASE >= 23
+        end,
+    ok =
+        if
+            HasAsmModule -> test_match_all(Bin);
+            true -> ok
+        end,
+    ok = test_match_fail(Bin),
+    0.
+
+test_match_4(Bin) ->
+    <<Head:4/binary, Rest/binary>> = Bin,
+    4 = byte_size(Head),
+    4 = byte_size(Rest),
+    <<1, 2, 3, 4>> = Head,
+    <<5, 6, 7, 8>> = Rest,
+    ok.
+
+test_match_3(Bin) ->
+    <<Head:3/binary, Rest/binary>> = Bin,
+    3 = byte_size(Head),
+    5 = byte_size(Rest),
+    <<1, 2, 3>> = Head,
+    <<4, 5, 6, 7, 8>> = Rest,
+    ok.
+
+test_match_all(Bin) ->
+    %% Uses bs_get_binary2 with {atom, all} via hand-written BEAM assembly,
+    %% since the compiler generates bs_skip_bits2/bs_get_tail instead.
+    <<2, 3, 4, 5, 6, 7, 8>> = bs_get_binary2_all_asm:extract_all_after_skip1(Bin),
+    7 = byte_size(bs_get_binary2_all_asm:extract_all_after_skip1(Bin)),
+    ok.
+
+test_match_fail(Bin) ->
+    case Bin of
+        <<_Head:9/binary, _Rest/binary>> ->
+            error;
+        _ ->
+            ok
+    end.
+
+id(X) -> X.

--- a/tests/libs/jit/jit_x86_64_asm_tests.erl
+++ b/tests/libs/jit/jit_x86_64_asm_tests.erl
@@ -914,9 +914,59 @@ andb_test_() ->
 
 subq_test_() ->
     [
+        % 8-bit immediates
+        ?_assertAsmEqual(
+            <<16#48, 16#83, 16#E8, 16#01>>, "subq $0x1, %rax", jit_x86_64_asm:subq(1, rax)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#83, 16#E9, 16#01>>, "subq $0x1, %rcx", jit_x86_64_asm:subq(1, rcx)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#83, 16#EA, 16#01>>, "subq $0x1, %rdx", jit_x86_64_asm:subq(1, rdx)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#83, 16#EE, 16#01>>, "subq $0x1, %rsi", jit_x86_64_asm:subq(1, rsi)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#83, 16#EF, 16#01>>, "subq $0x1, %rdi", jit_x86_64_asm:subq(1, rdi)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#83, 16#E8, 16#01>>, "subq $0x1, %r8", jit_x86_64_asm:subq(1, r8)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#83, 16#E9, 16#01>>, "subq $0x1, %r9", jit_x86_64_asm:subq(1, r9)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#83, 16#EA, 16#01>>, "subq $0x1, %r10", jit_x86_64_asm:subq(1, r10)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#83, 16#EB, 16#01>>, "subq $0x1, %r11", jit_x86_64_asm:subq(1, r11)
+        ),
+        % Register to register
         ?_assertAsmEqual(<<16#48, 16#29, 16#c1>>, "subq %rax, %rcx", jit_x86_64_asm:subq(rax, rcx)),
         ?_assertAsmEqual(<<16#49, 16#29, 16#c2>>, "subq %rax, %r10", jit_x86_64_asm:subq(rax, r10)),
-        ?_assertAsmEqual(<<16#4c, 16#29, 16#c1>>, "subq %r8, %rcx", jit_x86_64_asm:subq(r8, rcx))
+        ?_assertAsmEqual(<<16#4c, 16#29, 16#c1>>, "subq %r8, %rcx", jit_x86_64_asm:subq(r8, rcx)),
+        % 32-bit immediates
+        ?_assertAsmEqual(
+            <<16#48, 16#2D, 16#78, 16#56, 16#34, 16#12>>,
+            "subq $0x12345678,%rax",
+            jit_x86_64_asm:subq(16#12345678, rax)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#81, 16#EE, 16#78, 16#56, 16#34, 16#12>>,
+            "subq $0x12345678,%rsi",
+            jit_x86_64_asm:subq(16#12345678, rsi)
+        ),
+        ?_assertAsmEqual(
+            <<16#49, 16#81, 16#EB, 16#78, 16#56, 16#34, 16#12>>,
+            "subq $0x12345678,%r11",
+            jit_x86_64_asm:subq(16#12345678, r11)
+        ),
+        ?_assertAsmEqual(
+            <<16#48, 16#2D, 16#88, 16#A9, 16#CB, 16#ED>>,
+            "subq $-0x12345678,%rax",
+            jit_x86_64_asm:subq(-16#12345678, rax)
+        )
     ].
 
 decl_test_() ->

--- a/tests/test.c
+++ b/tests/test.c
@@ -524,6 +524,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_list_to_tuple, 69),
 
     TEST_CASE(bs_context_byte_size),
+    TEST_CASE(bs_get_binary_fixed_size),
     TEST_CASE_EXPECTED(bs_context_to_binary_with_offset, 42),
     TEST_CASE_EXPECTED(bs_restore2_start_offset, 823),
 


### PR DESCRIPTION
In OP_BS_GET_BINARY2, `Size` from decode_compact_term is a tagged term integer ((N bsl 4) bor 0xF). The code used `Size bsl 4` which shifts the already-tagged value further left, producing a garbage value. The correct operation is `Size bsr 4` to untag and get the raw byte count, matching what the non-JIT interpreter does with term_to_int().

This bug caused bs_get_binary2 with a compile-time literal size to always fail the bounds check, making patterns like <<Head:N/binary, Rest/binary>> (with literal N) unmatchable.

Also add a test for the atom all case using assembly and fix subq on x86_64 with large integers following what other backends do.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
