### PR TITLE
Add suport to `is_integer/3` BIF (and to OTP-29)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -299,7 +299,7 @@ jobs:
           compiler_pkgs: "gcc-10 g++-10 gcc-10-multilib g++-10-multilib libc6-dev-i386
             libc6-dbg:i386 zlib1g-dev:i386 libmbedtls-dev:i386"
 
-        # JIT build
+        # JIT build with OTP-28
         - os: "ubuntu-24.04"
           cc: "cc"
           cxx: "c++"
@@ -307,6 +307,18 @@ jobs:
           otp: "28"
           elixir_version: "1.17"
           rebar3_version: "3.24.0"
+          cmake_opts_other: "-DAVM_DISABLE_JIT=OFF"
+          jit_target_arch: "x86_64"
+
+        # JIT build with OTP-29.0-rc1
+        - os: "ubuntu-24.04"
+          cc: "cc"
+          cxx: "c++"
+          cflags: ""
+          otp: "29.0-rc1"
+          version_type: "strict"
+          elixir_version: "1.19.5"
+          rebar3_version: "3.27.0"
           cmake_opts_other: "-DAVM_DISABLE_JIT=OFF"
           jit_target_arch: "x86_64"
 
@@ -568,6 +580,7 @@ jobs:
 
     - uses: erlef/setup-beam@v1
       with:
