### PR TITLE
Fix bug in `OP_BS_CREATE_BIN` (and improve JIT coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ instead `badarg`.
 - Supervisor now honors period and intensity options.
 - Fix supervisor crash if a `one_for_one` child fails to restart.
 - Fix collision in references created with `make_ref/0` on 32 bits platforms.
+- Fixed a bug in `OP_BS_CREATE_BIN`
 
 ## [0.6.7] - Unreleased
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -7005,17 +7005,13 @@ wait_timeout_trap_handler:
                                         JUMP_TO_LABEL(mod, fail);
                                     }
                                 }
-                                // size is optional for floats, defaults to 64
-                                avm_int_t signed_size_value = 64;
-                                if (size != term_nil()) {
-                                    VERIFY_IS_INTEGER(size, "bs_create_bin/6", fail);
-                                    signed_size_value = term_to_int(size);
-                                    if (UNLIKELY(signed_size_value != 16 && signed_size_value != 32 && signed_size_value != 64)) {
-                                        if (fail == 0) {
-                                            RAISE_ERROR(BADARG_ATOM);
-                                        } else {
-                                            JUMP_TO_LABEL(mod, fail);
-                                        }
+                                VERIFY_IS_INTEGER(size, "bs_create_bin/6", fail);
+                                avm_int_t signed_size_value = term_to_int(size);
+                                if (UNLIKELY(signed_size_value != 16 && signed_size_value != 32 && signed_size_value != 64)) {
+                                    if (fail == 0) {
+                                        RAISE_ERROR(BADARG_ATOM);
+                                    } else {
+                                        JUMP_TO_LABEL(mod, fail);
                                     }
                                 }
                                 segment_size = signed_size_value;
@@ -7150,11 +7146,7 @@ wait_timeout_trap_handler:
                                 size_value = (size_t) term_to_int(size);
                                 break;
                             case FLOAT_ATOM:
-                                if (size != term_nil()) {
-                                    size_value = (size_t) term_to_int(size);
-                                } else {
-                                    size_value = 64;
-                                }
+                                size_value = (size_t) term_to_int(size);
                                 break;
                             default:
                                 break;
@@ -7195,7 +7187,7 @@ wait_timeout_trap_handler:
                                     TRACE("bs_create_bin/6: Failed to insert integer into binary\n");
                                     RAISE_ERROR(BADARG_ATOM);
                                 }
-                                segment_size = size_value;
+                                segment_size = size_value * segment_unit;
                                 break;
                             }
                             case FLOAT_ATOM: {

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -541,6 +541,13 @@ compile_erlang(test_list_to_tuple)
 
 compile_erlang(bs_context_byte_size)
 compile_erlang(bs_get_binary_fixed_size)
+compile_erlang(bs_get_integer_fixed_size)
+compile_erlang(bs_get_float_dynamic_size)
+compile_erlang(test_is_not_equal)
+compile_assembler(test_is_not_equal_asm)
+compile_erlang(test_has_map_fields)
+compile_erlang(test_bs_create_bin_accum)
+compile_assembler(test_bs_create_bin_accum_asm)
 compile_erlang(bs_context_to_binary_with_offset)
 compile_erlang(bs_restore2_start_offset)
 compile_erlang(test_refc_binaries)
@@ -614,7 +621,6 @@ compile_assembler(test_op_bs_start_match_asm)
 compile_erlang(test_op_bs_create_bin)
 compile_assembler(test_op_bs_create_bin_asm)
 
-compile_erlang(bs_get_binary_fixed_size)
 compile_assembler(bs_get_binary2_all_asm)
 
 compile_erlang(bigint)
@@ -637,6 +643,7 @@ endif()
 if(Erlang_VERSION VERSION_GREATER_EQUAL "25")
     set(OTP25_OR_GREATER_TESTS
         test_op_bs_create_bin_asm.beam
+        test_bs_create_bin_accum_asm.beam
     )
 else()
     set(OTP25_OR_GREATER_TESTS)
@@ -1080,6 +1087,12 @@ set(erlang_test_beams
 
     bs_context_byte_size.beam
     bs_get_binary_fixed_size.beam
+    bs_get_integer_fixed_size.beam
+    bs_get_float_dynamic_size.beam
+    test_is_not_equal.beam
+    test_is_not_equal_asm.beam
+    test_has_map_fields.beam
+    test_bs_create_bin_accum.beam
     bs_context_to_binary_with_offset.beam
     bs_restore2_start_offset.beam
     bs_append_extra_words.beam

--- a/tests/erlang_tests/bs_get_float_dynamic_size.erl
+++ b/tests/erlang_tests/bs_get_float_dynamic_size.erl
@@ -1,0 +1,54 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(bs_get_float_dynamic_size).
+
+%% Force the compiler to use bs_get_float2 opcode instead of the
+%% newer bs_match opcode (OTP 25+). On older OTP this is ignored.
+%% The no_bs_match option was removed in OTP 29.
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE =< 28).
+-compile([no_bs_match]).
+-endif.
+-endif.
+
+-export([start/0]).
+
+start() ->
+    %% Test bs_get_float2 with runtime-variable size.
+    Bin64 = id(<<3.14:64/float>>),
+    ok = test_float64_dynamic(Bin64, id(64)),
+    Bin32 = id(<<3.14:32/float>>),
+    ok = test_float32_dynamic(Bin32, id(32)),
+    0.
+
+test_float64_dynamic(Bin, Size) ->
+    <<F:Size/float>> = Bin,
+    true = (F > 3.13),
+    true = (F < 3.15),
+    ok.
+
+test_float32_dynamic(Bin, Size) ->
+    <<F:Size/float>> = Bin,
+    true = (F > 3.13),
+    true = (F < 3.15),
+    ok.
+
+id(X) -> X.

--- a/tests/erlang_tests/bs_get_integer_fixed_size.erl
+++ b/tests/erlang_tests/bs_get_integer_fixed_size.erl
@@ -1,0 +1,71 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(bs_get_integer_fixed_size).
+
+%% Force the compiler to use bs_get_integer2 opcode instead of the
+%% newer bs_match opcode (OTP 25+). On older OTP this is ignored.
+%% The no_bs_match option was removed in OTP 29.
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE =< 28).
+-compile([no_bs_match]).
+-endif.
+-endif.
+
+-export([start/0]).
+
+start() ->
+    Bin = id(<<1, 2, 3, 4, 5, 6, 7, 8>>),
+    ok = test_match_8bit(Bin),
+    ok = test_match_16bit(Bin),
+    ok = test_match_32bit(Bin),
+    ok = test_match_fail(Bin),
+    0.
+
+test_match_8bit(Bin) ->
+    <<X:8, Rest/binary>> = Bin,
+    1 = X,
+    7 = byte_size(Rest),
+    <<2, 3, 4, 5, 6, 7, 8>> = Rest,
+    ok.
+
+test_match_16bit(Bin) ->
+    <<X:16, Rest/binary>> = Bin,
+    258 = X,
+    6 = byte_size(Rest),
+    <<3, 4, 5, 6, 7, 8>> = Rest,
+    ok.
+
+test_match_32bit(Bin) ->
+    <<X:32, Rest/binary>> = Bin,
+    16909060 = X,
+    4 = byte_size(Rest),
+    <<5, 6, 7, 8>> = Rest,
+    ok.
+
+test_match_fail(Bin) ->
+    case Bin of
+        <<_X:72, _Rest/binary>> ->
+            error;
+        _ ->
+            ok
+    end.
+
+id(X) -> X.

