### PR TITLE
Factorize jit tests with `jit_tests_common:assert_stream/3`

### DIFF
--- a/tests/libs/jit/jit_aarch64_tests.erl
+++ b/tests/libs/jit/jit_aarch64_tests.erl
@@ -49,7 +49,7 @@ call_primitive_0_test() ->
             "  14:	a8c10be1 	ldp	x1, x2, [sp], #16\n"
             "  18:	a8c103fe 	ldp	x30, x0, [sp], #16\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_primitive_1_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -66,7 +66,7 @@ call_primitive_1_test() ->
             "  14:	a8c10be1 	ldp	x1, x2, [sp], #16\n"
             "  18:	a8c103fe 	ldp	x30, x0, [sp], #16\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_primitive_2_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -86,7 +86,7 @@ call_primitive_2_args_test() ->
             "  20:	a8c10be1 	ldp	x1, x2, [sp], #16\n"
             "  24:	a8c103fe 	ldp	x30, x0, [sp], #16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_primitive_5_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -100,7 +100,7 @@ call_primitive_5_args_test() ->
             "   c:	d2800044 	mov	x4, #0x2                   	// #2\n"
             "  10:	d61f00e0 	br	x7"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_primitive_6_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -131,7 +131,7 @@ call_primitive_6_args_test() ->
             "  30:	a8c10be1 	ldp	x1, x2, [sp], #16\n"
             "  34:	a8c103fe 	ldp	x30, x0, [sp], #16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_primitive_extended_regs_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -189,7 +189,7 @@ call_primitive_extended_regs_test() ->
             "  98:	a8c103fe 	ldp	x30, x0, [sp], #16\n"
             "  9c:	f9000127 	str	x7, [x9]\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_primitive_few_free_regs_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -227,7 +227,7 @@ call_primitive_few_free_regs_test() ->
         "  4c:	a8c10be1 	ldp	x1, x2, [sp], #16\n"
         "  50:	a8c103fe 	ldp	x30, x0, [sp], #16"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_ext_only_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -249,7 +249,7 @@ call_ext_only_test() ->
         "  2c:	92800004 	mov	x4, #0xffffffffffffffff    	// #-1\n"
         "  30:	d61f00e0 	br	x7"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_primitive_last_5_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -266,7 +266,7 @@ call_primitive_last_5_args_test() ->
         "  10:	aa0703e4 	mov	x4, x7\n"
         "  14:	d61f0100 	br	x8"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_ext_last_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -288,7 +288,7 @@ call_ext_last_test() ->
         "  2c:	d2800144 	mov	x4, #0xa                   	// #10\n"
         "  30:	d61f00e0 	br	x7"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_primitive_last_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -300,7 +300,7 @@ call_primitive_last_test() ->
             "   4:	d2800542 	mov	x2, #0x2a                  	// #42\n"
             "   8:	d61f00e0 	br	x7"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 return_if_not_equal_to_ctx_test_() ->
     {setup,
@@ -332,7 +332,7 @@ return_if_not_equal_to_ctx_test_() ->
                             "  24:	aa0703e0 	mov	x0, x7\n"
                             "  28:	d65f03c0 	ret"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 ?_test(begin
                     {State1, ResultReg} = ?BACKEND:call_primitive(
@@ -360,7 +360,7 @@ return_if_not_equal_to_ctx_test_() ->
                             "  28:	aa0803e0 	mov	x0, x8\n"
                             "  2c:	d65f03c0 	ret"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end)
             ]
         end}.
@@ -375,7 +375,7 @@ move_to_cp_test() ->
             "   4:	f94000e7 	ldr	x7, [x7]\n"
             "   8:	f9005c07 	str	x7, [x0, #184]"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 increment_sp_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -387,7 +387,7 @@ increment_sp_test() ->
             "   4:	9100e0e7 	add	x7, x7, #0x38\n"
             "   8:	f9001407 	str	x7, [x0, #40]"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 if_block_test_() ->
     {setup,
@@ -414,7 +414,7 @@ if_block_test_() ->
                         "   8:	b6f80047 	tbz	x7, #63, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -433,7 +433,7 @@ if_block_test_() ->
                         "   c:	5400004a 	b.ge	0x14  // b.tcont\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -451,7 +451,7 @@ if_block_test_() ->
                         "   8:	b5000047 	cbnz	x7, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -469,7 +469,7 @@ if_block_test_() ->
                         "   8:	b5000047 	cbnz	x7, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -487,7 +487,7 @@ if_block_test_() ->
                         "   8:	35000047 	cbnz	w7, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -505,7 +505,7 @@ if_block_test_() ->
                         "   8:	35000047 	cbnz	w7, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -524,7 +524,7 @@ if_block_test_() ->
                         "   c:	54000040 	b.eq	0x14  // b.none\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -543,7 +543,7 @@ if_block_test_() ->
                         "   c:	54000040 	b.eq	0x14  // b.none\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -562,7 +562,7 @@ if_block_test_() ->
                         "   c:	54000040 	b.eq	0x14  // b.none\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -581,7 +581,7 @@ if_block_test_() ->
                         "   c:	54000040 	b.eq	0x14  // b.none\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -600,7 +600,7 @@ if_block_test_() ->
                         "   c:	54000041 	b.ne	0x14  // b.any\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -619,7 +619,7 @@ if_block_test_() ->
                         "   c:	54000041 	b.ne	0x14  // b.any\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -638,7 +638,7 @@ if_block_test_() ->
                         "   c:	54000041 	b.ne	0x14  // b.any\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -657,7 +657,7 @@ if_block_test_() ->
                         "   c:	54000041 	b.ne	0x14  // b.any\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -675,7 +675,7 @@ if_block_test_() ->
                         "   8:	37000047 	tbnz	w7, #0, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -693,7 +693,7 @@ if_block_test_() ->
                         "   8:	37000047 	tbnz	w7, #0, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -711,7 +711,7 @@ if_block_test_() ->
                         "   8:	36000047 	tbz	w7, #0, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -729,7 +729,7 @@ if_block_test_() ->
                         "   8:	36000047 	tbz	w7, #0, 0x10\n"
                         "   c:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -748,7 +748,7 @@ if_block_test_() ->
                         "   c:	54000040 	b.eq	0x14  // b.none\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -768,7 +768,7 @@ if_block_test_() ->
                         "  10:	54000040 	b.eq	0x18  // b.none\n"
                         "  14:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -787,7 +787,7 @@ if_block_test_() ->
                         "   c:	54000040 	b.eq	0x14  // b.none\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -807,7 +807,7 @@ if_block_test_() ->
                         "  10:	54000040 	b.eq	0x18  // b.none\n"
                         "  14:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -827,7 +827,7 @@ if_block_test_() ->
                         "  10:	54000040 	b.eq	0x18  // b.none\n"
                         "  14:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -846,7 +846,7 @@ if_block_test_() ->
                         "   c:	5400004d 	b.le	0x14\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -865,7 +865,7 @@ if_block_test_() ->
                         "   c:	5400004d 	b.le	0x14\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -884,7 +884,7 @@ if_block_test_() ->
                         "   c:	5400004a 	b.ge	0x14  // b.tcont\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -903,7 +903,7 @@ if_block_test_() ->
                         "   c:	5400004a 	b.ge	0x14  // b.tcont\n"
                         "  10:	91000908 	add	x8, x8, #0x2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end)
             ]
@@ -934,7 +934,7 @@ if_else_block_test() ->
             "  14:	14000002 	b	0x1c\n"
             "  18:	91001108 	add	x8, x8, #0x4"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 shift_right_test_() ->
     [
@@ -948,7 +948,7 @@ shift_right_test_() ->
                     "   0:	f9401807 	ldr	x7, [x0, #48]\n"
                     "   4:	d343fce7 	lsr	x7, x7, #3"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(aarch64, Dump, Stream)
         end),
         ?_test(begin
             State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -961,7 +961,7 @@ shift_right_test_() ->
                     "   0:	f9401807 	ldr	x7, [x0, #48]\n"
                     "   4:	d343fce8 	lsr	x8, x7, #3"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(aarch64, Dump, Stream)
         end)
     ].
 
@@ -975,7 +975,7 @@ shift_left_test() ->
             "   0:	f9401807 	ldr	x7, [x0, #48]\n"
             "   4:	d37df0e7 	lsl	x7, x7, #3"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_only_or_schedule_next_and_label_relocation_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1007,7 +1007,7 @@ call_only_or_schedule_next_and_label_relocation_test() ->
             "  34:	f9400447 	ldr	x7, [x2, #8]\n"
             "  38:	d61f00e0 	br	x7"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_only_or_schedule_next_known_label_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1039,7 +1039,7 @@ call_only_or_schedule_next_known_label_test() ->
             "  34:	f9400447 	ldr	x7, [x2, #8]\n"
             "  38:	d61f00e0 	br	x7"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_bif_with_large_literal_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1095,7 +1095,7 @@ call_bif_with_large_literal_integer_test() ->
             "  8c:	d61f00e0 	br	x7\n"
             "  90:	f9001807 	str	x7, [x0, #48]"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 get_list_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1116,7 +1116,7 @@ get_list_test() ->
         "  18:	f94000e9 	ldr	x9, [x7]\n"
         "  1c:	f9000109 	str	x9, [x8]"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 is_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1173,7 +1173,7 @@ is_integer_test() ->
         "  3c:	54000040 	b.eq	0x44  // b.none\n"
         "  40:	14000041 	b	0x144"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 cond_jump_to_label(Cond, Label, MMod, MSt0) ->
     MMod:if_block(MSt0, Cond, fun(BSt0) ->
@@ -1232,7 +1232,7 @@ is_number_test() ->
         "  48:	54000040 	b.eq	0x50  // b.none\n"
         "  4c:	14000041 	b	0x150"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 is_boolean_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1260,7 +1260,7 @@ is_boolean_test() ->
         "  18:	54000040 	b.eq	0x20\n"
         "  1c:	14000041 	b	0x120"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 %% Test OP_WAIT_TIMEOUT pattern
 wait_timeout_test() ->
@@ -1320,7 +1320,7 @@ wait_timeout_test() ->
         "  70:	d2800542 	mov	x2, #0x2a                  	// #42\n"
         "  74:	d61f00e0 	br	x7"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 %% Test OP_WAIT pattern that uses set_continuation_to_label
 wait_test() ->
@@ -1347,7 +1347,7 @@ wait_test() ->
         "  20:	f9407447 	ldr	x7, [x2, #232]\n"
         "  24:	d61f00e0 	br	x7"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 %% Test set_continuation_to_label with known label
 wait_known_test() ->
@@ -1374,7 +1374,7 @@ wait_known_test() ->
         "  20:	f9407447 	ldr	x7, [x2, #232]\n"
         "  24:	d61f00e0 	br	x7"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 return_labels_and_lines_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1407,7 +1407,7 @@ return_labels_and_lines_test() ->
         "  28:	14001000 	b	0x4028\n"
         "  2c:	20000000 	.inst	0x20000000"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 %% Test call_primitive with {free, {x_reg, X}}
 gc_bif2_test() ->
@@ -1440,7 +1440,7 @@ gc_bif2_test() ->
         "  48:	a8c10be1 	ldp	x1, x2, [sp], #16\n"
         "  4c:	a8c103fe 	ldp	x30, x0, [sp], #16"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 %% Test case where parameter value is in r1
 memory_ensure_free_with_roots_test() ->
@@ -1462,7 +1462,7 @@ memory_ensure_free_with_roots_test() ->
         "  20:	a8c10be1 	ldp	x1, x2, [sp], #16\n"
         "  24:	a8c103fe 	ldp	x30, x0, [sp], #16"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_ext_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1491,7 +1491,7 @@ call_ext_test() ->
         "  44:	92800004 	mov	x4, #0xffffffffffffffff    	// #-1\n"
         "  48:	d61f00e0 	br	x7"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 call_fun_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1562,12 +1562,12 @@ call_fun_test() ->
         "  90:	d2800003 	mov	x3, #0x0                   	// #0\n"
         "  94:	d61f0100 	br	x8"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 move_to_vm_register_test0(State, Source, Dest, Dump) ->
     State1 = ?BACKEND:move_to_vm_register(State, Source, Dest),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 move_to_vm_register_test_() ->
     {setup,
@@ -1791,7 +1791,7 @@ move_to_vm_register_test_() ->
                         "   8:	f9406008 	ldr	x8, [x0, #192]\n"
                         "   c:	f9000d07 	str	x7, [x8, #24]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end)
             ]
         end}.
@@ -1799,7 +1799,7 @@ move_to_vm_register_test_() ->
 move_array_element_test0(State, Reg, Index, Dest, Dump) ->
     State1 = ?BACKEND:move_array_element(State, Reg, Index, Dest),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 move_array_element_test_() ->
     {setup,
@@ -1896,7 +1896,7 @@ get_array_element_test_() ->
                     Dump = <<
                         "   0:	f9401107 	ldr	x7, [x8, #32]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream),
                     ?assertEqual(r7, Reg)
                 end)
             ]
