### PR TITLE
CI: Enable ESP32-P4/C5 crypto and C5 wifi tests

### DIFF
--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -319,14 +319,11 @@ TEST_CASE("test_md5", "[test_run]")
     TEST_ASSERT(ret_value == OK_ATOM);
 }
 
-// Full crypto suite not yet supported on ESP32-P4 simulator.
-#if !CONFIG_IDF_TARGET_ESP32P4 && !CONFIG_IDF_TARGET_ESP32C5
 TEST_CASE("test_crypto", "[test_run]")
 {
     term ret_value = avm_test_case("test_crypto.beam");
     TEST_ASSERT(ret_value == OK_ATOM);
 }
-#endif
 
 TEST_CASE("test_monotonic_time", "[test_run]")
 {
@@ -610,7 +607,7 @@ TEST_CASE("test_rtc_slow", "[test_run]")
 }
 
 // Only test wifi on simulator, not on QEMU
-#if !CONFIG_ETH_USE_OPENETH && !CONFIG_IDF_TARGET_ESP32H2 && !CONFIG_IDF_TARGET_ESP32P4 && !CONFIG_IDF_TARGET_ESP32C5
+#if !CONFIG_ETH_USE_OPENETH && !CONFIG_IDF_TARGET_ESP32H2 && !CONFIG_IDF_TARGET_ESP32P4
 TEST_CASE("test_wifi_example", "[test_run]")
 {
     term ret_value = avm_test_case("test_wifi_example.beam");


### PR DESCRIPTION
Wokwi/Simtest now supports these features.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