--- a/tests/erlang_tests/test_bs_create_bin_accum.erl
+++ b/tests/erlang_tests/test_bs_create_bin_accum.erl
@@ -1,0 +1,63 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_bs_create_bin_accum).
+
+-export([start/0]).
+
+start() ->
+    HasBSCreateBin =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                erlang:system_info(otp_release) >= "25";
+            "ATOM" ->
+                ?OTP_RELEASE >= 25
+        end,
+    ok =
+        if
+            HasBSCreateBin ->
+                ok = test_int_utf8(),
+                ok = test_int_float();
+            true ->
+                ok
+        end,
+    0.
+
+test_int_utf8() ->
+    %% <<42:8, 65/utf8>> = <<42, 65>>
+    %% 65 = 'A', 1 byte in UTF-8
+    <<42, 65>> = test_bs_create_bin_accum_asm:create_int_utf8(id(42), id(65), id(1)),
+    %% <<42:16, 12450/utf8>> = <<0, 42, 227, 130, 162>>
+    %% 12450 is a 3-byte UTF-8 character
+    <<0, 42, 227, 130, 162>> = test_bs_create_bin_accum_asm:create_int_utf8(
+        id(42), id(12450), id(2)
+    ),
+    ok.
+
+test_int_float() ->
+    %% <<42:8, 3.14:64/float>>
+    Bin = test_bs_create_bin_accum_asm:create_int_float(id(42), id(3.14), id(64), id(1)),
+    9 = byte_size(Bin),
+    <<42, F:64/float>> = Bin,
+    true = (F > 3.13),
+    true = (F < 3.15),
+    ok.
+
+id(X) -> X.