@@ -1917,7 +1917,7 @@ move_to_array_element_test_() ->
                         "   0:	f9401807 	ldr	x7, [x0, #48]\n"
                         "   4:	f9000907 	str	x7, [x8, #16]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_array_element/4: x_reg to reg[reg]
                 ?_test(begin
@@ -1927,7 +1927,7 @@ move_to_array_element_test_() ->
                         "  0:	f9401807 	ldr	x7, [x0, #48]\n"
                         "   4:	f8297907 	str	x7, [x8, x9, lsl #3]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_array_element/4: ptr to reg[reg]
                 ?_test(begin
@@ -1937,7 +1937,7 @@ move_to_array_element_test_() ->
                         "   0:	f94000e7 	ldr	x7, [x7]\n"
                         "   4:	f8297907 	str	x7, [x8, x9, lsl #3]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_array_element/4: y_reg to reg[reg]
                 ?_test(begin
@@ -1948,7 +1948,7 @@ move_to_array_element_test_() ->
                         "   4:	f94008e7 	ldr	x7, [x7, #16]\n"
                         "   8:	f8297907 	str	x7, [x8, x9, lsl #3]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_array_element/5: x_reg to reg[x+offset]
                 ?_test(begin
@@ -1958,7 +1958,7 @@ move_to_array_element_test_() ->
                         "   0:	f9401807 	ldr	x7, [x0, #48]\n"
                         "   4:	f9000d07 	str	x7, [x8, #24]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_array_element/5: x_reg to reg[x+offset]
                 ?_test(begin
@@ -1972,7 +1972,7 @@ move_to_array_element_test_() ->
                         "   4:	9100052a 	add	x10, x9, #0x1\n"
                         "   8:	f82a7907 	str	x7, [x8, x10, lsl #3]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_array_element/5: imm to reg[x+offset]
                 ?_test(begin
@@ -1986,7 +1986,7 @@ move_to_array_element_test_() ->
                         "   4:	9100052a 	add	x10, x9, #0x1\n"
                         "   8:	f82a7907 	str	x7, [x8, x10, lsl #3]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end)
             ]
         end}.
@@ -2006,7 +2006,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	d2800547 	mov	x7, #0x2a                  	// #42"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {ptr, reg}
                 ?_test(begin
@@ -2016,7 +2016,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	f94000c6 	ldr	x6, [x6]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {x_reg, N}
                 ?_test(begin
@@ -2026,7 +2026,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	f9402407 	ldr	x7, [x0, #72]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {y_reg, N}
                 ?_test(begin
@@ -2037,7 +2037,7 @@ move_to_native_register_test_() ->
                         "   0:	f9401407 	ldr	x7, [x0, #40]\n"
                         "   4:	f9400ce7 	ldr	x7, [x7, #24]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_native_register/3: imm to reg
                 ?_test(begin
@@ -2046,7 +2046,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	d2800548 	mov	x8, #0x2a                  	// #42"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_native_register/3: reg to reg
                 ?_test(begin
@@ -2055,7 +2055,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	aa0703e8 	mov	x8, x7"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {ptr, reg} to reg
                 ?_test(begin
@@ -2064,7 +2064,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	f94000e8 	ldr	x8, [x7]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {x_reg, x} to reg[reg]
                 ?_test(begin
@@ -2073,7 +2073,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	f9402008 	ldr	x8, [x0, #64]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {y_reg, y} to reg[reg]
                 ?_test(begin
@@ -2083,7 +2083,7 @@ move_to_native_register_test_() ->
                         "   0:	f9401408 	ldr	x8, [x0, #40]\n"
                         "   4:	f9400908 	ldr	x8, [x8, #16]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(aarch64, Dump, Stream)
                 end)
             ]
         end}.
@@ -2091,7 +2091,7 @@ move_to_native_register_test_() ->
 add_test0(State0, Reg, Imm, Dump) ->
     State1 = ?BACKEND:add(State0, Reg, Imm),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 add_test_() ->
     {setup,
@@ -2121,7 +2121,7 @@ add_test_() ->
 sub_test0(State0, Reg, Imm, Dump) ->
     State1 = ?BACKEND:sub(State0, Reg, Imm),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 sub_test_() ->
     {setup,
@@ -2151,7 +2151,7 @@ sub_test_() ->
 mul_test0(State0, Reg, Imm, Dump) ->
     State1 = ?BACKEND:mul(State0, Reg, Imm),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
 
 mul_test_() ->
     {setup,
@@ -2235,48 +2235,4 @@ jump_to_continuation_test() ->
             "   4:	8b0000e7 	add	x7, x7, x0\n"
             "   8:	d61f00e0 	br	x7"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
-
-dump_to_bin(Dump) ->
-    dump_to_bin0(Dump, addr, []).
-
--define(IS_HEX_DIGIT(C),
-    ((C >= $0 andalso C =< $9) orelse (C >= $a andalso C =< $f) orelse (C >= $A andalso C =< $F))
-).
-
-dump_to_bin0(<<N, $:, Tail/binary>>, addr, Acc) when ?IS_HEX_DIGIT(N) ->
-    dump_to_bin0(Tail, hex, Acc);
-dump_to_bin0(<<N, Tail/binary>>, addr, Acc) when ?IS_HEX_DIGIT(N) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\n, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\s, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\t, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\s, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, hex, Acc);
-dump_to_bin0(<<$\t, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, hex, Acc);
-dump_to_bin0(<<H1, H2, H3, H4, H5, H6, H7, H8, Sp, Rest/binary>>, hex, Acc) when
-    (Sp =:= $\t orelse Sp =:= $\s) andalso
-        ?IS_HEX_DIGIT(H1) andalso
-        ?IS_HEX_DIGIT(H2) andalso
-        ?IS_HEX_DIGIT(H3) andalso
-        ?IS_HEX_DIGIT(H4) andalso
-        ?IS_HEX_DIGIT(H5) andalso
-        ?IS_HEX_DIGIT(H6) andalso
-        ?IS_HEX_DIGIT(H7) andalso
-        ?IS_HEX_DIGIT(H8)
-->
-    %% Parse 8 hex digits (AArch64 32-bit instruction)
-    Instr = list_to_integer([H1, H2, H3, H4, H5, H6, H7, H8], 16),
-    dump_to_bin0(Rest, instr, [<<Instr:32/little>> | Acc]);
-dump_to_bin0(<<$\n, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\n, Tail/binary>>, instr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<_Other, Tail/binary>>, instr, Acc) ->
-    dump_to_bin0(Tail, instr, Acc);
-dump_to_bin0(<<>>, _, Acc) ->
-    list_to_binary(lists:reverse(Acc)).
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).

--- a/tests/libs/jit/jit_armv6m_tests.erl
+++ b/tests/libs/jit/jit_armv6m_tests.erl
@@ -48,7 +48,7 @@ call_primitive_0_test() ->
             "   8:	4607      	mov	r7, r0\n"
             "   a:	bc05      	pop	{r0, r2}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_primitive_1_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -64,7 +64,7 @@ call_primitive_1_test() ->
             "   8:	4607      	mov	r7, r0\n"
             "   a:	bc05      	pop	{r0, r2}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_primitive_2_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -82,7 +82,7 @@ call_primitive_2_args_test() ->
             "   c:	4607      	mov	r7, r0\n"
             "   e:	bc05      	pop	{r0, r2}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_primitive_5_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -101,7 +101,7 @@ call_primitive_5_args_test() ->
             "  10:	b002      	add	sp, #8\n"
             "  12:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_primitive_6_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -136,7 +136,7 @@ call_primitive_6_args_test() ->
             "  20:	b002      	add	sp, #8\n"
             "  22:	bc05      	pop	{r0, r2}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_primitive_extended_regs_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -178,7 +178,7 @@ call_primitive_extended_regs_test() ->
         "  30:	bc55      	pop	{r0, r2, r4, r6}\n"
         "  32:	6037      	str	r7, [r6, #0]"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_primitive_few_free_regs_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -215,7 +215,7 @@ call_primitive_few_free_regs_test() ->
         "  24:	b002      	add	sp, #8\n"
         "  26:	bce7      	pop	{r0, r1, r2, r5, r6, r7}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_ext_only_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -252,7 +252,7 @@ call_ext_only_test() ->
         "  34:	b002      	add	sp, #8\n"
         "  36:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_ext_only_unaligned_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -294,7 +294,7 @@ call_ext_only_unaligned_test() ->
         "  34:	b002      	add	sp, #8\n"
         "  36:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_primitive_last_5_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -320,7 +320,7 @@ call_primitive_last_5_args_test() ->
         "  14:	02cb      	lsls	r3, r1, #11\n"
         "  16:	0000      	movs	r0, r0"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_ext_last_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -358,7 +358,7 @@ call_ext_last_test() ->
         "  32:	b002      	add	sp, #8\n"
         "  34:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_primitive_last_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -373,7 +373,7 @@ call_primitive_last_test() ->
             "   8:	46b6      	mov	lr, r6\n"
             "   a:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 return_if_not_equal_to_ctx_test_() ->
     {setup,
@@ -404,7 +404,7 @@ return_if_not_equal_to_ctx_test_() ->
                             "  10:	4638      	mov	r0, r7\n"
                             "  12:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 ?_test(begin
                     {State1, ResultReg} = ?BACKEND:call_primitive(
@@ -431,7 +431,7 @@ return_if_not_equal_to_ctx_test_() ->
                             "  12:	4630      	mov	r0, r6\n"
                             "  14:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end)
             ]
         end}.
@@ -446,7 +446,7 @@ move_to_cp_test() ->
             "   2:	6837      	ldr	r7, [r6, #0]\n"
             "   4:	65c7      	str	r7, [r0, #92]	; 0x5c"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 increment_sp_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -458,7 +458,7 @@ increment_sp_test() ->
             "   2:	371c      	adds	r7, #28\n"
             "   4:	6147      	str	r7, [r0, #20]"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 if_block_test_() ->
     {setup,
@@ -486,7 +486,7 @@ if_block_test_() ->
                         "   6:	d500      	bpl.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -505,7 +505,7 @@ if_block_test_() ->
                         "   6:	da00      	bge.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -524,7 +524,7 @@ if_block_test_() ->
                         "   6:	da00      	bge.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -547,7 +547,7 @@ if_block_test_() ->
                         "   c:	3602      	adds	r6, #2\n"
                         "   e:	e077      	b.n	0x100"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -566,7 +566,7 @@ if_block_test_() ->
                         "   6:	d100      	bne.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -585,7 +585,7 @@ if_block_test_() ->
                         "   6:	d100      	bne.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -606,7 +606,7 @@ if_block_test_() ->
                         "   a:	d100      	bne.n	0xe\n"
                         "   c:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -625,7 +625,7 @@ if_block_test_() ->
                         "   6:	d100      	bne.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -644,7 +644,7 @@ if_block_test_() ->
                         "   6:	d100      	bne.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -663,7 +663,7 @@ if_block_test_() ->
                         "   6:	d000      	beq.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -682,7 +682,7 @@ if_block_test_() ->
                         "   6:	d000      	beq.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -701,7 +701,7 @@ if_block_test_() ->
                         "   6:	d000      	beq.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -727,7 +727,7 @@ if_block_test_() ->
                         "  10:	07cb      	lsls	r3, r1, #31\n"
                         "  12:	0000      	movs	r0, r0"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 ?_test(begin
                     State1 = ?BACKEND:if_block(
@@ -745,7 +745,7 @@ if_block_test_() ->
                         "   6:	d000      	beq.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -764,7 +764,7 @@ if_block_test_() ->
                         "   6:	d100      	bne.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -783,7 +783,7 @@ if_block_test_() ->
                         "   6:	d100      	bne.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -802,7 +802,7 @@ if_block_test_() ->
                         "   6:	d100      	bne.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -821,7 +821,7 @@ if_block_test_() ->
                         "   6:	d100      	bne.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -840,7 +840,7 @@ if_block_test_() ->
                         "   6:	d400      	bmi.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -859,7 +859,7 @@ if_block_test_() ->
                         "   6:	d400      	bmi.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -878,7 +878,7 @@ if_block_test_() ->
                         "   6:	d500      	bpl.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -897,7 +897,7 @@ if_block_test_() ->
                         "   6:	d500      	bpl.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -916,7 +916,7 @@ if_block_test_() ->
                         "   6:	d000      	beq.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -936,7 +936,7 @@ if_block_test_() ->
                         "   8:	d000      	beq.n	0xc\n"
                         "   a:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -955,7 +955,7 @@ if_block_test_() ->
                         "   6:	d000      	beq.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -975,7 +975,7 @@ if_block_test_() ->
                         "   8:	d000      	beq.n	0xc\n"
                         "   a:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -995,7 +995,7 @@ if_block_test_() ->
                         "   8:	d000      	beq.n	0xc\n"
                         "   a:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1017,7 +1017,7 @@ if_block_test_() ->
                         "   c:	d000      	beq.n	0x10\n"
                         "   e:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1036,7 +1036,7 @@ if_block_test_() ->
                         "   6:	da00      	bge.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1063,7 +1063,7 @@ if_block_test_() ->
                         "   a:	d000      	beq.n	0xe\n"
                         "   c:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1082,7 +1082,7 @@ if_block_test_() ->
                         "   6:	dd00      	ble.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1101,7 +1101,7 @@ if_block_test_() ->
                         "   6:	dd00      	ble.n	0xa\n"
                         "   8:	3602      	adds	r6, #2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1124,7 +1124,7 @@ if_block_test_() ->
                         "   c:	3602      	adds	r6, #2\n"
                         "   e:	e077      	b.n	0x100"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1147,7 +1147,7 @@ if_block_test_() ->
                         "   c:	3602      	adds	r6, #2\n"
                         "   e:	e077      	b.n	0x100"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1172,7 +1172,7 @@ if_block_test_() ->
                         "  10:	03ff      	lsls	r7, r7, #15\n"
                         "  12:	0000      	movs	r0, r0"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1197,7 +1197,7 @@ if_block_test_() ->
                         "  10:	03ff      	lsls	r7, r7, #15\n"
                         "  12:	0000      	movs	r0, r0"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end)
             ]
@@ -1226,7 +1226,7 @@ bitwise_and_optimization_test_() ->
                 "   6:	d000      	beq.n	0xa\n"
                 "   8:	3602      	adds	r6, #2"
             >>,
-            ?assertEqual(dump_to_bin(Dump), Stream),
+            jit_tests_common:assert_stream(arm, Dump, Stream),
             ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State3))
         end),
         %% Test optimized case: 16#F (low bits mask, 4 bits) - lsls r5, r7, #28
@@ -1246,7 +1246,7 @@ bitwise_and_optimization_test_() ->
                 "   6:	d000      	beq.n	0xa\n"
                 "   8:	3602      	adds	r6, #2"
             >>,
-            ?assertEqual(dump_to_bin(Dump), Stream),
+            jit_tests_common:assert_stream(arm, Dump, Stream),
             ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State3))
         end),
         %% Test optimized case: 16#3F (low bits mask, 6 bits) - lsls r5, r7, #26
@@ -1266,7 +1266,7 @@ bitwise_and_optimization_test_() ->
                 "   6:	d000      	beq.n	0xa\n"
                 "   8:	3602      	adds	r6, #2"
             >>,
-            ?assertEqual(dump_to_bin(Dump), Stream),
+            jit_tests_common:assert_stream(arm, Dump, Stream),
             ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State3))
         end),
         %% Test non-optimized case: 5 (neither single bit nor low bits mask) - mov+tst
@@ -1287,7 +1287,7 @@ bitwise_and_optimization_test_() ->
                 "   8:	d000      	beq.n	0xc\n"
                 "   a:	3602      	adds	r6, #2"
             >>,
-            ?assertEqual(dump_to_bin(Dump), Stream),
+            jit_tests_common:assert_stream(arm, Dump, Stream),
             ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State3))
         end)
     ].
