### PR TITLE
Fix use-after-free in process scheduling lists

### DIFF
--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -287,9 +287,6 @@ Context *scheduler_run(GlobalContext *global)
             // process signal messages and also empty outer list to inner list.
             scheduler_process_native_signal_messages(result);
             if (UNLIKELY(result->flags & Killed)) {
-                SMP_SPINLOCK_LOCK(&global->processes_spinlock);
-                list_remove(&result->processes_list_head);
-                SMP_SPINLOCK_UNLOCK(&global->processes_spinlock);
                 context_destroy(result);
             } else {
                 if (mailbox_has_next(&result->mailbox)) {
@@ -429,6 +426,7 @@ void scheduler_terminate(Context *ctx)
     SMP_SPINLOCK_LOCK(&ctx->global->processes_spinlock);
     context_update_flags(ctx, ~NoFlags, Killed);
     list_remove(&ctx->processes_list_head);
+    list_init(&ctx->processes_list_head);
     SMP_SPINLOCK_UNLOCK(&ctx->global->processes_spinlock);
     if (!ctx->leader) {
         context_destroy(ctx);


### PR DESCRIPTION
While reviewing https://github.com/atomvm/AtomVM/pull/2139 AI found below:

https://ampcode.com/threads/T-019c9441-412f-768c-83d5-9f8982eb753c#message-21-block-0

So AI slop/hallucination danger, but it did call it a "time bomb" when I asked how severe it was - would only happen under memory pressure..

When `do_spawn` fails after `context_new` has been called, `context_destroy` is invoked directly. `context_new` calls `globalcontext_init_process` which adds the context to both `processes_table` and `waiting_processes`, but `context_destroy` only removed from `processes_table`. The freed context's node remained linked in `waiting_processes`, causing a use-after-free corruption of the scheduling list.

Fix by adding a spinlock-protected `list_remove` +  `list_init` of `processes_list_head` in `context_destroy`. The `list_init` makes the node self-referential so that a second `list_remove` (from callers like `scheduler_terminate` that already do the removal before calling `context_destroy`) is a safe no-op.

Also remove the now-redundant explicit removal in the native handler kill path of `scheduler_run`, since `context_destroy` handles it.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
