### PR TITLE
Fix lock usage on `dist_connections`

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -262,6 +262,7 @@ COLD_FUNC void globalcontext_destroy(GlobalContext *glb)
     smp_mutex_destroy(glb->schedulers_mutex);
     smp_rwlock_destroy(glb->modules_lock);
 #endif
+    synclist_destroy(&glb->dist_connections);
     synclist_destroy(&glb->registered_processes);
     synclist_destroy(&glb->processes_table);
 


### PR DESCRIPTION
Fix a case where the lock held on `dist_connections` was a rdlock, yet we modified the list for autoconnect.

Also add a missing `synclist_destroy` in `globalcontext_destroy`

Also fix a double-unlock possibility on error path in
`dist_get_net_kernel_and_create_connection` which doesn't own the lock

This fixes CI failures such as https://github.com/atomvm/AtomVM/actions/runs/22431662251/job/64951689475#step:32:770

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