@@ -1317,7 +1317,7 @@ if_else_block_test() ->
             "   a:	e000      	b.n	0xe\n"
             "   c:	3604      	adds	r6, #4"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 shift_right_test_() ->
     [
@@ -1331,7 +1331,7 @@ shift_right_test_() ->
                     "   0:	6987      	ldr	r7, [r0, #24]\n"
                     "   2:	08ff      	lsrs	r7, r7, #3"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(arm, Dump, Stream)
         end),
         ?_test(begin
             State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1344,7 +1344,7 @@ shift_right_test_() ->
                     "   0:	6987      	ldr	r7, [r0, #24]\n"
                     "   2:	08fe      	lsrs	r6, r7, #3"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(arm, Dump, Stream)
         end)
     ].
 
@@ -1358,7 +1358,7 @@ shift_left_test() ->
             "   0:	6987      	ldr	r7, [r0, #24]\n"
             "   2:	00ff      	lsls	r7, r7, #3"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_only_or_schedule_next_and_label_relocation_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1426,7 +1426,7 @@ call_only_or_schedule_next_and_label_relocation_test() ->
             "  62:	46b6      	mov	lr, r6\n"
             "  64:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test with different alignment (unaligned start)
 call_only_or_schedule_next_and_label_relocation_unaligned_test() ->
@@ -1499,7 +1499,7 @@ call_only_or_schedule_next_and_label_relocation_unaligned_test() ->
             "  66:	46b6      	mov	lr, r6\n"
             "  68:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test with large gap (256+ bytes) to force mov_immediate path
 call_only_or_schedule_next_and_label_relocation_large_gap_test() ->
