### PR TITLE
Fix Elixir .avm staleness with ninja builds

### DIFF
--- a/CMakeModules/BuildElixir.cmake
+++ b/CMakeModules/BuildElixir.cmake
@@ -48,7 +48,7 @@ macro(pack_archive avm_name)
 
     add_custom_command(
         OUTPUT ${avm_name}.avm
-        DEPENDS ${avm_name}_beams PackBEAM
+        DEPENDS ${avm_name}_beams PackBEAM ${BEAMS}
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM -a ${INCLUDE_LINES} ${avm_name}.avm ${BEAMS}
         COMMENT "Packing archive ${avm_name}.avm"
         VERBATIM
@@ -93,7 +93,7 @@ macro(pack_runnable avm_name main)
 
     add_custom_command(
         OUTPUT ${avm_name}.avm
-        DEPENDS ${avm_name}_main ${ARCHIVE_TARGETS} PackBEAM
+        DEPENDS ${avm_name}_main ${ARCHIVE_TARGETS} PackBEAM Elixir.${main}.beam ${ARCHIVES}
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} ${avm_name}.avm Elixir.${main}.beam ${ARCHIVES}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
@@ -170,7 +170,7 @@ macro(pack_test avm_name main)
 
     add_custom_command(
         OUTPUT ${avm_name}.avm
-        DEPENDS ${avm_name}_main ${avm_name}_tests ${ARCHIVE_TARGETS} PackBEAM
+        DEPENDS ${avm_name}_main ${avm_name}_tests ${ARCHIVE_TARGETS} PackBEAM Elixir.${main}.beam ${TEST_BEAMS} ${ARCHIVES}
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} ${avm_name}.avm Elixir.${main}.beam ${TEST_BEAMS} ${ARCHIVES}
         COMMENT "Packing test ${avm_name}.avm"
         VERBATIM

--- a/tests/libs/exavmlib/CMakeLists.txt
+++ b/tests/libs/exavmlib/CMakeLists.txt
@@ -27,3 +27,10 @@ set(TEST_MODULES
 )
 
 pack_test(Tests Tests ${TEST_MODULES})
+
+# alisp is not in pack_test's standard library list but is needed by exavmlib tests
+add_custom_command(
+    OUTPUT Tests.avm
+    DEPENDS ${CMAKE_BINARY_DIR}/libs/alisp/src/alisp.avm alisp
+    APPEND
+)


### PR DESCRIPTION
Fixes issues where libs, and Tests.avm would not be rebuild.

Fixes https://github.com/atomvm/AtomVM/issues/2119

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
