### PR TITLE
CI: Bump FreeBSD - add 15.0

### DIFF
--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os_release: ["13.4", "14.2"]
+        os_release: ["13.5", "14.3", "15.0"]
 
     steps:
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