@@ -1560,7 +1560,7 @@ call_only_or_schedule_next_and_label_relocation_large_gap_test() ->
         " 164:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
     >>,
     {_, RelevantBinary} = split_binary(Stream, 16#124),
-    ?assertEqual(dump_to_bin(Dump), RelevantBinary).
+    jit_tests_common:assert_stream(arm, Dump, RelevantBinary).
 
 %% Test with large gap (256+ bytes) and different alignment to force literal pool path
 call_only_or_schedule_next_and_label_relocation_large_gap_unaligned_test() ->
@@ -1622,7 +1622,7 @@ call_only_or_schedule_next_and_label_relocation_large_gap_unaligned_test() ->
         " 164:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
     >>,
     {_, RelevantBinary} = split_binary(Stream, 16#122),
-    ?assertEqual(dump_to_bin(Dump), RelevantBinary).
+    jit_tests_common:assert_stream(arm, Dump, RelevantBinary).
 
 call_bif_with_large_literal_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1675,7 +1675,7 @@ call_bif_with_large_literal_integer_test() ->
             "  40:	e895 3b7f 	ldmia.w	r5, {r0, r1, r2, r3, r4, r5, r6, r8, r9, fp, ip, sp}\n"
             "  44:	6187      	str	r7, [r0, #24]"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 get_list_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1697,7 +1697,7 @@ get_list_test() ->
         "   e:	6946      	ldr	r6, [r0, #20]\n"
         "  10:	6035      	str	r5, [r6, #0]"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 is_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1755,7 +1755,7 @@ is_integer_test() ->
         "  30:	46c0      	nop			; (mov r8, r8)\n"
         "  32:	46c0      	nop			; (mov r8, r8)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 cond_jump_to_label(Cond, Label, MMod, MSt0) ->
     MMod:if_block(MSt0, Cond, fun(BSt0) ->
@@ -1825,7 +1825,7 @@ is_number_test() ->
         "  3c:	46c0      	nop			; (mov r8, r8)\n"
         "  3e:	46c0      	nop			; (mov r8, r8)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 is_boolean_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1866,7 +1866,7 @@ is_boolean_test() ->
         "  28:	46c0      	nop\n"
         "  2a:	46c0      	nop"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 is_boolean_far_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1907,7 +1907,7 @@ is_boolean_far_test() ->
         "  28:	0fd9      	lsrs	r1, r3, #31\n"
         "  2a:	0000      	movs	r0, r0"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 is_boolean_far_unaligned_test() ->
     % Create a new state with a 2-byte instruction already in the stream
@@ -1943,7 +1943,7 @@ is_boolean_far_unaligned_test() ->
         "  14:	0fef      	lsrs	r7, r5, #31\n"
         "  16:	0000      	movs	r0, r0"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 is_boolean_far_known_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1984,7 +1984,7 @@ is_boolean_far_known_test() ->
         "  28:	0fd9      	lsrs	r1, r3, #31\n"
         "  2a:	0000      	movs	r0, r0"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 is_boolean_far_known_unaligned_test() ->
     % Create a new state with a 2-byte instruction already in the stream
@@ -2033,7 +2033,7 @@ is_boolean_far_known_unaligned_test() ->
         "  2c:	0fd7      	lsrs	r7, r2, #31\n"
         "  2e:	0000      	movs	r0, r0"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test OP_WAIT_TIMEOUT pattern that uses set_continuation_to_offset and continuation_entry_point
 wait_timeout_test() ->
@@ -2103,7 +2103,7 @@ wait_timeout_test() ->
         "  4c:	46b6      	mov	lr, r6\n"
         "  4e:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test OP_WAIT pattern that uses set_continuation_to_label
 wait_test() ->
@@ -2151,7 +2151,7 @@ wait_test() ->
         "  38:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}\n"
         "  3a:	46c0      	nop			; (mov r8, r8)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test return_labels_and_lines/2 function
 return_labels_and_lines_test() ->
@@ -2210,7 +2210,7 @@ return_labels_and_lines_test() ->
         "  40:	0000      	movs	r0, r0\n"
         "  42:	2000      	movs	r0, #0"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test return_labels_and_lines/2 with unaligned offset
 return_labels_and_lines_unaligned_test() ->
@@ -2270,7 +2270,7 @@ return_labels_and_lines_unaligned_test() ->
         "  44:	0000      	movs	r0, r0\n"
         "  46:	2000      	movs	r0, #0"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test call_primitive with {free, {x_reg, X}}
 gc_bif2_test() ->
@@ -2302,7 +2302,7 @@ gc_bif2_test() ->
         "  22:	b002      	add	sp, #8\n"
         "  24:	bc05      	pop	{r0, r2}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test case where parameter value is in r1
 memory_ensure_free_with_roots_test() ->
@@ -2328,7 +2328,7 @@ memory_ensure_free_with_roots_test() ->
         "  18:	b002      	add	sp, #8\n"
         "  1a:	bc05      	pop	{r0, r2}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_ext_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -2375,7 +2375,7 @@ call_ext_test() ->
         "  46:	0000      	movs	r0, r0\n"
         "  48:	b5f2      	push	{r1, r4, r5, r6, r7, lr}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 call_fun_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -2477,13 +2477,13 @@ call_fun_test() ->
         "  86:	0000      	movs	r0, r0\n"
         "  88:	b5f2      	push	{r1, r4, r5, r6, r7, lr}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 move_to_vm_register_test0(State, Source, Dest, Dump) ->
     State1 = ?BACKEND:move_to_vm_register(State, Source, Dest),
     State2 = ?BACKEND:jump_to_offset(State1, 16#100),
     Stream = ?BACKEND:stream(State2),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 move_to_vm_register_test_() ->
     {setup,
@@ -2666,15 +2666,15 @@ move_to_vm_register_test_() ->
                     State2 = ?BACKEND:move_to_vm_register(State1, 16#12345678, {x_reg, 0}),
                     State3 = ?BACKEND:jump_to_offset(State2, 16#100),
                     Stream = ?BACKEND:stream(State3),
-                    Expected = dump_to_bin(<<
+                    Dump = <<
                         "   0:	6019      	str	r1, [r3, #0]\n"
                         "   2:	4f01      	ldr	r7, [pc, #4]	; (0x8)\n"
                         "   4:	6187      	str	r7, [r0, #24]\n"
                         "   6:	e07b      	b.n	0x100\n"
                         "   8:	5678      	ldrsb	r0, [r7, r1]\n"
                         "   a:	1234      	asrs	r4, r6, #8"
-                    >>),
-                    ?assertEqual(Expected, Stream)
+                    >>,
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 ?_test(begin
                     move_to_vm_register_test0(State0, 16#12345678, {x_reg, extra}, <<
@@ -2761,7 +2761,7 @@ move_to_vm_register_test_() ->
 move_array_element_test0(State, Reg, Index, Dest, Dump) ->
     State1 = ?BACKEND:move_array_element(State, Reg, Index, Dest),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 move_array_element_test_() ->
     {setup,
@@ -2898,7 +2898,7 @@ get_array_element_test_() ->
                     Dump = <<
                         "   0:	6927      	ldr	r7, [r4, #16]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual(r7, Reg)
                 end),
                 %% get_array_element: reg[x] with large offset (index 32, offset 128)
@@ -2911,7 +2911,7 @@ get_array_element_test_() ->
                         "   2:	4426      	add	r6, r4\n"
                         "   4:	6ff7      	ldr	r7, [r6, #124]	; 0x7c"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual(r7, Reg)
                 end)
             ]
@@ -2932,7 +2932,7 @@ move_to_array_element_test_() ->
                         "   0:	6987      	ldr	r7, [r0, #24]\n"
                         "   2:	609f      	str	r7, [r3, #8]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_array_element/4: x_reg to reg[x], larger immediate offset
                 ?_test(begin
@@ -2944,7 +2944,7 @@ move_to_array_element_test_() ->
                         "   4:	441e      	add	r6, r3\n"
                         "   6:	67f7      	str	r7, [r6, #124]	; 0x7c"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_array_element/4: x_reg to reg[reg]
                 ?_test(begin
@@ -2956,7 +2956,7 @@ move_to_array_element_test_() ->
                         "   4:	00b6      	lsls	r6, r6, #2\n"
                         "   6:	519f      	str	r7, [r3, r6]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_array_element/4: ptr to reg[reg]
                 ?_test(begin
@@ -2968,7 +2968,7 @@ move_to_array_element_test_() ->
                         "   4:	00b6      	lsls	r6, r6, #2\n"
                         "   6:	519f      	str	r7, [r3, r6]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_array_element/4: y_reg to reg[reg]
                 ?_test(begin
@@ -2981,7 +2981,7 @@ move_to_array_element_test_() ->
                         "   6:	00b6      	lsls	r6, r6, #2\n"
                         "   8:	519f      	str	r7, [r3, r6]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_array_element/5: x_reg to reg[x+offset]
                 ?_test(begin
@@ -2991,7 +2991,7 @@ move_to_array_element_test_() ->
                         "   0:	6987      	ldr	r7, [r0, #24]\n"
                         "   2:	609f      	str	r7, [r3, #8]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_array_element/5: x_reg to reg[x+offset]
                 ?_test(begin
@@ -3006,7 +3006,7 @@ move_to_array_element_test_() ->
                         "   4:	00b6      	lsls	r6, r6, #2\n"
                         "   6:	519f      	str	r7, [r3, r6]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_array_element/5: imm to reg[x+offset]
                 ?_test(begin
@@ -3021,7 +3021,7 @@ move_to_array_element_test_() ->
                         "   4:	00b6      	lsls	r6, r6, #2\n"
                         "   6:	519f      	str	r7, [r3, r6]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end)
             ]
         end}.
@@ -3041,7 +3041,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	272a      	movs	r7, #42	; 0x2a"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/2: negative value
                 ?_test(begin
@@ -3052,7 +3052,7 @@ move_to_native_register_test_() ->
                         "   0:	272a      	movs	r7, #42	; 0x2a\n"
                         "   2:	427f      	negs	r7, r7"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/2: -255 (boundary case)
                 ?_test(begin
@@ -3063,7 +3063,7 @@ move_to_native_register_test_() ->
                         "   0:	27ff      	movs	r7, #255	; 0xff\n"
                         "   2:	427f      	negs	r7, r7"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/2: -256 (boundary case, should use literal pool)
                 ?_test(begin
@@ -3076,7 +3076,7 @@ move_to_native_register_test_() ->
                         "   2:	43ff      	mvns	r7, r7\n"
                         "   4:	e07c      	b.n	0x100"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {ptr, reg}
                 ?_test(begin
@@ -3086,7 +3086,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	6836      	ldr	r6, [r6, #0]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {x_reg, N}
                 ?_test(begin
@@ -3096,7 +3096,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	6a47      	ldr	r7, [r0, #36]	; 0x24"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {y_reg, N}
                 ?_test(begin
@@ -3107,7 +3107,7 @@ move_to_native_register_test_() ->
                         "   0:	6946      	ldr	r6, [r0, #20]\n"
                         "   2:	68f7      	ldr	r7, [r6, #12]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/3: imm to reg
                 ?_test(begin
@@ -3116,7 +3116,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	262a      	movs	r6, #42	; 0x2a"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/3: reg to reg
                 ?_test(begin
@@ -3125,7 +3125,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	463d      	mov	r5, r7"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {ptr, reg} to reg
                 ?_test(begin
@@ -3134,7 +3134,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	683c      	ldr	r4, [r7, #0]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {x_reg, x} to reg[reg]
                 ?_test(begin
@@ -3143,7 +3143,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:	6a03      	ldr	r3, [r0, #32]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {y_reg, y} to reg[reg]
                 ?_test(begin
@@ -3153,7 +3153,7 @@ move_to_native_register_test_() ->
                         "   0:	6947      	ldr	r7, [r0, #20]\n"
                         "   2:	68b9      	ldr	r1, [r7, #8]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% Test: ptr with offset to fp_reg (term_to_float)
                 ?_test(begin
@@ -3170,7 +3170,7 @@ move_to_native_register_test_() ->
                         "   8:	68bd      	ldr	r5, [r7, #8]\n"
                         "   a:	61f5      	str	r5, [r6, #28]"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 %% Force literal pool flush
                 ?_test(begin
@@ -3196,7 +3196,7 @@ move_to_native_register_test_() ->
                         " 216:  0000        .dword 0x0000\n\n"
                         " 218:  0402        .dword 0x0402\n\n"
                     >>,
-                    ?assertEqual(dump_to_bin(LoadAndBranchDump), LoadAndBranch),
+                    jit_tests_common:assert_stream(arm, LoadAndBranchDump, LoadAndBranch),
                     {_, Continuation0} = split_binary(Stream, 16#2f8),
                     {Continuation, _} = split_binary(Continuation0, 8),
                     ContinuationDump = <<
@@ -3205,7 +3205,7 @@ move_to_native_register_test_() ->
                         " 2fc:   19ff       adds    r7, r7, r7\n"
                         " 2fe:   4f02       ldr	    r7, [pc, #8]	; (0x308)"
                     >>,
-                    ?assertEqual(dump_to_bin(ContinuationDump), Continuation)
+                    jit_tests_common:assert_stream(arm, ContinuationDump, Continuation)
                 end),
                 ?_test(begin
                     % Different alignment
@@ -3233,7 +3233,7 @@ move_to_native_register_test_() ->
                         " 218:   0401       .dword 0x401\n\n"
                         " 21a:   0000       .dword 0x000"
                     >>,
-                    ?assertEqual(dump_to_bin(LoadAndBranchDump), LoadAndBranch),
+                    jit_tests_common:assert_stream(arm, LoadAndBranchDump, LoadAndBranch),
                     {_, Continuation0} = split_binary(Stream, 16#2fc),
                     {Continuation, _} = split_binary(Continuation0, 8),
                     ContinuationDump = <<
@@ -3242,7 +3242,7 @@ move_to_native_register_test_() ->
                         " 300:   19b6       adds    r6, r6, r6\n"
                         " 302:   4e02      	ldr     r6, [pc, #8]	; (0x30c)"
                     >>,
-                    ?assertEqual(dump_to_bin(ContinuationDump), Continuation)
+                    jit_tests_common:assert_stream(arm, ContinuationDump, Continuation)
                 end)
             ]
         end}.
@@ -3252,7 +3252,7 @@ add_test0(State0, Reg, Imm, Dump) ->
     % Force emission of literal pool
     State2 = ?BACKEND:jump_to_offset(State1, 16#100),
     Stream = ?BACKEND:stream(State2),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 add_test_() ->
     {setup,
@@ -3309,7 +3309,7 @@ sub_test0(State0, Reg, Imm, Dump) ->
     % Force emission of literal pool
     State2 = ?BACKEND:jump_to_offset(State1, 16#100),
     Stream = ?BACKEND:stream(State2),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 sub_test_() ->
     {setup,
@@ -3355,7 +3355,7 @@ sub_test_() ->
 mul_test0(State0, Reg, Imm, Dump) ->
     State1 = ?BACKEND:mul(State0, Reg, Imm),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 mul_test_() ->
     {setup,
@@ -3450,7 +3450,7 @@ set_args1_y_reg_test() ->
         "   e:	4607      	mov	r7, r0\n"
         "  10:	bc05      	pop	{r0, r2}"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test large Y register read (Y=32, offset=128, exceeds 124-byte limit)
 large_y_reg_read_test() ->
@@ -3465,7 +3465,7 @@ large_y_reg_read_test() ->
         "   4:	4437      	add	r7, r6\n"
         "   6:	683f      	ldr	r7, [r7, #0]"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream),
+    jit_tests_common:assert_stream(arm, Dump, Stream),
     ?assertEqual(r7, Reg).
 
 %% Test large Y register write with available temp registers
@@ -3484,7 +3484,7 @@ large_y_reg_write_test() ->
         "   6:	4435      	add	r5, r6\n"
         "   8:	602f      	str	r7, [r5, #0]"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test large Y register read with limited registers (uses IP_REG fallback)
 large_y_reg_read_register_exhaustion_test() ->
@@ -3511,7 +3511,7 @@ large_y_reg_read_register_exhaustion_test() ->
         "  10:	4461      	add	r1, ip\n"
         "  12:	6809      	ldr	r1, [r1, #0]"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream),
+    jit_tests_common:assert_stream(arm, Dump, Stream),
     ?assertEqual(r1, ResultReg).
 
 %% Test large Y register write with register exhaustion (uses IP_REG fallback)
@@ -3540,7 +3540,7 @@ large_y_reg_write_register_exhaustion_test() ->
         "  10:	4461      	add	r1, ip\n"
         "  12:	600f      	str	r7, [r1, #0]"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test boundary case: Y=31 (124 bytes, exactly at limit, should use direct addressing)
 y_reg_boundary_direct_test() ->
@@ -3552,7 +3552,7 @@ y_reg_boundary_direct_test() ->
         "   0:	6946      	ldr	r6, [r0, #20]\n"
         "   2:	6ff7      	ldr	r7, [r6, #124]	; 0x7c"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream),
+    jit_tests_common:assert_stream(arm, Dump, Stream),
     ?assertEqual(r7, Reg).
 
 %% Test debugger function
@@ -3563,7 +3563,7 @@ debugger_test() ->
     Dump = <<
         "   0:	be00      	bkpt	0x0000"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 and_register_exhaustion_negative_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -3589,7 +3589,7 @@ and_register_exhaustion_negative_test() ->
         "  10:	4387      	bics	r7, r0\n"
         "  12:	4660      	mov	r0, ip"
     >>,
-    ?assertEqual(dump_to_bin(ExpectedDump), Stream).
+    jit_tests_common:assert_stream(arm, ExpectedDump, Stream).
 
 and_register_exhaustion_positive_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -3615,7 +3615,7 @@ and_register_exhaustion_positive_test() ->
         "  10:	4007      	ands	r7, r0\n"
         "  12:	4660      	mov	r0, ip"
     >>,
-    ?assertEqual(dump_to_bin(ExpectedDump), Stream).
+    jit_tests_common:assert_stream(arm, ExpectedDump, Stream).
 
 jump_table_large_labels_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -3640,7 +3640,7 @@ alloc_boxed_integer_fragment_small_test() ->
             "   a:	4607      	mov	r7, r0\n"
             "   c:	bc05      	pop	{r0, r2}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 alloc_boxed_integer_fragment_large_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -3678,7 +3678,7 @@ alloc_boxed_integer_fragment_large_test() ->
             "  28:	028b      	lsls	r3, r1, #10\n"
             "  2a:	0000      	movs	r0, r0"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test for stack alignment issue in call_func_ptr
 %% When we have an odd number of saved registers, the stack becomes misaligned
@@ -3701,7 +3701,7 @@ call_func_ptr_stack_alignment_test() ->
             "   c:	4604      	mov	r4, r0\n"
             "   e:	bced      	pop	{r0, r2, r3, r5, r6, r7}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Test for register exhaustion issue in call_func_ptr with 5+ arguments
 %% When all registers are used and we call a function with 5+ args,
@@ -3749,7 +3749,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "  1e:	b002      	add	sp, #8\n"
                             "  20:	bcb7      	pop	{r0, r1, r2, r4, r5, r7}"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 ?_test(begin
                     {State7, _ResultReg} = ?BACKEND:call_func_ptr(
@@ -3777,7 +3777,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "  1c:	b002      	add	sp, #8\n"
                             "  1e:	bcb7      	pop	{r0, r1, r2, r4, r5, r7}"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 ?_test(begin
                     {State7, ResultReg} = ?BACKEND:call_func_ptr(
@@ -3807,7 +3807,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "  20:	b002      	add	sp, #8\n"
                             "  22:	bcb7      	pop	{r0, r1, r2, r4, r5, r7}"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(arm, Dump, Stream),
                     ?assertEqual(r6, ResultReg)
                 end),
                 ?_test(begin
@@ -3833,7 +3833,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "  16:	9001      	str	r0, [sp, #4]\n"
                             "  18:	bcff      	pop	{r0, r1, r2, r3, r4, r5, r6, r7}"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end),
                 ?_test(begin
                     {State7, ResultReg} = ?BACKEND:call_func_ptr(
@@ -3859,7 +3859,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "  16:	9006      	str	r0, [sp, #24]\n"
                             "  18:	bcff      	pop	{r0, r1, r2, r3, r4, r5, r6, r7}"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
                 end)
             ]
         end}.
@@ -3883,7 +3883,7 @@ jump_to_continuation_test() ->
             "   e:	46be      	mov	lr, r7\n"
             "  10:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(arm, Dump, Stream).
 
 %% Mimic part of add.beam
 add_beam_test() ->
@@ -4045,60 +4045,4 @@ add_beam_test() ->
             "  e6:	46b6      	mov	lr, r6\n"
             "  e8:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
-
-dump_to_bin(Dump) ->
-    dump_to_bin0(Dump, addr, []).
-
--define(IS_HEX_DIGIT(C),
-    ((C >= $0 andalso C =< $9) orelse (C >= $a andalso C =< $f) orelse (C >= $A andalso C =< $F))
-).
-
-dump_to_bin0(<<N, $:, Tail/binary>>, addr, Acc) when ?IS_HEX_DIGIT(N) ->
-    dump_to_bin0(Tail, hex, Acc);
-dump_to_bin0(<<N, Tail/binary>>, addr, Acc) when ?IS_HEX_DIGIT(N) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\n, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\s, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\t, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\s, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, hex, Acc);
-dump_to_bin0(<<$\t, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, hex, Acc);
-%% Handle 32-bits undefined instruction
-dump_to_bin0(<<H1, H2, H3, H4, $\s, H5, H6, H7, H8, Sp, Rest/binary>>, hex, Acc) when
-    (Sp =:= $\t orelse Sp =:= $\s) andalso
-        ?IS_HEX_DIGIT(H1) andalso
-        ?IS_HEX_DIGIT(H2) andalso
-        ?IS_HEX_DIGIT(H3) andalso
-        ?IS_HEX_DIGIT(H4) andalso
-        ?IS_HEX_DIGIT(H5) andalso
-        ?IS_HEX_DIGIT(H6) andalso
-        ?IS_HEX_DIGIT(H7) andalso
-        ?IS_HEX_DIGIT(H8)
-->
-    InstrA = list_to_integer([H1, H2, H3, H4], 16),
-    InstrB = list_to_integer([H5, H6, H7, H8], 16),
-    dump_to_bin0(Rest, instr, [<<InstrB:16/little>>, <<InstrA:16/little>> | Acc]);
-%% Handle 16-bit ARM32 Thumb instructions (4 hex digits)
-dump_to_bin0(<<H1, H2, H3, H4, Sp, Rest/binary>>, hex, Acc) when
-    (Sp =:= $\t orelse Sp =:= $\s) andalso
-        ?IS_HEX_DIGIT(H1) andalso
-        ?IS_HEX_DIGIT(H2) andalso
-        ?IS_HEX_DIGIT(H3) andalso
-        ?IS_HEX_DIGIT(H4)
-->
-    %% Parse 4 hex digits (ARM32 Thumb 16-bit instruction)
-    Instr = list_to_integer([H1, H2, H3, H4], 16),
-    dump_to_bin0(Rest, instr, [<<Instr:16/little>> | Acc]);
-dump_to_bin0(<<$\n, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\n, Tail/binary>>, instr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<_Other, Tail/binary>>, instr, Acc) ->
-    dump_to_bin0(Tail, instr, Acc);
-dump_to_bin0(<<>>, _, Acc) ->
-    list_to_binary(lists:reverse(Acc)).
+    jit_tests_common:assert_stream(arm, Dump, Stream).

--- a/tests/libs/jit/jit_riscv32_tests.erl
+++ b/tests/libs/jit/jit_riscv32_tests.erl
@@ -55,7 +55,7 @@ call_primitive_0_test() ->
             "  18:  4632                lw  a2,12(sp)\n"
             "  1a:  0141                addi    sp,sp,16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_primitive_1_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -78,7 +78,7 @@ call_primitive_1_test() ->
             "  18:  4632                lw  a2,12(sp)\n"
             "  1a:  0141                addi    sp,sp,16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_primitive_2_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -104,7 +104,7 @@ call_primitive_2_args_test() ->
             "  24:  4632                lw  a2,12(sp)\n"
             "  26:  0141                addi    sp,sp,16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_primitive_5_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -118,7 +118,7 @@ call_primitive_5_args_test() ->
             "   a:  4709                li  a4,2\n"
             "   c:  8f82                jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_primitive_6_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -159,7 +159,7 @@ call_primitive_6_args_test() ->
             "  3a:  4632                lw  a2,12(sp)\n"
             "  3c:  0141                addi    sp,sp,16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_primitive_extended_regs_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -241,7 +241,7 @@ call_primitive_extended_regs_test() ->
         "  90:  02010113            addi    sp,sp,32\n"
         "  94:  01cea023            sw  t3,0(t4)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_primitive_few_free_regs_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -289,7 +289,7 @@ call_primitive_few_free_regs_test() ->
         "  3e:  4fe2                lw  t6,24(sp)\n"
         "  40:  02010113            addi    sp,sp,32"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_ext_only_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -314,7 +314,7 @@ call_ext_only_test() ->
         "  2c:  57fd                li  a5,-1\n"
         "  2e:  8f82                jr  t6"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_primitive_last_5_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -331,7 +331,7 @@ call_primitive_last_5_args_test() ->
         "   e: 877e                mv  a4,t6\n"
         "  10: 8f02                jr  t5"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_ext_last_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -356,7 +356,7 @@ call_ext_last_test() ->
         "   2c:    47a9                    li  a5,10\n"
         "   2e:    8f82                    jr  t6"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_primitive_last_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -368,7 +368,7 @@ call_primitive_last_test() ->
             "   4: 02a00613            li  a2,42\n"
             "   8: 8f82                    jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 return_if_not_equal_to_ctx_test_() ->
     {setup,
@@ -405,7 +405,7 @@ return_if_not_equal_to_ctx_test_() ->
                             "  20:  857e                mv  a0,t6\n"
                             "  22:  8082                ret"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 ?_test(begin
                     {State1, ResultReg} = ?BACKEND:call_primitive(
@@ -438,7 +438,7 @@ return_if_not_equal_to_ctx_test_() ->
                             "  22:  857a                mv  a0,t5\n"
                             "  24:  8082                ret"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end)
             ]
         end}.
@@ -453,7 +453,7 @@ move_to_cp_test() ->
             "   4:  000f2f83            lw  t6,0(t5)\n"
             "   8:  05f52e23            sw  t6,92(a0)"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 increment_sp_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -465,7 +465,7 @@ increment_sp_test() ->
             "   4: 0ff1                addi    t6,t6,28\n"
             "   6: 01f52a23            sw  t6,20(a0)"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 if_block_test_() ->
     {setup,
@@ -492,7 +492,7 @@ if_block_test_() ->
                         "   8:  000fd363            bgez    t6,0xe\n"
                         "   c:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -510,7 +510,7 @@ if_block_test_() ->
                         "   8:  01efd363            bge t6,t5,0xe\n"
                         "   c:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -529,7 +529,7 @@ if_block_test_() ->
                         "   c:  01dfd363            bge t6,t4,0x12\n"
                         "  10:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -550,7 +550,7 @@ if_block_test_() ->
                         "  10:  0f09                addi    t5,t5,2\n"
                         "  12:  a0fd                j   0x100"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -568,7 +568,7 @@ if_block_test_() ->
                         "   8:  000f9363            bnez    t6,0xe\n"
                         "   c:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -586,7 +586,7 @@ if_block_test_() ->
                         "   8:  000f9363            bnez    t6,0xe\n"
                         "   c:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -605,7 +605,7 @@ if_block_test_() ->
                         "   a:  01df9363            bne t6,t4,0x10\n"
                         "   e:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -623,7 +623,7 @@ if_block_test_() ->
                         "   8:  000f9363            bnez    t6,0xe\n"
                         "   c:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -641,7 +641,7 @@ if_block_test_() ->
                         "   8:  000f9363            bnez    t6,0xe\n"
                         "   c:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -660,7 +660,7 @@ if_block_test_() ->
                         "   c:  01df8363            beq t6,t4,0x12\n"
                         "  10:  0f09                addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -679,7 +679,7 @@ if_block_test_() ->
                         "      c:   01df8363            beq t6,t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -698,7 +698,7 @@ if_block_test_() ->
                         "      c:   01df8363            beq t6,t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -720,7 +720,7 @@ if_block_test_() ->
                         "     10:   0f05                    addi    t5,t5,1\n"
                         "     12:   a0fd                    j   0x100"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 ?_test(begin
                     State1 = ?BACKEND:if_block(
@@ -738,7 +738,7 @@ if_block_test_() ->
                         "      c:   01df8363            beq t6,t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -757,7 +757,7 @@ if_block_test_() ->
                         "      c:   01df9363            bne t6,t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -776,7 +776,7 @@ if_block_test_() ->
                         "      c:   01df9363            bne t6,t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -795,7 +795,7 @@ if_block_test_() ->
                         "      c:   01df9363            bne t6,t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -814,7 +814,7 @@ if_block_test_() ->
                         "      c:   01df9363            bne t6,t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -833,7 +833,7 @@ if_block_test_() ->
                         "      c:   000ec363            bltz    t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -852,7 +852,7 @@ if_block_test_() ->
                         "      c:   000ec363            bltz    t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -871,7 +871,7 @@ if_block_test_() ->
                         "      c:   000ed363            bgez    t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -890,7 +890,7 @@ if_block_test_() ->
                         "      c:   000ed363            bgez    t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -909,7 +909,7 @@ if_block_test_() ->
                         "      c:   000e8363            beqz    t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -928,7 +928,7 @@ if_block_test_() ->
                         "      c:   000e8363            beqz    t4,0x12\n"
                         "     10:   0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -947,7 +947,7 @@ if_block_test_() ->
                         "   c:  000e8363            beqz    t4,0x12\n"
                         "  10:  0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -967,7 +967,7 @@ if_block_test_() ->
                         "      e:   000e8363            beqz    t4,0x14\n"
                         "      12:  0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -987,7 +987,7 @@ if_block_test_() ->
                         "   e:  000f8363            beqz    t6,0x14\n"
                         "  12:  0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1009,7 +1009,7 @@ if_block_test_() ->
                         "  14:  01ce8363            beq t4,t3,0x1a\n"
                         "  18:  0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1027,7 +1027,7 @@ if_block_test_() ->
                         "   8:  01efd363            bge t6,t5,0xe\n"
                         "   c:  0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1054,7 +1054,7 @@ if_block_test_() ->
                         "      12:  01df8363            beq t6,t4,0x18\n"
                         "      16:  0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 %% Test {RegA, '&', 16#3, '!=', 0} using ANDI instruction
@@ -1074,7 +1074,7 @@ if_block_test_() ->
                         "      c:   000e8363            beqz    t4,0x12\n"
                         "      10:  0f09                    addi    t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1093,7 +1093,7 @@ if_block_test_() ->
                         "   c:	01fed363          	bge	t4,t6,0x12\n"
                         "  10:	0f09                	addi	t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1112,7 +1112,7 @@ if_block_test_() ->
                         "   c:	01fed363          	bge	t4,t6,0x12\n"
                         "  10:	0f09                	addi	t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1131,7 +1131,7 @@ if_block_test_() ->
                         "   c:	01fed363          	bge	t4,t6,0x12\n"
                         "  10:	0f09                	addi	t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -1150,7 +1150,7 @@ if_block_test_() ->
                         "   c:	01fed363          	bge	t4,t6,0x12\n"
                         "  10:	0f09                	addi	t5,t5,2"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end)
             ]
@@ -1181,7 +1181,7 @@ if_else_block_test() ->
             "12:    a011                    j   0x16\n"
             "14:    0f11                    addi    t5,t5,4"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 shift_right_test_() ->
     [
@@ -1195,7 +1195,7 @@ shift_right_test_() ->
                     "   0:  01852f83            lw  t6,24(a0)\n"
                     "   4:  003fdf93            srli    t6,t6,0x3"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(riscv32, Dump, Stream)
         end),
         ?_test(begin
             State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1208,7 +1208,7 @@ shift_right_test_() ->
                     "   0:  01852f83            lw  t6,24(a0)\n"
                     "   4:  003fdf13            srli    t5,t6,0x3"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(riscv32, Dump, Stream)
         end)
     ].
 
@@ -1222,7 +1222,7 @@ shift_left_test() ->
             "0: 01852f83            lw  t6,24(a0)\n"
             "4: 0f8e                    slli    t6,t6,0x3"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_only_or_schedule_next_and_label_relocation_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1262,7 +1262,7 @@ call_only_or_schedule_next_and_label_relocation_test() ->
             "  46:  00462f83            lw  t6,4(a2)\n"
             "  4a:  8f82                    jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_only_or_schedule_next_known_label_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1298,7 +1298,7 @@ call_only_or_schedule_next_known_label_test() ->
             "  3c:  00462f83            lw  t6,4(a2)\n"
             "  40:  8f82                    jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test with large gap (256+ bytes) to force mov_immediate path
 call_only_or_schedule_next_and_label_relocation_large_gap_test() ->
@@ -1345,7 +1345,7 @@ call_only_or_schedule_next_and_label_relocation_large_gap_test() ->
         "  32:  8f82                    jr  t6"
     >>,
     {_, RelevantBinary} = split_binary(Stream, 16#118),
-    ?assertEqual(dump_to_bin(Dump), RelevantBinary).
+    jit_tests_common:assert_stream(riscv32, Dump, RelevantBinary).
 
 call_bif_with_large_literal_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1417,7 +1417,7 @@ call_bif_with_large_literal_integer_test() ->
             "     76:   8f82                    jr  t6\n"
             "     78:   01f52c23            sw  t6,24(a0)"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 get_list_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1441,7 +1441,7 @@ get_list_test() ->
             "1e:    01452f03            lw  t5,20(a0)\n"
             "22:    01df2023            sw  t4,0(t5)"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 is_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1504,7 +1504,7 @@ is_integer_test() ->
             "  52:  0001                nop\n"
             "  54:  00000013            nop"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 cond_jump_to_label(Cond, Label, MMod, MSt0) ->
     MMod:if_block(MSt0, Cond, fun(BSt0) ->
@@ -1578,7 +1578,7 @@ is_number_test() ->
             "  62:  0001                nop\n"
             "  64:  00000013            nop"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 is_boolean_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1611,7 +1611,7 @@ is_boolean_test() ->
         "  24:  0001                nop\n"
         "  26:  00000013            nop"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 is_boolean_far_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1644,7 +1644,7 @@ is_boolean_far_test() ->
             "  22:  7df0006f            j   0x1000\n"
             "  26:  00000013            nop"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 is_boolean_far_known_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1677,7 +1677,7 @@ is_boolean_far_known_test() ->
             "  22:  00001f17            auipc   t5,0x1\n"
             "  26:  fdef0067            jr  -34(t5) # 0x1000"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test OP_WAIT_TIMEOUT pattern that uses set_continuation_to_offset and continuation_entry_point
 wait_timeout_test() ->
@@ -1754,7 +1754,7 @@ wait_timeout_test() ->
             "  6e:  02a00613            li  a2,42\n"
             "  72:  8f82                    jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test OP_WAIT pattern that uses set_continuation_to_label
 wait_test() ->
@@ -1797,7 +1797,7 @@ wait_test() ->
             "  3c:  07462f83            lw  t6,116(a2)\n"
             "  40:  8f82                jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test set_continuation_to_label with known label
 wait_known_test() ->
@@ -1840,7 +1840,7 @@ wait_known_test() ->
             "  3c:  07462f83            lw  t6,116(a2)\n"
             "  40:  8f82                jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test return_labels_and_lines/2 function
 return_labels_and_lines_test() ->
@@ -1890,7 +1890,7 @@ return_labels_and_lines_test() ->
             "  3a:  0000                unimp\n"
             "  3c:  2000                fld fs0,0(s0)"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test call_primitive with {free, {x_reg, X}}
 gc_bif2_test() ->
@@ -1936,7 +1936,7 @@ gc_bif2_test() ->
             "  44:  4632                    lw  a2,12(sp)\n"
             "  46:  0141                    addi    sp,sp,16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test case where parameter value is in a1
 memory_ensure_free_with_roots_test() ->
@@ -1968,7 +1968,7 @@ memory_ensure_free_with_roots_test() ->
             "  26:  4632                    lw  a2,12(sp)\n"
             "  28:  0141                    addi    sp,sp,16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_ext_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -2001,7 +2001,7 @@ call_ext_test() ->
             "  42:  577d                    li  a4,-1\n"
             "  44:  8f82                    jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 call_fun_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -2084,13 +2084,13 @@ call_fun_test() ->
             "  98:  4681                    li  a3,0\n"
             "  9a:  8f02                    jr  t5"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 move_to_vm_register_test0(State, Source, Dest, Dump) ->
     State1 = ?BACKEND:move_to_vm_register(State, Source, Dest),
     State2 = ?BACKEND:jump_to_offset(State1, 16#100),
     Stream = ?BACKEND:stream(State2),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 move_to_vm_register_test_() ->
     {setup,
@@ -2355,7 +2355,7 @@ move_to_vm_register_test_() ->
 move_array_element_test0(State, Reg, Index, Dest, Dump) ->
     State1 = ?BACKEND:move_array_element(State, Reg, Index, Dest),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 move_array_element_test_() ->
     {setup,
@@ -2467,7 +2467,7 @@ get_array_element_test_() ->
                     Dump = <<
                         "   0:  010e2f83            lw  t6,16(t3)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual(t6, Reg)
                 end)
             ]
@@ -2488,7 +2488,7 @@ move_to_array_element_test_() ->
                         "   0:  01852f83            lw  t6,24(a0)\n"
                         "   4:  01f6a423            sw  t6,8(a3)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_array_element/4: x_reg to reg[reg]
                 ?_test(begin
@@ -2501,7 +2501,7 @@ move_to_array_element_test_() ->
                         "   8:  01e68f33            add t5,a3,t5\n"
                         "   c:  01ff2023            sw  t6,0(t5)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_array_element/4: ptr to reg[reg]
                 ?_test(begin
@@ -2514,7 +2514,7 @@ move_to_array_element_test_() ->
                         "   8:  01e68f33            add t5,a3,t5\n"
                         "   c:  01ff2023            sw  t6,0(t5)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_array_element/4: y_reg to reg[reg]
                 ?_test(begin
@@ -2528,7 +2528,7 @@ move_to_array_element_test_() ->
                         "   c:  01e68f33            add t5,a3,t5\n"
                         "  10:  01ff2023            sw  t6,0(t5)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_array_element/5: x_reg to reg[x+offset]
                 ?_test(begin
@@ -2538,7 +2538,7 @@ move_to_array_element_test_() ->
                         "   0:  01852f83            lw  t6,24(a0)\n"
                         "   4:  01f6a423            sw  t6,8(a3)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_array_element/5: x_reg to reg[x+offset]
                 ?_test(begin
@@ -2554,7 +2554,7 @@ move_to_array_element_test_() ->
                         "   a:  01e68f33            add t5,a3,t5\n"
                         "   e:  01ff2023            sw  t6,0(t5)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_array_element/5: imm to reg[x+offset]
                 ?_test(begin
@@ -2570,7 +2570,7 @@ move_to_array_element_test_() ->
                         "      a:   01e68f33            add t5,a3,t5\n"
                         "      e:   01ff2023            sw  t6,0(t5)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end)
             ]
         end}.
@@ -2590,7 +2590,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  02a00f93            li  t6,42"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/2: negative value
                 ?_test(begin
@@ -2600,7 +2600,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  fd600f93            li  t6,-42"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/2: -255 (boundary case)
                 ?_test(begin
@@ -2610,7 +2610,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  f0100f93            li  t6,-255"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/2: -256 (boundary case, fits in immediate for RISC-V)
                 ?_test(begin
@@ -2622,7 +2622,7 @@ move_to_native_register_test_() ->
                         "   0:  f0000f93            li  t6,-256\n"
                         "   4:  a8f5                    j   0x100"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {ptr, reg}
                 ?_test(begin
@@ -2632,7 +2632,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  000f2f03            lw  t5,0(t5)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {x_reg, N}
                 ?_test(begin
@@ -2642,7 +2642,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  02c52f83            lw  t6,44(a0)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/2: {y_reg, N}
                 ?_test(begin
@@ -2653,7 +2653,7 @@ move_to_native_register_test_() ->
                         "   0:  01452f03            lw  t5,20(a0)\n"
                         "   4:  00cf2f83            lw  t6,12(t5)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/3: imm to reg
                 ?_test(begin
@@ -2662,7 +2662,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  02a00f13            li  t5,42"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/3: reg to reg
                 ?_test(begin
@@ -2671,7 +2671,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  8efe                    mv  t4,t6"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {ptr, reg} to reg
                 ?_test(begin
@@ -2680,7 +2680,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  000fae03            lw  t3,0(t6)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {x_reg, x} to reg[reg]
                 ?_test(begin
@@ -2689,7 +2689,7 @@ move_to_native_register_test_() ->
                     Dump = <<
                         "   0:  5114                    lw  a3,32(a0)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% move_to_native_register/3: {y_reg, y} to reg[reg]
                 ?_test(begin
@@ -2699,7 +2699,7 @@ move_to_native_register_test_() ->
                         "   0:  01452f83            lw  t6,20(a0)\n"
                         "   4:  008fa583            lw  a1,8(t6)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 %% Test: ptr with offset to fp_reg (term_to_float)
                 ?_test(begin
@@ -2716,7 +2716,7 @@ move_to_native_register_test_() ->
                         "  10:  008fae83            lw  t4,8(t6)\n"
                         "  14:  01df2e23            sw  t4,28(t5)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end)
             ]
         end}.
@@ -2726,7 +2726,7 @@ add_test0(State0, Reg, Imm, Dump) ->
     % Force emission of literal pool
     State2 = ?BACKEND:jump_to_offset(State1, 16#100),
     Stream = ?BACKEND:stream(State2),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 add_test_() ->
     {setup,
@@ -2762,7 +2762,7 @@ sub_test0(State0, Reg, Imm, Dump) ->
     % Force emission of literal pool
     State2 = ?BACKEND:jump_to_offset(State1, 16#100),
     Stream = ?BACKEND:stream(State2),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 sub_test_() ->
     {setup,
@@ -2796,7 +2796,7 @@ sub_test_() ->
 mul_test0(State0, Reg, Imm, Dump) ->
     State1 = ?BACKEND:mul(State0, Reg, Imm),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 mul_test_() ->
     {setup,
@@ -2900,7 +2900,7 @@ set_args1_y_reg_test() ->
         "  28:  4632                    lw  a2,12(sp)\n"
         "  2a:  0141                    addi    sp,sp,16"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test large Y register read (Y=123, offset=492, exceeds immediate limit)
 large_y_reg_read_test() ->
@@ -2915,7 +2915,7 @@ large_y_reg_read_test() ->
         "   8:  9ffa                    add t6,t6,t5\n"
         "   a:  000faf83            lw  t6,0(t6)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream),
+    jit_tests_common:assert_stream(riscv32, Dump, Stream),
     ?assertEqual(t6, Reg).
 
 %% Test large Y register write with immediate value
@@ -2932,7 +2932,7 @@ large_y_reg_write_test() ->
         "   c:  9efe                    add t4,t4,t6\n"
         "   e:  01eea023            sw  t5,0(t4)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test large Y register read with limited registers (uses IP_REG fallback)
 large_y_reg_read_register_exhaustion_test() ->
@@ -2958,7 +2958,7 @@ large_y_reg_read_register_exhaustion_test() ->
         "  1c:  9316                    add t1,t1,t0\n"
         "  1e:  00032303            lw  t1,0(t1)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream),
+    jit_tests_common:assert_stream(riscv32, Dump, Stream),
     ?assertEqual(t1, ResultReg).
 
 %% Test large Y register write with register exhaustion (uses t1/t0 fallback)
@@ -2986,7 +2986,7 @@ large_y_reg_write_register_exhaustion_test() ->
         "     1c:   929a                    add t0,t0,t1\n"
         "     1e:   01f2a023            sw  t6,0(t0)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test boundary case: Y=31 (124 bytes, exactly at limit, should use direct addressing)
 y_reg_boundary_direct_test() ->
@@ -2998,7 +2998,7 @@ y_reg_boundary_direct_test() ->
         "   0:  01452f03            lw  t5,20(a0)\n"
         "   4:  07cf2f83            lw  t6,124(t5)"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream),
+    jit_tests_common:assert_stream(riscv32, Dump, Stream),
     ?assertEqual(t6, Reg).
 
 %% Test debugger function
@@ -3009,7 +3009,7 @@ debugger_test() ->
     Dump = <<
         "      0:   9002                    ebreak"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 and_register_exhaustion_negative_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -3034,7 +3034,7 @@ and_register_exhaustion_negative_test() ->
         "     1a:   fff2c293            not t0,t0\n"
         "     1e:   005fffb3            and t6,t6,t0"
     >>,
-    ?assertEqual(dump_to_bin(ExpectedDump), Stream).
+    jit_tests_common:assert_stream(riscv32, ExpectedDump, Stream).
 
 and_register_exhaustion_positive_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -3058,7 +3058,7 @@ and_register_exhaustion_positive_test() ->
         "  18:  03f00293            li  t0,63\n"
         "  1c:  005fffb3            and t6,t6,t0"
     >>,
-    ?assertEqual(dump_to_bin(ExpectedDump), Stream).
+    jit_tests_common:assert_stream(riscv32, ExpectedDump, Stream).
 
 jump_table_large_labels_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -3092,7 +3092,7 @@ alloc_boxed_integer_fragment_small_test() ->
             "     1e:   4632                    lw  a2,12(sp)\n"
             "     20:   0141                    addi    sp,sp,16"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 alloc_boxed_integer_fragment_large_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -3130,7 +3130,7 @@ alloc_boxed_integer_fragment_large_test() ->
             "     38:   877e                    mv  a4,t6\n"
             "     3a:   8f02                    jr  t5"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test for stack alignment issue in call_func_ptr
 %% RISC-V maintains 16-byte stack alignment (RISC-V calling convention)
@@ -3168,7 +3168,7 @@ call_func_ptr_stack_alignment_test() ->
             "     34:   4fe2                    lw  t6,24(sp)\n"
             "     36:   02010113            addi    sp,sp,32"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
 %% Test for register exhaustion issue in call_func_ptr with 5+ arguments
 %% When all registers are used and we call a function with 5+ args,
@@ -3228,7 +3228,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "     42:   4ff2                    lw  t6,28(sp)\n"
                             "     44:   02010113            addi    sp,sp,32"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 ?_test(begin
                     {State7, _ResultReg} = ?BACKEND:call_func_ptr(
@@ -3269,7 +3269,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "     42:   4ff2                    lw  t6,28(sp)\n"
                             "     44:   02010113            addi    sp,sp,32"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 ?_test(begin
                     {State7, ResultReg} = ?BACKEND:call_func_ptr(
@@ -3310,7 +3310,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "     42:   4ff2                    lw  t6,28(sp)\n"
                             "     44:   02010113            addi    sp,sp,32"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual(t5, ResultReg)
                 end),
                 ?_test(begin
@@ -3356,7 +3356,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "  4c:  5f92                lw  t6,36(sp)\n"
                             "  4e:  03010113            addi    sp,sp,48"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
                 ?_test(begin
                     {State7, ResultReg} = ?BACKEND:call_func_ptr(
@@ -3400,7 +3400,7 @@ call_func_ptr_register_exhaustion_test_() ->
                             "  4a:  5f82                lw  t6,32(sp)\n"
                             "  4c:  03010113            addi    sp,sp,48"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end)
             ]
         end}.
@@ -3420,7 +3420,7 @@ jump_to_continuation_test_() ->
                     "   4:  9faa                add t6,t6,a0\n"
                     "   6:  8f82                jr  t6"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(riscv32, Dump, Stream)
         end),
         ?_test(begin
             % Test 2: jump_to_continuation after jump table (non-zero relative address)
@@ -3446,7 +3446,7 @@ jump_to_continuation_test_() ->
                     "  26:  9faa                add t6,t6,a0\n"
                     "  28:  8f82                jr  t6"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(riscv32, Dump, Stream)
         end)
     ].
 
@@ -3566,75 +3566,4 @@ add_beam_test() ->
             "  e0:  00462f83            lw  t6,4(a2)\n"
             "  e4:  8f82                jr  t6"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
-
-dump_to_bin(Dump) ->
-    dump_to_bin0(Dump, addr, []).
-
--define(IS_HEX_DIGIT(C),
-    ((C >= $0 andalso C =< $9) orelse (C >= $a andalso C =< $f) orelse (C >= $A andalso C =< $F))
-).
-
-dump_to_bin0(<<N, $:, Tail/binary>>, addr, Acc) when ?IS_HEX_DIGIT(N) ->
-    dump_to_bin0(Tail, hex, Acc);
-dump_to_bin0(<<N, Tail/binary>>, addr, Acc) when ?IS_HEX_DIGIT(N) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\n, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\s, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\t, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\s, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, hex, Acc);
-dump_to_bin0(<<$\t, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, hex, Acc);
-%% Handle RISC-V 32-bit instructions (8 consecutive hex digits)
-dump_to_bin0(<<H1, H2, H3, H4, H5, H6, H7, H8, Sp, Rest/binary>>, hex, Acc) when
-    (Sp =:= $\t orelse Sp =:= $\s) andalso
-        ?IS_HEX_DIGIT(H1) andalso
-        ?IS_HEX_DIGIT(H2) andalso
-        ?IS_HEX_DIGIT(H3) andalso
-        ?IS_HEX_DIGIT(H4) andalso
-        ?IS_HEX_DIGIT(H5) andalso
-        ?IS_HEX_DIGIT(H6) andalso
-        ?IS_HEX_DIGIT(H7) andalso
-        ?IS_HEX_DIGIT(H8)
-->
-    %% RISC-V instructions are 32-bit little-endian
-    Instr = list_to_integer([H1, H2, H3, H4, H5, H6, H7, H8], 16),
-    dump_to_bin0(Rest, instr, [<<Instr:32/little>> | Acc]);
-%% Handle 32-bits undefined instruction (ARM format with space: "1234 5678")
-dump_to_bin0(<<H1, H2, H3, H4, $\s, H5, H6, H7, H8, Sp, Rest/binary>>, hex, Acc) when
-    (Sp =:= $\t orelse Sp =:= $\s) andalso
-        ?IS_HEX_DIGIT(H1) andalso
-        ?IS_HEX_DIGIT(H2) andalso
-        ?IS_HEX_DIGIT(H3) andalso
-        ?IS_HEX_DIGIT(H4) andalso
-        ?IS_HEX_DIGIT(H5) andalso
-        ?IS_HEX_DIGIT(H6) andalso
-        ?IS_HEX_DIGIT(H7) andalso
-        ?IS_HEX_DIGIT(H8)
-->
-    InstrA = list_to_integer([H1, H2, H3, H4], 16),
-    InstrB = list_to_integer([H5, H6, H7, H8], 16),
-    dump_to_bin0(Rest, instr, [<<InstrB:16/little>>, <<InstrA:16/little>> | Acc]);
-%% Handle 16-bit ARM32 Thumb instructions (4 hex digits)
-dump_to_bin0(<<H1, H2, H3, H4, Sp, Rest/binary>>, hex, Acc) when
-    (Sp =:= $\t orelse Sp =:= $\s) andalso
-        ?IS_HEX_DIGIT(H1) andalso
-        ?IS_HEX_DIGIT(H2) andalso
-        ?IS_HEX_DIGIT(H3) andalso
-        ?IS_HEX_DIGIT(H4)
-->
-    %% Parse 4 hex digits (ARM32 Thumb 16-bit instruction)
-    Instr = list_to_integer([H1, H2, H3, H4], 16),
-    dump_to_bin0(Rest, instr, [<<Instr:16/little>> | Acc]);
-dump_to_bin0(<<$\n, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\n, Tail/binary>>, instr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<_Other, Tail/binary>>, instr, Acc) ->
-    dump_to_bin0(Tail, instr, Acc);
-dump_to_bin0(<<>>, _, Acc) ->
-    list_to_binary(lists:reverse(Acc)).
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).

--- a/tests/libs/jit/jit_tests_common.erl
+++ b/tests/libs/jit/jit_tests_common.erl
@@ -20,7 +20,7 @@
 
 -module(jit_tests_common).
 
--export([asm/3]).
+-export([asm/3, assert_stream/3]).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -75,17 +75,23 @@ asm(Arch, Bin, Str) ->
 %% Helper function to find available binutils for a given architecture
 -spec find_binutils(atom()) -> {ok, string(), string()} | false.
 find_binutils(Arch) ->
-    ArchStr = atom_to_list(Arch),
-    BinutilsList = [
-        {ArchStr ++ "-esp-elf-as", ArchStr ++ "-esp-elf-objdump"},
-        {ArchStr ++ "-unknown-elf-as", ArchStr ++ "-unknown-elf-objdump"},
-        {ArchStr ++ "-elf-as", ArchStr ++ "-elf-objdump"},
-        {ArchStr ++ "-none-eabi-as", ArchStr ++ "-none-eabi-objdump"},
-        {ArchStr ++ "-linux-gnu-as", ArchStr ++ "-linux-gnu-objdump"}
-    ],
-    find_binutils_from_list(BinutilsList).
+    Prefixes0 = toolchain_prefixes(Arch),
+    Prefixes =
+        case Arch of
+            riscv32 ->
+                Prefixes0 ++ toolchain_prefixes(riscv64);
+            _ ->
+                Prefixes0
+        end,
+    find_binutils_from_list([{P ++ "-as", P ++ "-objdump"} || P <- Prefixes]).
 
 %% Private functions
+
+-spec toolchain_prefixes(atom()) -> [string()].
+toolchain_prefixes(Arch) ->
+    ArchStr = atom_to_list(Arch),
+    Variants = ["-esp-elf", "-unknown-elf", "-elf", "-none-eabi", "-linux-gnu"],
+    [ArchStr ++ V || V <- Variants].
 
 %% Generic helper function to find binutils from a list
 -spec find_binutils_from_list([{string(), string()}]) -> {ok, string(), string()} | false.
@@ -162,3 +168,131 @@ hex_to_bin(HexStr, Acc, Arch) ->
             % All architectures use little-endian encoding
             <<Acc/binary, HexVal:NumBits/little>>
     end.
+
+%% Assert that Stream matches the expected objdump output Dump.
+%% On mismatch, run objdump on both expected and actual binaries and diff -u.
+-spec assert_stream(atom(), binary(), binary()) -> ok.
+assert_stream(Arch, Dump, Stream) ->
+    Expected = dump_to_bin(Dump),
+    case Expected =:= Stream of
+        true ->
+            ok;
+        false ->
+            diff_disasm(Arch, Expected, Stream),
+            ?assertEqual(Expected, Stream)
+    end.
+
+-define(IS_HEX_DIGIT(C),
+    ((C >= $0 andalso C =< $9) orelse (C >= $a andalso C =< $f) orelse (C >= $A andalso C =< $F))
+).
+
+%% Parse an objdump text dump into binary.
+%% Handles all architectures: hex chunks (bytes or words) are parsed as
+%% little-endian values. Hex groups are separated by single spaces;
+%% the instruction text starts after a tab or two consecutive spaces.
+-spec dump_to_bin(binary()) -> binary().
+dump_to_bin(Dump) ->
+    dump_to_bin(Dump, addr, [], []).
+
+dump_to_bin(<<$:, Tail/binary>>, addr, [], Acc) ->
+    dump_to_bin(Tail, pre_hex, [], Acc);
+dump_to_bin(<<$\n, Tail/binary>>, addr, [], Acc) ->
+    dump_to_bin(Tail, addr, [], Acc);
+dump_to_bin(<<_, Tail/binary>>, addr, [], Acc) ->
+    dump_to_bin(Tail, addr, [], Acc);
+dump_to_bin(<<$\s, Tail/binary>>, pre_hex, [], Acc) ->
+    dump_to_bin(Tail, pre_hex, [], Acc);
+dump_to_bin(<<$\t, Tail/binary>>, pre_hex, [], Acc) ->
+    dump_to_bin(Tail, pre_hex, [], Acc);
+dump_to_bin(<<$\n, Tail/binary>>, pre_hex, [], Acc) ->
+    dump_to_bin(Tail, addr, [], Acc);
+dump_to_bin(<<C, Tail/binary>>, pre_hex, [], Acc) when ?IS_HEX_DIGIT(C) ->
+    dump_to_bin(Tail, hex, [C], Acc);
+dump_to_bin(<<C, Tail/binary>>, hex, Chunk, Acc) when ?IS_HEX_DIGIT(C) ->
+    dump_to_bin(Tail, hex, [C | Chunk], Acc);
+dump_to_bin(<<$\s, Tail/binary>>, hex, Chunk, Acc) ->
+    dump_to_bin(Tail, hex_space, Chunk, Acc);
+dump_to_bin(<<$\t, Tail/binary>>, hex, Chunk, Acc) ->
+    dump_to_bin(Tail, instr, [], [emit_chunk(Chunk) | Acc]);
+dump_to_bin(<<$\n, Tail/binary>>, hex, Chunk, Acc) ->
+    dump_to_bin(Tail, addr, [], [emit_chunk(Chunk) | Acc]);
+dump_to_bin(<<C, Tail/binary>>, hex_space, Chunk, Acc) when ?IS_HEX_DIGIT(C) ->
+    dump_to_bin(Tail, hex, [C], [emit_chunk(Chunk) | Acc]);
+dump_to_bin(<<$\n, Tail/binary>>, hex_space, Chunk, Acc) ->
+    dump_to_bin(Tail, addr, [], [emit_chunk(Chunk) | Acc]);
+dump_to_bin(<<_, Tail/binary>>, hex_space, Chunk, Acc) ->
+    dump_to_bin(Tail, instr, [], [emit_chunk(Chunk) | Acc]);
+dump_to_bin(<<$\n, Tail/binary>>, instr, [], Acc) ->
+    dump_to_bin(Tail, addr, [], Acc);
+dump_to_bin(<<_, Tail/binary>>, instr, [], Acc) ->
+    dump_to_bin(Tail, instr, [], Acc);
+dump_to_bin(<<>>, _, Chunk, Acc) ->
+    FinalAcc =
+        case Chunk of
+            [] -> Acc;
+            _ -> [emit_chunk(Chunk) | Acc]
+        end,
+    list_to_binary(lists:reverse(FinalAcc)).
+
+emit_chunk(RevChars) ->
+    Chars = lists:reverse(RevChars),
+    NumBits = length(Chars) * 4,
+    Val = list_to_integer(Chars, 16),
+    <<Val:NumBits/little>>.
+
+%% Run objdump on both expected and actual binaries, then diff -u the outputs.
+-spec diff_disasm(atom(), binary(), binary()) -> ok.
+diff_disasm(Arch, Expected, Actual) ->
+    case find_binutils(Arch) of
+        false ->
+            io:format("expected bytes: ~w~nactual bytes:   ~w~n", [Expected, Actual]);
+        {ok, _AsCmd, ObjdumpCmd} ->
+            TempBase = "jit_test_" ++ integer_to_list(erlang:unique_integer([positive])),
+            ExpFile = TempBase ++ "_expected.bin",
+            ActFile = TempBase ++ "_actual.bin",
+            ExpDis = TempBase ++ "_expected.dis",
+            ActDis = TempBase ++ "_actual.dis",
+            ObjdumpFlags = get_objdump_flags(Arch),
+            try
+                ok = file:write_file(ExpFile, Expected),
+                ok = file:write_file(ActFile, Actual),
+                Cleanup =
+                    "grep '^ '"
+                    " | sed -e 's/[[:space:]]*;.*$//' -e 's/[[:space:]]*\\/\\/.*$//'",
+                ObjdumpCmdExp = lists:flatten(
+                    io_lib:format(
+                        "~s -b binary ~s -D -z ~s | ~s > ~s",
+                        [ObjdumpCmd, ObjdumpFlags, ExpFile, Cleanup, ExpDis]
+                    )
+                ),
+                ObjdumpCmdAct = lists:flatten(
+                    io_lib:format(
+                        "~s -b binary ~s -D -z ~s | ~s > ~s",
+                        [ObjdumpCmd, ObjdumpFlags, ActFile, Cleanup, ActDis]
+                    )
+                ),
+                os:cmd(ObjdumpCmdExp),
+                os:cmd(ObjdumpCmdAct),
+                DiffCmd = lists:flatten(
+                    io_lib:format("diff -u -w ~s ~s | tail -n +3", [ExpDis, ActDis])
+                ),
+                DiffResult = os:cmd(DiffCmd),
+                io:format("~s~n", [DiffResult])
+            after
+                file:delete(ExpFile),
+                file:delete(ActFile),
+                file:delete(ExpDis),
+                file:delete(ActDis)
+            end,
+            ok
+    end.
+
+-spec get_objdump_flags(atom()) -> string().
+get_objdump_flags(arm) ->
+    "-marm --disassembler-options=force-thumb";
+get_objdump_flags(aarch64) ->
+    "-m aarch64";
+get_objdump_flags(x86_64) ->
+    "-m i386:x86-64";
+get_objdump_flags(riscv32) ->
+    "-m riscv:rv32".

--- a/tests/libs/jit/jit_x86_64_tests.erl
+++ b/tests/libs/jit/jit_x86_64_tests.erl
@@ -49,7 +49,7 @@ call_primitive_0_test() ->
             "9:   5e                      pop    %rsi\n"
             "a:   5f                      pop    %rdi\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_primitive_1_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -66,7 +66,7 @@ call_primitive_1_test() ->
             "a:   5e                      pop    %rsi\n"
             "b:   5f                      pop    %rdi\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_primitive_2_args_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -86,7 +86,7 @@ call_primitive_2_args_test() ->
             "  1f:  5e                      pop    %rsi\n"
             "  20:  5f                      pop    %rdi\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_primitive_extended_regs_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -161,7 +161,7 @@ call_primitive_extended_regs_test() ->
             "  6c:	5f                   	pop    %rdi\n"
             "  6d:	49 89 02             	mov    %rax,(%r10)"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_primitive_few_regs_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -215,7 +215,7 @@ call_primitive_few_regs_test() ->
             "  47:	5e                   	pop    %rsi\n"
             "  48:	5f                   	pop    %rdi"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_ext_only_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -236,7 +236,7 @@ call_ext_only_test() ->
             "  28:	49 c7 c0 ff ff ff ff 	mov    $0xffffffffffffffff,%r8\n"
             "  2f:	ff e0                	jmpq   *%rax\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_ext_last_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -257,7 +257,7 @@ call_ext_last_test() ->
             "  28:	49 c7 c0 0a 00 00 00 	mov    $0xa,%r8\n"
             "  2f:	ff e0                	jmpq   *%rax\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_primitive_last_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -269,7 +269,7 @@ call_primitive_last_test() ->
             "   3:  48 c7 c2 2a 00 00 00    mov    $0x2a,%rdx\n"
             "   a:  ff e0                   jmpq   *%rax\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 return_if_not_equal_to_ctx_test_() ->
     {setup,
@@ -301,7 +301,7 @@ return_if_not_equal_to_ctx_test_() ->
                             "  12:	74 01                	je     0x15\n"
                             "  14:	c3                   	retq"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream)
                 end),
                 ?_test(begin
                     {State1, ResultReg} = ?BACKEND:call_primitive(
@@ -330,7 +330,7 @@ return_if_not_equal_to_ctx_test_() ->
                             "  17:	4c 89 d8             	mov    %r11,%rax\n"
                             "  1a:	c3                   	retq"
                         >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream)
                 end)
             ]
         end}.
@@ -345,7 +345,7 @@ move_to_cp_test() ->
             "   4:	48 8b 00             	mov    (%rax),%rax\n"
             "   7:	48 89 87 b8 00 00 00 	mov    %rax,0xb8(%rdi)\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 increment_sp_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -357,7 +357,7 @@ increment_sp_test() ->
             "   4:	48 83 c0 38          	add    $0x38,%rax\n"
             "   8:	48 89 47 28          	mov    %rax,0x28(%rdi)\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 if_block_test_() ->
     {setup,
@@ -385,7 +385,7 @@ if_block_test_() ->
                         "   b:	7d 04                	jge    0x11\n"
                         "   d:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -404,7 +404,7 @@ if_block_test_() ->
                         "   b:	7d 04                	jge    0x11\n"
                         "   d:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -423,7 +423,7 @@ if_block_test_() ->
                         "   b:	75 04                	jne    0x11\n"
                         "   d:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -442,7 +442,7 @@ if_block_test_() ->
                         "   b:	75 04                	jne    0x11\n"
                         "   d:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -461,7 +461,7 @@ if_block_test_() ->
                         "   a:	75 04                	jne    0x10\n"
                         "   c:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -480,7 +480,7 @@ if_block_test_() ->
                         "   a:	75 04                	jne    0x10\n"
                         "   c:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -499,7 +499,7 @@ if_block_test_() ->
                         "   c:	74 04                	je     0x12\n"
                         "   e:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -518,7 +518,7 @@ if_block_test_() ->
                         "   c:	74 04                	je     0x12\n"
                         "   e:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -537,7 +537,7 @@ if_block_test_() ->
                         "   b:	74 04                	je     0x11\n"
                         "   d:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -556,7 +556,7 @@ if_block_test_() ->
                         "   b:	74 04                	je     0x11\n"
                         "   d:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -575,7 +575,7 @@ if_block_test_() ->
                         "   c:	75 04                	jne    0x12\n"
                         "   e:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -594,7 +594,7 @@ if_block_test_() ->
                         "   c:	75 04                	jne    0x12\n"
                         "   e:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -613,7 +613,7 @@ if_block_test_() ->
                         "   b:	75 04                	jne    0x11\n"
                         "   d:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -632,7 +632,7 @@ if_block_test_() ->
                         "   b:	75 04                	jne    0x11\n"
                         "   d:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -651,7 +651,7 @@ if_block_test_() ->
                         "   a:	75 04                	jne    0x10\n"
                         "   c:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -670,7 +670,7 @@ if_block_test_() ->
                         "   a:	75 04                	jne    0x10\n"
                         "   c:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -689,7 +689,7 @@ if_block_test_() ->
                         "   a:	74 04                	je     0x10\n"
                         "   c:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -708,7 +708,7 @@ if_block_test_() ->
                         "   a:	74 04                	je     0x10\n"
                         "   c:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -727,7 +727,7 @@ if_block_test_() ->
                         "   a:	74 04                	je     0x10\n"
                         "   c:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -746,7 +746,7 @@ if_block_test_() ->
                         "   a:	74 04                	je     0x10\n"
                         "   c:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -767,7 +767,7 @@ if_block_test_() ->
                         "  13:	74 04                	je     0x19\n"
                         "  15:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -787,7 +787,7 @@ if_block_test_() ->
                         "   d:	74 04                	je     0x13\n"
                         "   f:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -806,7 +806,7 @@ if_block_test_() ->
                         "   c:	7e 04                	jle    0x12\n"
                         "   e:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -825,7 +825,7 @@ if_block_test_() ->
                         "   c:	7e 04                	jle    0x12\n"
                         "   e:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -844,7 +844,7 @@ if_block_test_() ->
                         "   c:	7d 04                	jge    0x12\n"
                         "   e:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -863,7 +863,7 @@ if_block_test_() ->
                         "   c:	7d 04                	jge    0x12\n"
                         "   e:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -884,7 +884,7 @@ if_block_test_() ->
                         "  15:	7d 04                	jge    0x1b\n"
                         "  17:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -905,7 +905,7 @@ if_block_test_() ->
                         "  15:	7d 04                	jge    0x1b\n"
                         "  17:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -926,7 +926,7 @@ if_block_test_() ->
                         "  15:	7e 04                	jle    0x1b\n"
                         "  17:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB, RegA], ?BACKEND:used_regs(State1))
                 end),
                 ?_test(begin
@@ -947,7 +947,7 @@ if_block_test_() ->
                         "  15:	7e 04                	jle    0x1b\n"
                         "  17:	49 83 c3 02          	add    $0x2,%r11"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
                 end)
             ]
@@ -978,7 +978,7 @@ if_else_block_test() ->
             "  12:	eb 04                	jmp    0x18\n"
             "  14:	49 83 c3 04          	add    $0x4,%r11"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 shift_right_test_() ->
     [
@@ -992,7 +992,7 @@ shift_right_test_() ->
                     "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
                     "   4:	48 c1 e8 03          	shr    $0x3,%rax"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(x86_64, Dump, Stream)
         end),
         ?_test(begin
             State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1006,7 +1006,7 @@ shift_right_test_() ->
                     "   4:	49 89 c3             	mov    %rax,%r11\n"
                     "   7:	49 c1 eb 03          	shr    $0x3,%r11"
                 >>,
-            ?assertEqual(dump_to_bin(Dump), Stream)
+            jit_tests_common:assert_stream(x86_64, Dump, Stream)
         end)
     ].
 
@@ -1020,7 +1020,7 @@ shift_left_test() ->
             "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
             "   4:	48 c1 e0 03          	shl    $0x3,%rax"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_only_or_schedule_next_and_label_relocation_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1051,7 +1051,7 @@ call_only_or_schedule_next_and_label_relocation_test() ->
             "  2f:	48 8b 42 08          	mov    0x8(%rdx),%rax\n"
             "  33:	ff e0                	jmpq   *%rax\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_only_or_schedule_next_known_label_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1082,7 +1082,7 @@ call_only_or_schedule_next_known_label_test() ->
             "  2f:	48 8b 42 08          	mov    0x8(%rdx),%rax\n"
             "  33:	ff e0                	jmpq   *%rax\n"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_bif_with_large_literal_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1143,7 +1143,7 @@ call_bif_with_large_literal_integer_test() ->
             "  61:	ff e0                	jmpq   *%rax\n"
             "  63:	48 89 47 30          	mov    %rax,0x30(%rdi)"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 get_list_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1164,7 +1164,7 @@ get_list_test() ->
         "  18:	4c 8b 10             	mov    (%rax),%r10\n"
         "  1b:	4d 89 13             	mov    %r10,(%r11)\n"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 is_integer_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1222,7 +1222,7 @@ is_integer_test() ->
         "  39:	74 05                	je     0x40\n"
         "  3b:	e9 00 01 00 00       	jmpq   0x140"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 cond_jump_to_label(Cond, Label, MMod, MSt0) ->
     MMod:if_block(MSt0, Cond, fun(BSt0) ->
@@ -1283,7 +1283,7 @@ is_number_test() ->
         "  46:	74 05                	je     0x4d\n"
         "  48:	e9 00 01 00 00       	jmpq   0x14d"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 is_boolean_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1311,7 +1311,7 @@ is_boolean_test() ->
         "  18:	74 05                	je     0x1f\n"
         "  1a:	e9 00 01 00 00       	jmpq   0x11f\n"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_ext_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1338,7 +1338,7 @@ call_ext_test() ->
         "  3e:	49 c7 c0 ff ff ff ff 	mov    $0xffffffffffffffff,%r8\n"
         "  45:	ff e0                	jmpq   *%rax\n"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 call_fun_test() ->
     State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
@@ -1408,12 +1408,12 @@ call_fun_test() ->
         "  94:	48 c7 c1 00 00 00 00 	mov    $0x0,%rcx\n"
         "  9b:	41 ff e3             	jmpq   *%r11"
     >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 move_to_vm_register_test0(State, Source, Dest, Dump) ->
     State1 = ?BACKEND:move_to_vm_register(State, Source, Dest),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 move_to_vm_register_test_() ->
     {setup,
@@ -1636,7 +1636,7 @@ move_to_vm_register_test_() ->
                         "   8:	4c 8b 9f c0 00 00 00 	mov    0xc0(%rdi),%r11\n"
                         "   f:	49 89 43 18          	mov    %rax,0x18(%r11)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream)
                 end)
             ]
         end}.
@@ -1644,7 +1644,7 @@ move_to_vm_register_test_() ->
 move_array_element_test0(State, Reg, Index, Dest, Dump) ->
     State1 = ?BACKEND:move_array_element(State, Reg, Index, Dest),
     Stream = ?BACKEND:stream(State1),
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 move_array_element_test_() ->
     {setup,
@@ -1747,7 +1747,7 @@ get_array_element_test_() ->
                     Dump = <<
                         "   0:	49 8b 40 20          	mov    0x20(%r8),%rax"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream),
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream),
                     ?assertEqual(rax, Reg)
                 end)
             ]
@@ -1768,7 +1768,7 @@ move_to_array_element_test_() ->
                         "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
                         "   4:	49 89 40 10          	mov    %rax,0x10(%r8)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream)
                 end),
                 %% move_to_array_element/5: x_reg to reg[x+offset]
                 ?_test(begin
@@ -1778,7 +1778,7 @@ move_to_array_element_test_() ->
                         "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
                         "   4:	49 89 40 18          	mov    %rax,0x18(%r8)"
                     >>,
-                    ?assertEqual(dump_to_bin(Dump), Stream)
+                    jit_tests_common:assert_stream(x86_64, Dump, Stream)
                 end)
             ]
         end}.
@@ -1796,7 +1796,7 @@ jump_to_continuation_test() ->
             "   7:	48 01 c0             	add    %rax,%rax\n"
             "   a:	ff e0                	jmpq   *%rax"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 %% Test set_continuation_to_label with unknown label
 wait_test() ->
@@ -1824,7 +1824,7 @@ wait_test() ->
             "  29:	48 8b 82 e8 00 00 00 	mov    0xe8(%rdx),%rax\n"
             "  30:	ff e0                	jmpq   *%rax"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
 %% Test set_continuation_to_label with known label
 wait_known_test() ->
@@ -1852,41 +1852,4 @@ wait_known_test() ->
             "  29:	48 8b 82 e8 00 00 00 	mov    0xe8(%rdx),%rax\n"
             "  30:	ff e0                	jmpq   *%rax"
         >>,
-    ?assertEqual(dump_to_bin(Dump), Stream).
-
-dump_to_bin(Dump) ->
-    dump_to_bin0(Dump, addr, []).
-
-dump_to_bin0(<<N, Tail/binary>>, addr, Acc) when
-    (N >= $0 andalso N =< $9) orelse (N >= $a andalso N =< $f)
-->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\n, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\ , Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$\t, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<$:, Tail/binary>>, addr, Acc) ->
-    dump_to_bin0(Tail, pre_hex, Acc);
-dump_to_bin0(<<$\ , Tail/binary>>, pre_hex, Acc) ->
-    dump_to_bin0(Tail, pre_hex, Acc);
-dump_to_bin0(<<$\t, Tail/binary>>, pre_hex, Acc) ->
-    dump_to_bin0(Tail, pre_hex, Acc);
-dump_to_bin0(<<_Other, _Tail/binary>> = Bin, pre_hex, Acc) ->
-    dump_to_bin0(Bin, hex, Acc);
-dump_to_bin0(<<D1, D2, $\ , Tail/binary>>, hex, Acc) when
-    ((D1 >= $0 andalso D1 =< $9) orelse (D1 >= $a andalso D1 =< $f)) andalso
-        ((D2 >= $0 andalso D2 =< $9) orelse (D2 >= $a andalso D2 =< $f))
-->
-    dump_to_bin0(Tail, hex, [list_to_integer([D1, D2], 16) | Acc]);
-dump_to_bin0(<<$\n, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<_Other, Tail/binary>>, hex, Acc) ->
-    dump_to_bin0(Tail, instr, Acc);
-dump_to_bin0(<<$\n, Tail/binary>>, instr, Acc) ->
-    dump_to_bin0(Tail, addr, Acc);
-dump_to_bin0(<<_Other, Tail/binary>>, instr, Acc) ->
-    dump_to_bin0(Tail, instr, Acc);
-dump_to_bin0(<<>>, _, Acc) ->
-    list_to_binary(lists:reverse(Acc)).
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
