### PR TITLE
Fix a race condition in `dist_connection_dtor`

### DIFF
--- a/src/libAtomVM/dist_nifs.c
+++ b/src/libAtomVM/dist_nifs.c
@@ -111,6 +111,7 @@ struct DistConnection
 static void dist_connection_dtor(ErlNifEnv *caller_env, void *obj)
 {
     struct DistConnection *conn_obj = (struct DistConnection *) obj;
+    synclist_remove(&caller_env->global->dist_connections, &conn_obj->head);
     if (conn_obj->connection_process_id != INVALID_PROCESS_ID) {
         enif_demonitor_process(caller_env, conn_obj, &conn_obj->connection_process_monitor);
     }
@@ -132,7 +133,6 @@ static void dist_connection_dtor(ErlNifEnv *caller_env, void *obj)
     }
     synclist_unlock(&conn_obj->pending_packets);
     synclist_destroy(&conn_obj->pending_packets);
-    synclist_remove(&caller_env->global->dist_connections, &conn_obj->head);
 }
 
 static void dist_enqueue_message(term control_message, term payload, struct DistConnection *connection, GlobalContext *global)


### PR DESCRIPTION
Fix a bug yielding malloc corruption CI errors. A scheduler could try and lock a destroyed pending_packets rwlock. A connection being destroyed must be removed from the list of connections earlier so it cannot be found and be waited on by another scheduler.

Partial fix for #2030 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
