### PR TITLE
CI: use setup-beam on simtest

### DIFF
--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -80,26 +80,28 @@ jobs:
             "esp32c6",
             "esp32h2"
           ]
-        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.6", "v5.2.6", "v5.3.4", "v5.4.3", "v5.5.2"]')) || fromJSON('["v5.5.2"]') }}
+        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.7", "v5.2.6", "v5.3.4", "v5.4.3", "v5.5.3"]')) || fromJSON('["v5.5.3"]') }}
         exclude:
           - esp-idf-target: "esp32p4"
-            idf-version: "v5.1.6"
+            idf-version: "v5.1.7"
           - esp-idf-target: "esp32p4"
             idf-version: "v5.2.6"
           - esp-idf-target: "esp32h2"
-            idf-version: "v5.1.6"
+            idf-version: "v5.1.7"
           - esp-idf-target: "esp32h2"
             idf-version: "v5.2.6"
           - esp-idf-target: "esp32c5"
-            idf-version: "v5.1.6"
+            idf-version: "v5.1.7"
           - esp-idf-target: "esp32c5"
             idf-version: "v5.2.6"
           - esp-idf-target: "esp32c5"
             idf-version: "v5.3.4"
+          - esp-idf-target: "esp32c5"
+            idf-version: "v5.4.3"
         # CI now uses chip revision 3 that is currently only available in 5.5.2
         include:
           - esp-idf-target: "esp32p4"
-            idf-version: "v5.5.2"
+            idf-version: "v5.5.3"
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
And update to latest versions.

Some of the older containers are using very outdated erlang versions (22), leading to opcodes errors etc.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
