### PR TITLE
RP2: Improve initial flash message

### DIFF
--- a/src/platforms/rp2/src/main.c
+++ b/src/platforms/rp2/src/main.c
@@ -86,9 +86,9 @@ static int app_main()
 
     if (!avmpack_is_valid(MAIN_AVM, XIP_SRAM_BASE - (uintptr_t) MAIN_AVM)) {
         sleep_ms(5000);
-        fprintf(stderr, "Fatal error: invalid main.avm packbeam\n");
+        fprintf(stderr, "No application loaded. Please flash your application to get started.\n");
         if (avmpack_is_valid(LIB_AVM, (uintptr_t) MAIN_AVM - (uintptr_t) LIB_AVM)) {
-            fprintf(stderr, "Lib avm packbeam is valid, though\n");
+            fprintf(stderr, "Core libraries are loaded and ready.\n");
         }
         AVM_ABORT();
     }


### PR DESCRIPTION
After first flash/install of atomvm on picos, user was met with the rather blunt "Fatal error:.."

Suggestions, improvements welcome!

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