--- a/tests/erlang_tests/test_bs_create_bin_accum_asm.S
+++ b/tests/erlang_tests/test_bs_create_bin_accum_asm.S
@@ -1,0 +1,67 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% BEAM assembly file to test bs_create_bin with multi-segment binaries
+%% where the first segment has a runtime-variable size (setting AccSizeReg),
+%% followed by utf8 or float segments.
+%%
+%% This exercises utf8/float compute_size with AccSizeReg0 =/= undefined.
+
+{module, test_bs_create_bin_accum_asm}.
+
+{exports, [
+    {create_int_utf8, 3},
+    {create_int_float, 4}
+]}.
+
+{attributes, []}.
+
+{labels, 7}.
+
+%% create_int_utf8(IntValue, Utf8Char, IntSizeBytes) ->
+%%   <<IntValue:IntSizeBytes/integer-unit:8, Utf8Char/utf8>>
+%%   The integer segment has a runtime-variable size (x2), which sets
+%%   AccSizeReg in compute_size. The utf8 segment then finds
+%%   AccSizeReg =/= undefined.
+{function, create_int_utf8, 3, 2}.
+{label, 1}.
+{func_info, {atom, test_bs_create_bin_accum_asm}, {atom, create_int_utf8}, 3}.
+{label, 2}.
+{bs_create_bin, {f, 0}, 0, 3, 1, {x, 0},
+    {list, [
+        {atom, integer}, 1, 8, nil, {x, 0}, {x, 2},
+        {atom, utf8}, 2, 0, nil, {x, 1}, {atom, undefined}
+    ]}}.
+return.
+
+%% create_int_float(IntValue, FloatValue, FloatSizeBits, IntSizeBytes) ->
+%%   <<IntValue:IntSizeBytes/integer-unit:8, FloatValue:FloatSizeBits/float-unit:1>>
+%%   The integer segment sets AccSizeReg (runtime size in x3).
+%%   The float segment has a dynamic size (x2), and AccSizeReg =/= undefined.
+{function, create_int_float, 4, 5}.
+{label, 4}.
+{func_info, {atom, test_bs_create_bin_accum_asm}, {atom, create_int_float}, 4}.
+{label, 5}.
+{bs_create_bin, {f, 0}, 0, 4, 1, {x, 0},
+    {list, [
+        {atom, integer}, 1, 8, nil, {x, 0}, {x, 3},
+        {atom, float}, 2, 1, nil, {x, 1}, {x, 2}
+    ]}}.
+return.

