### PR TITLE
JIT x86: optimizations to movl immediate

### DIFF
--- a/libs/jit/src/jit_x86_64_asm.erl
+++ b/libs/jit/src/jit_x86_64_asm.erl
@@ -278,6 +278,11 @@ movabsq(Imm, Reg) when is_atom(Reg) ->
         {1, Index} -> <<16#49, (16#B8 + Index), Imm:64/little>>
     end.
 
+movl(Imm, DestReg) when is_integer(Imm), is_atom(DestReg) ->
+    case x86_64_x_reg(DestReg) of
+        {0, Index} -> <<(16#B8 + Index), Imm:32/little>>;
+        {1, Index} -> <<16#41, (16#B8 + Index), Imm:32/little>>
+    end;
 movl({0, SrcReg}, DestReg) when is_atom(SrcReg), is_atom(DestReg) ->
     {REX_B, MODRM_RM} = x86_64_x_reg(SrcReg),
     {REX_R, MODRM_REG} = x86_64_x_reg(DestReg),

--- a/tests/libs/jit/jit_x86_64_asm_tests.erl
+++ b/tests/libs/jit/jit_x86_64_asm_tests.erl
@@ -258,6 +258,34 @@ movabsq_test_() ->
 
 movl_test_() ->
     [
+        % movl(Imm, DestReg) - immediate to register (5 bytes for low regs, 6 for high)
+        ?_assertAsmEqual(
+            <<16#BA, 16#04, 16#00, 16#00, 16#00>>,
+            "movl $0x4,%edx",
+            jit_x86_64_asm:movl(4, rdx)
+        ),
+        ?_assertAsmEqual(
+            <<16#B9, 16#09, 16#00, 16#00, 16#00>>,
+            "movl $0x9,%ecx",
+            jit_x86_64_asm:movl(9, rcx)
+        ),
+        ?_assertAsmEqual(
+            <<16#B8, 16#78, 16#56, 16#34, 16#12>>,
+            "movl $0x12345678,%eax",
+            jit_x86_64_asm:movl(16#12345678, rax)
+        ),
+        ?_assertAsmEqual(
+            <<16#41, 16#B8, 16#78, 16#56, 16#34, 16#12>>,
+            "movl $0x12345678,%r8d",
+            jit_x86_64_asm:movl(16#12345678, r8)
+        ),
+        ?_assertAsmEqual(
+            <<16#41, 16#BB, 16#78, 16#56, 16#34, 16#12>>,
+            "movl $0x12345678,%r11d",
+            jit_x86_64_asm:movl(16#12345678, r11)
+        ),
+
+        % movl({0, SrcReg}, DestReg) - memory to register
         ?_assertAsmEqual(<<16#8b, 16#00>>, "movl (%rax),%eax", jit_x86_64_asm:movl({0, rax}, rax)),
         ?_assertAsmEqual(<<16#8b, 16#01>>, "movl (%rcx),%eax", jit_x86_64_asm:movl({0, rcx}, rax)),
         ?_assertAsmEqual(<<16#8b, 16#09>>, "movl (%rcx),%ecx", jit_x86_64_asm:movl({0, rcx}, rcx)),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
