### PR TITLE
Fix a bug where *.avm files would be stale with ninja

### DIFF
--- a/CMakeModules/BuildErlang.cmake
+++ b/CMakeModules/BuildErlang.cmake
@@ -288,7 +288,7 @@ macro(pack_runnable avm_name main)
 
     add_custom_command(
         OUTPUT ${avm_name}.avm
-        DEPENDS ${avm_name}_main ${pack_runnable_${avm_name}_archive_targets} PackBEAM
+        DEPENDS ${avm_name}_main ${main}.beam ${pack_runnable_${avm_name}_archives} ${pack_runnable_${avm_name}_archive_targets} PackBEAM
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} ${avm_name}.avm ${main}.beam ${pack_runnable_${avm_name}_archives}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
@@ -414,7 +414,7 @@ macro(pack_uf2 avm_name main)
 
     add_custom_command(
         OUTPUT ${avm_name}.avm
-        DEPENDS ${avm_name}_main ${pack_uf2_${avm_name}_archive_targets} PackBEAM
+        DEPENDS ${avm_name}_main ${main}.beam ${pack_uf2_${avm_name}_archives} ${pack_uf2_${avm_name}_archive_targets} PackBEAM
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${avm_name}.avm ${main}.beam ${pack_uf2_${avm_name}_archives}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM


### PR DESCRIPTION
CMake Ninja Generators use weaker ordering than other generators

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
