### PR TITLE
Prune runnables with `packbeam -p`

### DIFF
--- a/CMakeModules/BuildErlang.cmake
+++ b/CMakeModules/BuildErlang.cmake
@@ -289,7 +289,7 @@ macro(pack_runnable avm_name main)
     add_custom_command(
         OUTPUT ${avm_name}.avm
         DEPENDS ${avm_name}_main ${main}.beam ${pack_runnable_${avm_name}_archives} ${pack_runnable_${avm_name}_archive_targets} PackBEAM
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create -s ${main} ${INCLUDE_LINES} ${avm_name}.avm ${main}.beam ${pack_runnable_${avm_name}_archives}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create -p -s ${main} ${INCLUDE_LINES} ${avm_name}.avm ${main}.beam ${pack_runnable_${avm_name}_archives}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
     )
@@ -421,7 +421,7 @@ macro(pack_uf2 avm_name main)
     add_custom_command(
         OUTPUT ${avm_name}.avm
         DEPENDS ${avm_name}_main ${main}.beam ${pack_uf2_${avm_name}_archives} ${pack_uf2_${avm_name}_archive_targets} PackBEAM
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create ${INCLUDE_LINES} -s ${main} ${avm_name}.avm ${main}.beam ${pack_uf2_${avm_name}_archives}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create ${INCLUDE_LINES} -p -s ${main} ${avm_name}.avm ${main}.beam ${pack_uf2_${avm_name}_archives}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
     )

--- a/tools/packbeam/rebar.config
+++ b/tools/packbeam/rebar.config
@@ -19,7 +19,7 @@
 %
 
 {deps, [
-    {atomvm_packbeam, "0.8.1"}
+    {atomvm_packbeam, "0.8.2"}
 ]}.
 {escript_main_app, atomvm_packbeam}.
 {escript_name, packbeam}.


### PR DESCRIPTION
Continuation of:
- #1793 

Requires:
- https://github.com/atomvm/atomvm_packbeam/pull/60

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
