### PR TITLE
Add missing `ProtoDist:close(Listen)`

### DIFF
--- a/libs/estdlib/src/net_kernel.erl
+++ b/libs/estdlib/src/net_kernel.erl
@@ -342,8 +342,9 @@ handle_info(
     {noreply, State#state{connections = NewConnections}}.
 
 %% @hidden
-terminate(_Reason, State) ->
-    {ok, State}.
+terminate(_Reason, #state{listen = Listen, proto_dist = ProtoDist}) ->
+    ProtoDist:close(Listen),
+    ok.
 
 split_name(Options) ->
     LongNames = maps:get(name_domain, Options, longnames) =:= longnames,


### PR DESCRIPTION
`net_kernel` terminate handler didn't close the listening socket, which may trigger a dead lock if the socket was restarted during shutdown.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