--- a/tests/erlang_tests/test_has_map_fields.erl
+++ b/tests/erlang_tests/test_has_map_fields.erl
@@ -1,0 +1,58 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_has_map_fields).
+
+-export([start/0]).
+
+start() ->
+    %% Test has_map_fields with 2+ keys to exercise the multi-key loop.
+    M1 = id(#{a => 1, b => 2, c => 3}),
+    ok = test_two_keys(M1),
+    ok = test_three_keys(M1),
+    ok = test_missing_key(M1),
+    ok = test_partial_keys(M1),
+    0.
+
+test_two_keys(M) ->
+    case M of
+        #{a := _, b := _} -> ok;
+        _ -> error
+    end.
+
+test_three_keys(M) ->
+    case M of
+        #{a := _, b := _, c := _} -> ok;
+        _ -> error
+    end.
+
+test_missing_key(M) ->
+    case M of
+        #{a := _, d := _} -> error;
+        _ -> ok
+    end.
+
+test_partial_keys(M) ->
+    case M of
+        #{a := _, b := _, d := _} -> error;
+        _ -> ok
+    end.
+
+id(X) -> X.

--- a/tests/erlang_tests/test_is_not_equal.erl
+++ b/tests/erlang_tests/test_is_not_equal.erl
@@ -1,0 +1,45 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_is_not_equal).
+
+-export([start/0]).
+
+start() ->
+    %% Test the is_ne opcode (OP_IS_NOT_EQUAL, opcode 42) via assembly.
+    %% This opcode performs loose inequality (/=), where 1 == 1.0.
+
+    %% Same integer
+    equal = test_is_not_equal_asm:is_ne_test(id(42), id(42)),
+    %% Different integers
+    not_equal = test_is_not_equal_asm:is_ne_test(id(42), id(43)),
+    %% Integer and float with same value (loose equality: 1 == 1.0)
+    equal = test_is_not_equal_asm:is_ne_test(id(1), id(1.0)),
+    %% Integer and float with different values
+    not_equal = test_is_not_equal_asm:is_ne_test(id(1), id(2.0)),
+    %% Same atom
+    equal = test_is_not_equal_asm:is_ne_test(id(hello), id(hello)),
+    %% Different atoms
+    not_equal = test_is_not_equal_asm:is_ne_test(id(hello), id(world)),
+    %% Atom and integer
+    not_equal = test_is_not_equal_asm:is_ne_test(id(hello), id(42)),
+    0.
+
+id(X) -> X.

--- a/tests/erlang_tests/test_is_not_equal_asm.S
+++ b/tests/erlang_tests/test_is_not_equal_asm.S
@@ -1,0 +1,50 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% BEAM assembly file to test is_ne (OP_IS_NOT_EQUAL, opcode 42).
+%% Modern OTP compilers never generate is_ne -- they use is_eq with inverted
+%% branch logic instead.  This file exercises the JIT code path for
+%% OP_IS_NOT_EQUAL.
+
+{module, test_is_not_equal_asm}.
+
+{exports, [
+    {is_ne_test, 2}
+]}.
+
+{attributes, []}.
+
+{labels, 5}.
+
+%% is_ne_test(A, B) ->
+%%   Tests A /= B using the is_ne opcode.
+%%   Returns 'not_equal' if A /= B, 'equal' if A == B.
+{function, is_ne_test, 2, 2}.
+{label, 1}.
+{func_info, {atom, test_is_not_equal_asm}, {atom, is_ne_test}, 2}.
+{label, 2}.
+{test, is_ne, {f, 3}, [{x, 0}, {x, 1}]}.
+%% If we reach here, A /= B (the test did not jump)
+{move, {atom, not_equal}, {x, 0}}.
+return.
+{label, 3}.
+%% A == B (the test jumped because /= was false)
+{move, {atom, equal}, {x, 0}}.
+return.

--- a/tests/test.c
+++ b/tests/test.c
@@ -525,6 +525,11 @@ struct Test tests[] = {
 
     TEST_CASE(bs_context_byte_size),
     TEST_CASE(bs_get_binary_fixed_size),
+    TEST_CASE(bs_get_integer_fixed_size),
+    TEST_CASE(bs_get_float_dynamic_size),
+    TEST_CASE(test_is_not_equal),
+    TEST_CASE(test_has_map_fields),
+    TEST_CASE(test_bs_create_bin_accum),
     TEST_CASE_EXPECTED(bs_context_to_binary_with_offset, 42),
     TEST_CASE_EXPECTED(bs_restore2_start_offset, 823),
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