+        version-type: ${{ matrix.version_type || 'loose' }}
         otp-version: ${{ matrix.otp }}
         elixir-version: ${{ matrix.elixir_version }}
         rebar3-version: ${{ matrix.rebar3_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for ESP32 development builds to include NVS partition data at build time
 - Added missing `inet` functions: `ntoa/1`, `parse_address/1`, `parse_ipv4_address/1`,
 `parse_ipv4strict_address/1`
+- Added support for new `is_integer/3` BIF, introduced with OTP-29
+- Support for OTP-29
 
 ### Changed
 

--- a/README.Md
+++ b/README.Md
@@ -85,7 +85,7 @@ ecosystem. It can execute unmodified, compiled BEAM modules, and most
 [core standard library functions](https://doc.atomvm.org/main/api-reference-documentation.html)
 are already supported.
 
-AtomVM is tested with code compiled with any version from OTP 21 to 27 (28 is supported only in `main` branch).
+AtomVM is tested with code compiled with any version from OTP 21 to 27 (29 is supported only in `main` branch).
 
 Crashes may still occur in edge cases, so we recommend using either the
 [latest stable release](https://github.com/atomvm/AtomVM/releases)

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -35,6 +35,7 @@ AtomVM will run BEAM files that have been compiled using the following Erlang an
 | ✅ OTP 26 | ✅ 1.15 |
 | ✅ OTP 27 | ✅ 1.17 |
 | ✅ OTP 28 | ✅ 1.17 |
+| ✅ OTP 29 | ✅ 1.19 |
 
 ```{note}
 Versions of Elixir that are compatible with a particular OTP version may work.  This table reflects the versions that are tested.

--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -2533,7 +2533,26 @@ first_pass(<<?OP_BS_MATCH, Rest0/binary>>, MMod, MSt0, State0) ->
     ?TRACE("]\n", []),
     MSt9 = MMod:free_native_registers(MSt8, [BSBinaryReg, NewBSOffsetReg, MatchStateReg2]),
     ?ASSERT_ALL_NATIVE_FREE(MSt9),
-    first_pass(Rest4, MMod, MSt9, State0).
+    first_pass(Rest4, MMod, MSt9, State0);
+% 185
+first_pass(<<?OP_BIF3, Rest0/binary>>, MMod, MSt0, State0) ->
+    ?ASSERT_ALL_NATIVE_FREE(MSt0),
+    {FailLabel, Rest1} = decode_label(Rest0),
+    {Bif, Rest2} = decode_literal(Rest1),
+    {MSt1, FuncPtr} = MMod:call_primitive(MSt0, ?PRIM_GET_IMPORTED_BIF, [
+        jit_state, Bif
+    ]),
+    {MSt2, Arg1, Rest3} = decode_compact_term(Rest2, MMod, MSt1, State0),
+    {MSt3, Arg2, Rest4} = decode_compact_term(Rest3, MMod, MSt2, State0),
+    {MSt4, Arg3, Rest5} = decode_compact_term(Rest4, MMod, MSt3, State0),
+    {MSt5, Dest, Rest6} = decode_dest(Rest5, MMod, MSt4),
+    ?TRACE("OP_BIF3 ~p, ~p, ~p, ~p, ~p, ~p\n", [FailLabel, Bif, Arg1, Arg2, Arg3, Dest]),
+    {MSt6, ResultReg} = MMod:call_func_ptr(MSt5, {free, FuncPtr}, [
+        ctx, FailLabel, {free, Arg1}, {free, Arg2}, {free, Arg3}
+    ]),
+    MSt7 = bif_faillabel_test(FailLabel, MMod, MSt6, {free, ResultReg}, {free, Dest}),
+    ?ASSERT_ALL_NATIVE_FREE(MSt7),
+    first_pass(Rest6, MMod, MSt7, State0).
 
 first_pass_bs_create_bin_compute_size(
     AtomType, Src, _Size, _SegmentUnit, Fail, AccLiteralSize0, AccSizeReg0, MMod, MSt0, State0

--- a/libs/jit/src/opcodes.hrl
+++ b/libs/jit/src/opcodes.hrl
@@ -167,7 +167,8 @@
 -define(OP_BADRECORD, 180).
 -define(OP_UPDATE_RECORD, 181).
 -define(OP_BS_MATCH, 182).
+-define(OP_BIF3, 185).
 
--define(OPCODE_MAX, 182).
+-define(OPCODE_MAX, 185).
 
 % Remember to keep this list in sync with src/libAtomVM/opcodes.h

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -81,6 +81,9 @@
 #define INT64_MAX_AS_AVM_FLOAT 9223372036854775295.0 // 0x43DFFFFFFFFFFFFF = 2^62 * 1.1...1b
 #endif
 
+static void conv_term_to_bigint(term t, intn_digit_t *tmp_buf, const intn_digit_t **bigint,
+    size_t *bigint_len, intn_integer_sign_t *bigint_sign);
+
 const struct ExportedFunction *bif_registry_get_handler(const char *mfa)
 {
     const BifNameAndPtr *nameAndPtr = in_word_set(mfa, strlen(mfa));
@@ -248,6 +251,54 @@ term bif_erlang_is_integer_1(Context *ctx, uint32_t fail_label, term arg1)
     UNUSED(fail_label);
 
     return term_is_any_integer(arg1) ? TRUE_ATOM : FALSE_ATOM;
+}
+
+term bif_erlang_is_integer_3(Context *ctx, uint32_t fail_label, term arg1, term arg2, term arg3)
+{
+    if (term_is_int(arg1) && term_is_int(arg2) && term_is_int(arg3)) {
+        avm_int_t n = term_to_int(arg1);
+        avm_int_t a = term_to_int(arg2);
+        avm_int_t b = term_to_int(arg3);
+        return (a <= n) && (n <= b) ? TRUE_ATOM : FALSE_ATOM;
+
+    } else if (term_is_int64(arg1) && term_is_int64(arg2) && term_is_int64(arg3)) {
+        avm_int64_t n = term_maybe_unbox_int64(arg1);
+        avm_int64_t a = term_maybe_unbox_int64(arg2);
+        avm_int64_t b = term_maybe_unbox_int64(arg3);
+        return (a <= n) && (n <= b) ? TRUE_ATOM : FALSE_ATOM;
+    } else {
+        if (!term_is_any_integer(arg2) || !term_is_any_integer(arg3)) {
+            RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
+        }
+        if (UNLIKELY(!term_is_any_integer(arg1))) {
+            return FALSE_ATOM;
+        }
+
+        intn_digit_t tmp_buf1[INTN_INT64_LEN];
+        intn_digit_t tmp_buf2[INTN_INT64_LEN];
+
+        const intn_digit_t *big1;
+        size_t big1_len;
+        intn_integer_sign_t big1_sign;
+        conv_term_to_bigint(arg1, tmp_buf1, &big1, &big1_len, &big1_sign);
+
+        const intn_digit_t *big2;
+        size_t big2_len;
+        intn_integer_sign_t big2_sign;
+        conv_term_to_bigint(arg2, tmp_buf2, &big2, &big2_len, &big2_sign);
+
+        // `big1` is `n`, `big2` is `a`
+        if (intn_cmp(big2, big2_len, big2_sign, big1, big1_len, big1_sign) <= 0) {
+            // reuse tmp_buf2; we no longer need `a`
+            conv_term_to_bigint(arg3, tmp_buf2, &big2, &big2_len, &big2_sign); // now `big2` is `b`
+
+            if (intn_cmp(big1, big1_len, big1_sign, big2, big2_len, big2_sign) <= 0) {
+                return TRUE_ATOM;
+            }
+        }
+
+        return FALSE_ATOM;
+    }
 }
 
 term bif_erlang_is_list_1(Context *ctx, uint32_t fail_label, term arg1)
@@ -1033,7 +1084,7 @@ static term div_maybe_bigint(Context *ctx, uint32_t fail_label, uint32_t live, t
     intn_integer_sign_t big2_sign;
     conv_term_to_bigint(arg2, tmp_buf2, &big2, &big2_len, &big2_sign);
 
-    int cmp_result = intn_cmp(big1, big1_len, big2, big2_len);
+    int cmp_result = intn_cmpu(big1, big1_len, big2, big2_len);
     if (cmp_result < 0) {
         // a / b when a < b -> always 0
         return term_from_int(0);
@@ -1356,7 +1407,7 @@ static term rem_maybe_bigint(Context *ctx, uint32_t fail_label, uint32_t live, t
     intn_integer_sign_t big2_sign;
     conv_term_to_bigint(arg2, tmp_buf2, &big2, &big2_len, &big2_sign);
 
-    int cmp_result = intn_cmp(big1, big1_len, big2, big2_len);
+    int cmp_result = intn_cmpu(big1, big1_len, big2, big2_len);
     if (cmp_result < 0) {
         // a rem b when |a| < |b| -> always a
         return arg1;

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -55,6 +55,7 @@ term bif_erlang_is_float_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_function_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_function_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 term bif_erlang_is_integer_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_integer_3(Context *ctx, uint32_t fail_label, term arg1, term arg2, term arg3);
 term bif_erlang_is_list_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_number_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_pid_1(Context *ctx, uint32_t fail_label, term arg1);

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -50,6 +50,7 @@ erlang:is_float/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang
 erlang:is_function/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_function_1}
 erlang:is_function/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_is_function_2}
 erlang:is_integer/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_integer_1}
+erlang:is_integer/3, {.bif.base.type = BIFFunctionType, .bif.bif3_ptr = bif_erlang_is_integer_3}
 erlang:is_list/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_list_1}
 erlang:is_number/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_number_1}
 erlang:is_pid/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_pid_1}

--- a/src/libAtomVM/exportedfunction.h
+++ b/src/libAtomVM/exportedfunction.h
@@ -48,6 +48,7 @@ typedef struct JITState JITState;
 typedef term (*BifImpl0)(Context *ctx);
 typedef term (*BifImpl1)(Context *ctx, uint32_t fail_label, term arg1);
 typedef term (*BifImpl2)(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+typedef term (*BifImpl3)(Context *ctx, uint32_t fail_label, term arg1, term arg2, term arg3);
 
 typedef term (*GCBifImpl1)(Context *ctx, uint32_t fail_label, int live, term arg1);
 typedef term (*GCBifImpl2)(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
@@ -83,6 +84,7 @@ struct Bif
         BifImpl0 bif0_ptr;
         BifImpl1 bif1_ptr;
         BifImpl2 bif2_ptr;
+        BifImpl3 bif3_ptr;
     };
 };
 

--- a/src/libAtomVM/intn.c
+++ b/src/libAtomVM/intn.c
@@ -434,7 +434,7 @@ size_t intn_divu(const intn_digit_t m[], size_t m_len, const intn_digit_t n[], s
     return padded_q_len / UINT16_IN_A_DIGIT;
 }
 
-int intn_cmp(const intn_digit_t a[], size_t a_len, const intn_digit_t b[], size_t b_len)
+int intn_cmpu(const intn_digit_t a[], size_t a_len, const intn_digit_t b[], size_t b_len)
 {
     size_t normal_a_len = intn_count_digits(a, a_len);
     size_t normal_b_len = intn_count_digits(b, b_len);
@@ -456,6 +456,18 @@ int intn_cmp(const intn_digit_t a[], size_t a_len, const intn_digit_t b[], size_
     }
 
     return 0;
+}
+
+int intn_cmp(const intn_digit_t a[], size_t a_len, intn_integer_sign_t a_sign,
+    const intn_digit_t b[], size_t b_len, intn_integer_sign_t b_sign)
+{
+    if (a_sign != b_sign) {
+        return (a_sign == IntNNegativeInteger) ? -1 : 1;
+    }
+
+    int cmp = intn_cmpu(a, a_len, b, b_len);
+
+    return (a_sign == IntNNegativeInteger) ? -cmp : cmp;
 }
 
 size_t intn_addu(
@@ -515,7 +527,7 @@ size_t intn_add(const intn_digit_t m[], size_t m_len, intn_integer_sign_t m_sign
     }
     // Case 2: Different signs - subtract smaller from larger
     else {
-        int cmp = intn_cmp(m, m_len, n, n_len);
+        int cmp = intn_cmpu(m, m_len, n, n_len);
         if (cmp >= 0) {
             // |m| >= |n|, result takes sign of m
             *out_sign = m_sign;

--- a/src/libAtomVM/intn.h
+++ b/src/libAtomVM/intn.h
@@ -274,7 +274,28 @@ typedef uint32_t intn_digit_t;
  * @note Leading zeros are ignored in comparison
  * @note Accepts both normalized and non-normalized inputs
  */
-int intn_cmp(const intn_digit_t a[], size_t a_len, const intn_digit_t b[], size_t b_len);
+int intn_cmpu(const intn_digit_t a[], size_t a_len, const intn_digit_t b[], size_t b_len);
+
+/**
+ * @brief Compare two signed multi-precision integers
+ *
+ * Compares two multi-precision integers with explicit sign information.
+ * Magnitudes are compared using intn_cmpu(), which ignores sign and tolerates
+ * non-normalized inputs (leading zeros).
+ *
+ * @param a First integer array (magnitude digits)
+ * @param a_len Length of first integer in digits
+ * @param a_sign Sign of the first integer
+ * @param b Second integer array (magnitude digits)
+ * @param b_len Length of second integer in digits
+ * @param b_sign Sign of the second integer
+ * @return -1 if a < b, 0 if a == b, 1 if a > b
+ *
+ * @note Leading zeros are ignored in comparison
+ * @note Accepts both normalized and non-normalized inputs
+ */
+int intn_cmp(const intn_digit_t a[], size_t a_len, intn_integer_sign_t a_sign,
+    const intn_digit_t b[], size_t b_len, intn_integer_sign_t b_sign);
 
 /**
  * @brief Add two unsigned multi-precision integers
@@ -347,7 +368,7 @@ size_t intn_add_int64(int64_t num1, int64_t num2, intn_digit_t *out, intn_intege
  * @param[out] out Result buffer (must have at least \c INTN_SUB_OUT_LEN(a_len, b_len) digits)
  * @return Actual length of result in digits (may be less than buffer size)
  *
- * @pre a >= b (use \c intn_cmp to verify if needed)
+ * @pre a >= b (use \c intn_cmpu to verify if needed)
  * @pre out buffer must be at least \c INTN_SUB_OUT_LEN(a_len, b_len) digits
  * @post Result may have leading zeros (not normalized)
  * @note Accepts both normalized and non-normalized inputs

--- a/src/libAtomVM/opcodes.h
+++ b/src/libAtomVM/opcodes.h
@@ -171,6 +171,7 @@
 #define OP_BADRECORD 180
 #define OP_UPDATE_RECORD 181
 #define OP_BS_MATCH 182
+#define OP_BIF3 185
 
 // Remember to keep this list in sync with libs/jit/src/opcodes.hrl
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -7715,6 +7715,49 @@ wait_timeout_trap_handler:
 bs_match_jump_to_fail:
                     JUMP_TO_ADDRESS(mod->labels[fail]);
                 #endif
+
+                case OP_BIF3: {
+                    uint32_t fail_label;
+                    DECODE_LABEL(fail_label, pc);
+                    uint32_t bif;
+                    DECODE_LITERAL(bif, pc);
+                    term arg1;
+                    DECODE_COMPACT_TERM(arg1, pc)
+                    term arg2;
+                    DECODE_COMPACT_TERM(arg2, pc)
+                    term arg3;
+                    DECODE_COMPACT_TERM(arg3, pc);
+                    DEST_REGISTER(dreg);
+                    DECODE_DEST_REGISTER(dreg, pc);
+
+                    TRACE("bif3/6 bif=%i, fail=%i, dreg=%c%i\n", bif, fail_label, T_DEST_REG(dreg));
+                    USED_BY_TRACE(bif);
+
+                    #ifdef IMPL_CODE_LOADER
+                        UNUSED(arg1);
+                        UNUSED(arg2);
+                        UNUSED(arg3);
+                    #endif
+
+                    #ifdef IMPL_EXECUTE_LOOP
+                        const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
+                        BifImpl3 func = EXPORTED_FUNCTION_TO_BIF(exported_bif)->bif3_ptr;
+                        DEBUG_FAIL_NULL(func);
+                        term ret = func(ctx, fail_label, arg1, arg2, arg3);
+                        if (UNLIKELY(term_is_invalid_term(ret))) {
+                            if (fail_label) {
+                                pc = mod->labels[fail_label];
+                                break;
+                            } else {
+                                HANDLE_ERROR();
+                            }
+                        }
+
+                        WRITE_REGISTER(dreg, ret);
+                    #endif
+
+                    break;
+                }
             }
 #endif
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -637,6 +637,7 @@ compile_erlang(reraise_raiser)
 
 compile_erlang(stacktrace_function_args)
 compile_erlang(test_multi_value_comprehension)
+compile_erlang(test_is_integer_3)
 
 compile_erlang(test_inline_arith)
 
@@ -1189,6 +1190,7 @@ set(erlang_test_beams
     stacktrace_function_args.beam
 
     test_multi_value_comprehension.beam
+    test_is_integer_3.beam
 
     ${OTP23_OR_GREATER_TESTS}
     ${OTP25_OR_GREATER_TESTS}

--- a/tests/erlang_tests/test_is_integer_3.erl
+++ b/tests/erlang_tests/test_is_integer_3.erl
@@ -1,0 +1,349 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_is_integer_3).
+
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 29).
+-define(OTP29_OR_LATER, true).
+-endif.
+-endif.
+
+-ifdef(OTP29_OR_LATER).
+
+-export([
+    start/0,
+    id/1,
+    is_integer_helper/3,
+    is_0_100/1,
+    is_uint32/1,
+    is_uint64/1,
+    is_atomvm_integer/1,
+    classify/1
+]).
+
+start() ->
+    ok = test_small_int_interval(),
+    ok = test_swapped_interval(),
+    ok = test_single_value_interval(),
+    ok = test_known_bounds(),
+    ok = test_bigint(),
+    ok = test_errors(),
+    0.
+
+test_small_int_interval() ->
+    false = is_integer(?MODULE:id(-16#FFFFFFFFFFFFFFF), ?MODULE:id(0), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(-16#FFFFFFFF), ?MODULE:id(0), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(-20), ?MODULE:id(0), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(-1), ?MODULE:id(0), ?MODULE:id(10)),
+    true = is_integer(?MODULE:id(0), ?MODULE:id(0), ?MODULE:id(10)),
+    true = is_integer(?MODULE:id(5), ?MODULE:id(0), ?MODULE:id(10)),
+    true = is_integer(?MODULE:id(10), ?MODULE:id(0), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(20), ?MODULE:id(0), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(16#FFFFFFFF), ?MODULE:id(0), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(16#FFFFFFFFFFFFFFF), ?MODULE:id(0), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(not_a_number), ?MODULE:id(0), ?MODULE:id(10)),
+
+    false = ?MODULE:is_integer_helper(
+        ?MODULE:id(-16#FFFFFFFFFFFFFFF), ?MODULE:id(0), ?MODULE:id(10)
+    ),
+    false = ?MODULE:is_integer_helper(?MODULE:id(-16#FFFFFFFF), ?MODULE:id(0), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(-20), ?MODULE:id(0), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(-1), ?MODULE:id(0), ?MODULE:id(10)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(0), ?MODULE:id(0), ?MODULE:id(10)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(5), ?MODULE:id(0), ?MODULE:id(10)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(10), ?MODULE:id(0), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(20), ?MODULE:id(0), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(16#FFFFFFFF), ?MODULE:id(0), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(
+        ?MODULE:id(16#FFFFFFFFFFFFFFF), ?MODULE:id(0), ?MODULE:id(10)
+    ),
+    false = ?MODULE:is_integer_helper(
+        ?MODULE:id(<<"not a number">>), ?MODULE:id(0), ?MODULE:id(10)
+    ),
+
+    false = is_integer(?MODULE:id(-16#FFFFFFFFFFFFFFF), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(-16#FFFFFFFF), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(-20), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = is_integer(?MODULE:id(-10), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = is_integer(?MODULE:id(-1), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = is_integer(?MODULE:id(0), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = is_integer(?MODULE:id(5), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = is_integer(?MODULE:id(10), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(20), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(16#FFFFFFFF), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(16#FFFFFFFFFFFFFFF), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = is_integer(?MODULE:id(5.0), ?MODULE:id(-10), ?MODULE:id(10)),
+
+    false = ?MODULE:is_integer_helper(
+        ?MODULE:id(-16#FFFFFFFFFFFFFFF), ?MODULE:id(-10), ?MODULE:id(10)
+    ),
+    false = ?MODULE:is_integer_helper(?MODULE:id(-16#FFFFFFFF), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(-20), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(-10), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(-1), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(0), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(5), ?MODULE:id(-10), ?MODULE:id(10)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(10), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(20), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(16#FFFFFFFF), ?MODULE:id(-10), ?MODULE:id(10)),
+    false = ?MODULE:is_integer_helper(
+        ?MODULE:id(16#FFFFFFFFFFFFFFF), ?MODULE:id(-10), ?MODULE:id(10)
+    ),
+    false = ?MODULE:is_integer_helper(?MODULE:id(0.0), ?MODULE:id(-10), ?MODULE:id(10)),
+
+    ok.
+
+test_swapped_interval() ->
+    false = is_integer(?MODULE:id(-20), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = is_integer(?MODULE:id(-11), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = is_integer(?MODULE:id(-10), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = is_integer(?MODULE:id(0), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = is_integer(?MODULE:id(10), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = is_integer(?MODULE:id(11), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = is_integer(?MODULE:id(20), ?MODULE:id(10), ?MODULE:id(-10)),
+
+    false = ?MODULE:is_integer_helper(?MODULE:id(-20), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(-11), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(-10), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(0), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(10), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(11), ?MODULE:id(10), ?MODULE:id(-10)),
+    false = ?MODULE:is_integer_helper(?MODULE:id(20), ?MODULE:id(10), ?MODULE:id(-10)),
+
+    ok.
+
+test_single_value_interval() ->
+    true = is_integer(?MODULE:id(0), ?MODULE:id(0), ?MODULE:id(0)),
+    true = is_integer(?MODULE:id(1), ?MODULE:id(1), ?MODULE:id(1)),
+    true = is_integer(?MODULE:id(-1), ?MODULE:id(-1), ?MODULE:id(-1)),
+    true = is_integer(?MODULE:id(16#FFFFFFFF), ?MODULE:id(16#FFFFFFFF), ?MODULE:id(16#FFFFFFFF)),
+    true = is_integer(
+        ?MODULE:id(16#FFFFFFFFFFFFFFF),
+        ?MODULE:id(16#FFFFFFFFFFFFFFF),
+        ?MODULE:id(16#FFFFFFFFFFFFFFF)
+    ),
+
+    true = ?MODULE:is_integer_helper(?MODULE:id(0), ?MODULE:id(0), ?MODULE:id(0)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(1), ?MODULE:id(1), ?MODULE:id(1)),
+    true = ?MODULE:is_integer_helper(?MODULE:id(-1), ?MODULE:id(-1), ?MODULE:id(-1)),
+    true = ?MODULE:is_integer_helper(
+        ?MODULE:id(16#FFFFFFFF), ?MODULE:id(16#FFFFFFFF), ?MODULE:id(16#FFFFFFFF)
+    ),
+    true = ?MODULE:is_integer_helper(
+        ?MODULE:id(16#FFFFFFFFFFFFFFF),
+        ?MODULE:id(16#FFFFFFFFFFFFFFF),
+        ?MODULE:id(16#FFFFFFFFFFFFFFF)
+    ),
+    ok.
+
+test_known_bounds() ->
+    false = ?MODULE:is_0_100(?MODULE:id(-16#8000000000000000)),
+    false = ?MODULE:is_0_100(?MODULE:id(-16#FFFFCAFECAFE)),
+    false = ?MODULE:is_0_100(?MODULE:id(-16#CAFECAFE)),
+    false = ?MODULE:is_0_100(?MODULE:id(-100)),
+    false = ?MODULE:is_0_100(?MODULE:id(-1)),
+    true = ?MODULE:is_0_100(?MODULE:id(0)),
+    true = ?MODULE:is_0_100(?MODULE:id(1)),
+    true = ?MODULE:is_0_100(?MODULE:id(50)),
+    true = ?MODULE:is_0_100(?MODULE:id(99)),
+    true = ?MODULE:is_0_100(?MODULE:id(100)),
+    false = ?MODULE:is_0_100(?MODULE:id(101)),
+    false = ?MODULE:is_0_100(?MODULE:id(500)),
+    false = ?MODULE:is_0_100(?MODULE:id(16#CAFECAFE)),
+    false = ?MODULE:is_0_100(?MODULE:id(16#FFFFCAFECAFE)),
+    false = ?MODULE:is_0_100(?MODULE:id(16#7FFFFFFFFFFFFFFF)),
+    false = ?MODULE:is_0_100(?MODULE:id(5.0)),
+    false = ?MODULE:is_0_100(?MODULE:id(not_a_number)),
+
+    false = ?MODULE:is_uint32(?MODULE:id(-16#CAFECAFE)),
+    false = ?MODULE:is_uint32(?MODULE:id(-42)),
+    true = ?MODULE:is_uint32(?MODULE:id(0)),
+    true = ?MODULE:is_uint32(?MODULE:id(42)),
+    true = ?MODULE:is_uint32(?MODULE:id(16#CAFECAFE)),
+    false = ?MODULE:is_uint32(?MODULE:id(16#CAFECAFEFFF)),
+    false = ?MODULE:is_uint64(?MODULE:id(16#10000000000000000)),
+    false = ?MODULE:is_uint32(?MODULE:id(42.0)),
+    false = ?MODULE:is_uint32(?MODULE:id(not_a_number)),
+
+    false = ?MODULE:is_uint64(?MODULE:id(-16#FFFFFFFFFFFFFFFF)),
+    false = ?MODULE:is_uint64(?MODULE:id(-16#CAFECAFE)),
+    false = ?MODULE:is_uint64(?MODULE:id(-42)),
+    true = ?MODULE:is_uint64(?MODULE:id(0)),
+    true = ?MODULE:is_uint64(?MODULE:id(42)),
+    true = ?MODULE:is_uint64(?MODULE:id(16#CAFECAFE)),
+    true = ?MODULE:is_uint64(?MODULE:id(16#CAFECAFEFFF)),
+    true = ?MODULE:is_uint64(?MODULE:id(16#FFFFFFFFFFFFFFFF)),
+    false = ?MODULE:is_uint64(?MODULE:id(16#10000000000000000)),
+    false = ?MODULE:is_uint64(?MODULE:id(0.0)),
+    false = ?MODULE:is_uint64(?MODULE:id(<<"not_a_number">>)),
+
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(-16#FFFFFFFFFFFFFFFF)),
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(-16#CAFECAFE)),
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(-42)),
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(0)),
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(42)),
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(16#CAFECAFE)),
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(16#CAFECAFEFFF)),
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(16#FFFFFFFFFFFFFFFF)),
+    true = ?MODULE:is_atomvm_integer(?MODULE:id(16#10000000000000000)),
+    false = ?MODULE:is_atomvm_integer(?MODULE:id(-1.0)),
+    false = ?MODULE:is_atomvm_integer(?MODULE:id(<<"not_a_number">>)),
+
+    int8 = ?MODULE:classify(?MODULE:id(0)),
+    int8 = ?MODULE:classify(?MODULE:id(42)),
+    int8 = ?MODULE:classify(?MODULE:id(-100)),
+    uint8 = ?MODULE:classify(?MODULE:id(255)),
+    int16 = ?MODULE:classify(?MODULE:id(-30000)),
+    uint16 = ?MODULE:classify(?MODULE:id(60000)),
+    uint32 = ?MODULE:classify(?MODULE:id(16#FFFFFFFF)),
+    int32 = ?MODULE:classify(?MODULE:id(-16#FFFFFFF)),
+    uint64 = ?MODULE:classify(?MODULE:id(16#FFFFFFFFCAFEFFFF)),
+    int64 = ?MODULE:classify(?MODULE:id(-16#FFFFFFFFA)),
+    uint256 = ?MODULE:classify(?MODULE:id(16#FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)),
+
+    ok.
+
+is_0_100(N) when is_integer(N, 0, 100) ->
+    ?MODULE:id(true);
+is_0_100(_) ->
+    false.
+
+is_uint32(N) when is_integer(N, 0, 16#FFFFFFFF) ->
+    ?MODULE:id(true);
+is_uint32(_) ->
+    false.
+
+is_uint64(N) when is_integer(N, 0, 16#FFFFFFFFFFFFFFFF) ->
+    ?MODULE:id(true);
+is_uint64(_) ->
+    false.
+
+is_atomvm_integer(N) when
+    is_integer(
+        N,
+        -16#FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+        16#FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+    )
+->
+    ?MODULE:id(true);
+is_atomvm_integer(_) ->
+    false.
+
+classify(N) when is_integer(N, -16#80, 16#7F) ->
+    int8;
+classify(N) when is_integer(N, 0, 16#FF) ->
+    uint8;
+classify(N) when is_integer(N, -16#8000, 16#7FFF) ->
+    int16;
+classify(N) when is_integer(N, 0, 16#FFFF) ->
+    uint16;
+classify(N) when is_integer(N, -16#80000000, 16#7FFFFFFF) ->
+    int32;
+classify(N) when is_integer(N, 0, 16#FFFFFFFF) ->
+    uint32;
+classify(N) when is_integer(N, -16#8000000000000000, 16#7FFFFFFFFFFFFFFF) ->
+    int64;
+classify(N) when is_integer(N, 0, 16#FFFFFFFFFFFFFFFF) ->
+    uint64;
+classify(N) when
+    is_integer(N, 0, 16#FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+->
+    uint256.
+
+test_bigint() ->
+    MaxPatternBin = <<"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF">>,
+    MaxPattern = erlang:binary_to_integer(?MODULE:id(MaxPatternBin), 16),
+
+    UINT64MaxBin = <<"FFFFFFFFFFFFFFFF">>,
+    UINT64Max = erlang:binary_to_integer(?MODULE:id(UINT64MaxBin), 16),
+
+    UINT64MaxNegBin = <<"-FFFFFFFFFFFFFFFF">>,
+    UINT64MaxNeg = erlang:binary_to_integer(?MODULE:id(UINT64MaxNegBin), 16),
+
+    INT63MaxP1Bin = <<"8000000000000000">>,
+    INT63MaxP1 = erlang:binary_to_integer(?MODULE:id(INT63MaxP1Bin), 16),
+
+    false = is_integer(?MODULE:id(MaxPattern), ?MODULE:id(0), ?MODULE:id(5)),
+    false = is_integer(?MODULE:id(MaxPattern), ?MODULE:id(5), ?MODULE:id(0)),
+    true = is_integer(?MODULE:id(MaxPattern), ?MODULE:id(0), ?MODULE:id(MaxPattern)),
+    false = is_integer(?MODULE:id(MaxPattern), ?MODULE:id(MaxPattern), ?MODULE:id(0)),
+    false = ?MODULE:is_integer_helper(MaxPattern, 0, 5),
+    false = ?MODULE:is_integer_helper(MaxPattern, 5, 0),
+    true = ?MODULE:is_integer_helper(MaxPattern, 0, MaxPattern),
+    false = ?MODULE:is_integer_helper(MaxPattern, MaxPattern, 0),
+
+    false = ?MODULE:is_integer_helper(<<"hello">>, 0, MaxPattern),
+    false = ?MODULE:is_integer_helper(MaxPattern, <<"hello">>, MaxPattern),
+    false = ?MODULE:is_integer_helper(MaxPattern, 0, <<"hello">>),
+    false = is_integer(<<"hello">>, 0, MaxPattern),
+    false = is_integer(<<"hello">>, MaxPattern, 0),
+
+    true = is_integer(?MODULE:id(UINT64Max), ?MODULE:id(0), ?MODULE:id(MaxPattern)),
+    false = is_integer(?MODULE:id(UINT64Max), ?MODULE:id(MaxPattern), ?MODULE:id(0)),
+    true = is_integer(
+        ?MODULE:id(INT63MaxP1), ?MODULE:id(UINT64MaxNeg), ?MODULE:id(MaxPattern)
+    ),
+    false = is_integer(
+        ?MODULE:id(INT63MaxP1), ?MODULE:id(MaxPattern), ?MODULE:id(UINT64MaxNeg)
+    ),
+    true = ?MODULE:is_integer_helper(UINT64Max, 0, MaxPattern),
+    false = ?MODULE:is_integer_helper(UINT64Max, MaxPattern, 0),
+    true = ?MODULE:is_integer_helper(INT63MaxP1, UINT64MaxNeg, MaxPattern),
+    false = ?MODULE:is_integer_helper(INT63MaxP1, MaxPattern, UINT64MaxNeg),
+    ok.
+
+test_errors() ->
+    exp_err =
+        try
+            is_integer(42, ?MODULE:id(foo), 100)
+        catch
+            error:badarg -> exp_err
+        end,
+    exp_err =
+        try
+            is_integer(42, 0, ?MODULE:id(<<"bar">>))
+        catch
+            error:badarg -> exp_err
+        end,
+    exp_err =
+        try
+            is_integer(<<"foo">>, ?MODULE:id(foo), 100)
+        catch
+            error:badarg -> exp_err
+        end,
+    ok.
+
+is_integer_helper(I, A, B) when is_integer(I, A, B) ->
+    _ = ?MODULE:id(I),
+    true;
+is_integer_helper(_I, _A, _B) ->
+    ?MODULE:id(false).
+
+id(X) ->
+    X.
+-else.
+
+-export([start/0]).
+
+start() ->
+    0.
+
+-endif.

--- a/tests/test.c
+++ b/tests/test.c
@@ -565,6 +565,7 @@ struct Test tests[] = {
     TEST_CASE(test_op_bs_create_bin),
 
     TEST_CASE(test_multi_value_comprehension),
+    TEST_CASE(test_is_integer_3),
 
     TEST_CASE(test_code_server_nifs),
 


### PR DESCRIPTION
OTP-29 introduces is_integer/3 BIF, so in order to support it we have introduced it as well.

- bif.c implements the new BIF. It checks first small integers in order to provide best performance with them.

- opcodesswitch.h: has been updated to support the new opcode for calling BIFs with 3 arguments, such as `is_integer/3`.

- intn has been changed in order to provide a helper for signed big integers comparison (now we have `intn_cmpu` and `intn_cmp`).

- README and documentation has been updated with OTP-29 support.

Closes #2114 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
