### PR TITLE
Add `inet` IP address parse and ntoa functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing `ledc` functions for esp32 platform
 - Added support for Elixir GenServer and Supervisor.
 - Added support for 10 new STM32 families by switching to STM32 official SDK
+- Added missing `inet` functions: `ntoa/1`, `parse_address/1`, `parse_ipv4_address/1`,
+`parse_ipv4strict_address/1`
 
 ### Changed
 

--- a/tests/libs/estdlib/test_inet.erl
+++ b/tests/libs/estdlib/test_inet.erl
@@ -24,6 +24,10 @@
 
 test() ->
     ok = test_getaddr(),
+    ok = test_ntoa(),
+    ok = test_parse_address(),
+    ok = test_parse_ipv4_address(),
+    ok = test_parse_ipv4strict_address(),
     ok.
 
 test_getaddr() ->
@@ -39,4 +43,81 @@ test_getaddr() ->
     {error, einval} = inet:getaddr({foo, bar}, inet),
     {error, einval} = inet:getaddr(<<"localhost">>, inet),
     {error, _} = inet:getaddr("localhost.invalid", inet),
+    ok.
+
+test_ntoa() ->
+    "127.0.0.1" = inet:ntoa({127, 0, 0, 1}),
+    "192.168.0.1" = inet:ntoa({192, 168, 0, 1}),
+    "0.0.0.0" = inet:ntoa({0, 0, 0, 0}),
+    "255.255.255.255" = inet:ntoa({255, 255, 255, 255}),
+    case get_otp_version() of
+        OTPVersion when
+            (is_integer(OTPVersion) andalso OTPVersion >= 24) orelse OTPVersion == atomvm
+        ->
+            {error, einval} = inet:ntoa({256, 0, 0, 1}),
+            {error, einval} = inet:ntoa({0, 0, 0, -1}),
+            {error, einval} = inet:ntoa({1, 2, 3}),
+            {error, einval} = inet:ntoa(not_an_address);
+        _ ->
+            ok
+    end,
+    ok.
+
+get_otp_version() ->
+    case erlang:system_info(machine) of
+        "BEAM" -> list_to_integer(erlang:system_info(otp_release));
+        _ -> atomvm
+    end.
+
+test_parse_address() ->
+    {ok, {127, 0, 0, 1}} = inet:parse_address("127.0.0.1"),
+    {ok, {192, 168, 0, 1}} = inet:parse_address("192.168.0.1"),
+    {ok, {0, 0, 0, 0}} = inet:parse_address("0.0.0.0"),
+    {ok, {255, 255, 255, 255}} = inet:parse_address("255.255.255.255"),
+    {error, einval} = inet:parse_address("256.0.0.1"),
+    {error, einval} = inet:parse_address("not_an_address"),
+    case erlang:system_info(machine) of
+        "BEAM" ->
+            % BEAM accepts short-form IPv4 addresses
+            {ok, {127, 0, 0, 1}} = inet:parse_address("127.1"),
+            {ok, {127, 0, 0, 1}} = inet:parse_address("0x7f000001"),
+            {ok, {127, 0, 0, 1}} = inet:parse_address("127.0.000.001");
+        "ATOM" ->
+            % AtomVM only supports strict dotted-decimal IPv4 addresses
+            {error, einval} = inet:parse_address("127.1"),
+            {error, einval} = inet:parse_address("0x7f000001"),
+            % AtomVM doesn't allow leading zeros as well
+            {error, einval} = inet:parse_address("127.0.000.001")
+    end,
+    ok.
+
+test_parse_ipv4_address() ->
+    {ok, {127, 0, 0, 1}} = inet:parse_ipv4_address("127.0.0.1"),
+    {ok, {10, 0, 0, 1}} = inet:parse_ipv4_address("10.0.0.1"),
+    {ok, {0, 0, 0, 0}} = inet:parse_ipv4_address("0.0.0.0"),
+    {ok, {255, 255, 255, 255}} = inet:parse_ipv4_address("255.255.255.255"),
+    {error, einval} = inet:parse_ipv4_address("256.0.0.1"),
+    {error, einval} = inet:parse_ipv4_address("not_an_address"),
+    case erlang:system_info(machine) of
+        "BEAM" ->
+            % BEAM accepts short-form IPv4 addresses
+            {ok, {127, 0, 0, 1}} = inet:parse_ipv4_address("127.1"),
+            {ok, {127, 0, 0, 1}} = inet:parse_ipv4_address("0x7f000001");
+        "ATOM" ->
+            % AtomVM only supports strict dotted-decimal IPv4 addresses
+            {error, einval} = inet:parse_ipv4_address("127.1"),
+            {error, einval} = inet:parse_ipv4_address("0x7f000001")
+    end,
+    ok.
+
+test_parse_ipv4strict_address() ->
+    {ok, {127, 0, 0, 1}} = inet:parse_ipv4strict_address("127.0.0.1"),
+    {ok, {10, 0, 0, 1}} = inet:parse_ipv4strict_address("10.0.0.1"),
+    {ok, {0, 0, 0, 0}} = inet:parse_ipv4strict_address("0.0.0.0"),
+    {ok, {255, 255, 255, 255}} = inet:parse_ipv4strict_address("255.255.255.255"),
+    {error, einval} = inet:parse_ipv4strict_address("256.0.0.1"),
+    {error, einval} = inet:parse_ipv4strict_address("127.0.0"),
+    {error, einval} = inet:parse_ipv4strict_address("127.1"),
+    {error, einval} = inet:parse_ipv4strict_address("0x7f000001"),
+    {error, einval} = inet:parse_ipv4strict_address("not_an_address"),
     ok.


### PR DESCRIPTION
Add `ntoa/1`, `parse_address/1`, `parse_ipv4_address/1`, `parse_ipv4strict_address/1` functions.

Note: our parse_(ipv4_)address/1 has an important limitation: exotic IPv4 forms, such as "127.1" and "0x7f000001", are not accepted in order to keep our code short.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
