### PR TITLE
Add missing declaration for `binary:match/2,3`

### DIFF
--- a/libs/estdlib/src/binary.erl
+++ b/libs/estdlib/src/binary.erl
@@ -32,6 +32,7 @@
     encode_hex/1, encode_hex/2,
     part/3,
     split/2, split/3,
+    match/2, match/3,
     replace/3, replace/4
 ]).
 
@@ -102,6 +103,33 @@ encode_hex(Data, uppercase) ->
     <<(integer_to_binary(B, 16)) || <<B:4>> <= Data>>;
 encode_hex(Data, lowercase) ->
     <<<<(hd(string:to_lower(integer_to_list(B, 16)))):8>> || <<B:4>> <= Data>>.
+
+%%-----------------------------------------------------------------------------
+%% @equiv match(Binary, Pattern, [])
+%% @param   Binary  binary to search in
+%% @param   Pattern pattern to search for
+%% @returns `{Start, Length}' or `nomatch'
+%% @doc Find the first occurrence of Pattern in Binary.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec match(Binary :: binary(), Pattern :: binary() | [binary()]) ->
+    {non_neg_integer(), non_neg_integer()} | nomatch.
+match(_Binary, _Pattern) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Binary  binary to search in
+%% @param   Pattern pattern to search for
+%% @param   Options options for the match
+%% @returns `{Start, Length}' or `nomatch'
+%% @doc Find the first occurrence of Pattern in Binary.
+%% Options can include `{scope, {Start, Length}}'.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec match(Binary :: binary(), Pattern :: binary() | [binary()], Options :: [term()]) ->
+    {non_neg_integer(), non_neg_integer()} | nomatch.
+match(_Binary, _Pattern, _Options) ->
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Binary binary to extract a subbinary from


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
