### PR TITLE
Fix a race condition related to `globalcontext_get_process_nolock`

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -504,11 +504,11 @@ void globalcontext_init_process(GlobalContext *glb, Context *ctx)
 {
     ctx->global = glb;
 
-    synclist_append(&glb->processes_table, &ctx->processes_table_head);
     SMP_SPINLOCK_LOCK(&glb->processes_spinlock);
     ctx->process_id = ++glb->last_process_id;
     list_append(&glb->waiting_processes, &ctx->processes_list_head);
     SMP_SPINLOCK_UNLOCK(&glb->processes_spinlock);
+    synclist_append(&glb->processes_table, &ctx->processes_table_head);
 }
 
 bool globalcontext_register_process(GlobalContext *glb, int atom_index, term local_pid_or_port)


### PR DESCRIPTION
New processes were added to the process table before their process id was set, and `globalcontext_get_process_nolock` could read garbage when iterating on the process table.

Seen in CI:
https://github.com/atomvm/AtomVM/actions/runs/22364137773/job/64725440337?pr=2118

```
==19546== Thread 2:
==19546== Conditional jump or move depends on uninitialised value(s)
==19546==    at 0x40D99B: globalcontext_get_process_nolock (src/libAtomVM/globalcontext.c:280)
==19546==    by 0x4973B0: context_monitors_handle_terminate (src/libAtomVM/context.c:746)
==19546==    by 0x4973B0: context_destroy (src/libAtomVM/context.c:231)
==19546==    by 0x440F27: scheduler_entry_point (src/libAtomVM/opcodesswitch.h:7810)
==19546==    by 0x4A400E: scheduler_thread_entry_point (src/platforms/generic_unix/lib/smp.c:75)
==19546==    by 0x4A87608: start_thread (pthread_create.c:477)
==19546==    by 0x4BC1352: clone (clone.S:95)
==19546== 
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
