### PR TITLE
Add missing declarations for nifs/bifs in erlang module

### DIFF
--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -135,7 +135,38 @@
     dist_ctrl_put_data/2,
     unique_integer/0,
     unique_integer/1,
-    raise/3
+    raise/3,
+    abs/1,
+    byte_size/1,
+    element/2,
+    error/1,
+    error/2,
+    hd/1,
+    is_atom/1,
+    is_binary/1,
+    is_boolean/1,
+    is_float/1,
+    is_function/1,
+    is_function/2,
+    is_integer/1,
+    is_integer/3,
+    is_list/1,
+    is_number/1,
+    is_pid/1,
+    is_reference/1,
+    is_tuple/1,
+    length/1,
+    list_to_float/1,
+    node/0,
+    round/1,
+    self/0,
+    setelement/3,
+    size/1,
+    throw/1,
+    tl/1,
+    trunc/1,
+    tuple_size/1,
+    tuple_to_list/1
 ]).
 
 -export_type([
@@ -371,7 +402,7 @@ system_flag(_Key, _Value) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec md5(Data :: binary()) -> binary().
-md5(Data) when is_binary(Data) ->
+md5(Data) when erlang:is_binary(Data) ->
     crypto:hash(md5, Data).
 
 %%-----------------------------------------------------------------------------
@@ -408,7 +439,7 @@ apply(Module, Function, Args) ->
         [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6] ->
             Module:Function(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6);
         _ ->
-            error(badarg)
+            erlang:error(badarg)
     end.
 
 %%-----------------------------------------------------------------------------
@@ -443,7 +474,7 @@ apply(Function, Args) ->
         [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6] ->
             Function(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6);
         _ ->
-            error(badarg)
+            erlang:error(badarg)
     end.
 
 %%-----------------------------------------------------------------------------
@@ -1479,7 +1510,7 @@ setnode(_TargetNode, _ConnPid, _TargetFlagsCreation) ->
 %% @end
 -spec is_alive() -> boolean().
 is_alive() ->
-    node() =/= nonode@nohost.
+    erlang:node() =/= nonode@nohost.
 
 %% @hidden
 -spec dist_ctrl_get_data_notification(binary()) -> ok.
@@ -1582,14 +1613,385 @@ nif_error(_Reason) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
-%% @param   Options list of options.
-%% @returns a unique integer
-%% @doc     Return a unique integer. If positive is passed, returned integer is
-%%          positive. If monotonic is passed, returned integer is monotonically increasing
-%%          across all processes.
+%% @param   Class exception class to raise
+%% @param   Reason reason of the exception
+%% @param   Stacktrace list as provided by a try/catch clause
+%% @returns badarg if arguments are invalid
+%% @doc     Raise an exception of the specified class or return badarg if
+%%          arguments are invalid. To be sure to not return, the pattern
+%%          `error(erlang:raise(Class, Reason, Stacktrace))' is common.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec raise(error | exit | throw, Reason :: term(), Stacktrace :: raise_stacktrace()) ->
-    no_return().
+    badarg.
 raise(_Class, _Reason, _Stacktrace) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Number  the number to get the absolute value of
+%% @returns the absolute value of `Number'
+%% @doc     Return the absolute value of `Number'.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec abs(Number) -> Number when Number :: number().
+abs(_Number) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Bitstring  the bitstring to get the byte size of
+%% @returns the number of bytes needed to contain `Bitstring'
+%% @doc     Return the number of bytes needed to contain `Bitstring'.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec byte_size(Bitstring :: bitstring()) -> non_neg_integer().
+byte_size(_Bitstring) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   N       the one-based index of the element to return
+%% @param   Tuple   the tuple from which to get the element
+%% @returns the element at the given one-based index in the tuple
+%% @doc     Return the element at the given one-based index in a tuple.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec element(N :: pos_integer(), Tuple :: tuple()) -> term().
+element(_N, _Tuple) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Reason  the reason for the error
+%% @doc     Raises an exception of class `error' with reason `Reason'.
+%%
+%% The stacktrace is automatically added.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec error(Reason :: term()) -> no_return().
+error(_Reason) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Reason  the reason for the error
+%% @param   Args    the argument list, or a list of extra error information
+%% @doc     Raises an exception of class `error' with reason `Reason' and
+%%          arguments or extra error info `Args'.
+%%
+%% The stacktrace is automatically added.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec error(Reason :: term(), Args :: [term()] | none) -> no_return().
+error(_Reason, _Args) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   List    a nonempty list
+%% @returns the first element (head) of the list
+%% @doc     Return the first element of a list.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec hd(List :: nonempty_list()) -> term().
+hd(_List) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is an atom; `false', otherwise.
+%% @doc     Return `true' if `Term' is an atom; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_atom(Term :: term()) -> boolean().
+is_atom(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a binary; `false', otherwise.
+%% @doc     Return `true' if `Term' is a binary; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_binary(Term :: term()) -> boolean().
+is_binary(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a boolean (`true' or `false'); `false', otherwise.
+%% @doc     Return `true' if `Term' is a boolean; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_boolean(Term :: term()) -> boolean().
+is_boolean(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a float; `false', otherwise.
+%% @doc     Return `true' if `Term' is a floating point number; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_float(Term :: term()) -> boolean().
+is_float(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a function; `false', otherwise.
+%% @doc     Return `true' if `Term' is a function; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_function(Term :: term()) -> boolean().
+is_function(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term    the term to test
+%% @param   Arity   the expected arity
+%% @returns `true' if `Term' is a function with arity `Arity'; `false', otherwise.
+%% @doc     Return `true' if `Term' is a function with the given arity; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_function(Term :: term(), Arity :: non_neg_integer()) -> boolean().
+is_function(_Term, _Arity) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is an integer; `false', otherwise.
+%% @doc     Return `true' if `Term' is an integer; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_integer(Term :: term()) -> boolean().
+is_integer(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @param   LB    lower bound
+%% @param   LB    upper bound
+%% @returns `true' if `Term' is an integer between `LB` and `UB` inclusive,
+%%          `false', otherwise.
+%% @doc     Return `true' if `Term' is an integer between `LB` and `UB`
+%%          inclusive; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_integer(Term :: term(), LB :: integer(), UB :: integer()) -> boolean().
+is_integer(_Term, _LB, _UB) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a list (including the empty list); `false', otherwise.
+%% @doc     Return `true' if `Term' is a list; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_list(Term :: term()) -> boolean().
+is_list(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a number (integer or float); `false', otherwise.
+%% @doc     Return `true' if `Term' is a number; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_number(Term :: term()) -> boolean().
+is_number(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a pid; `false', otherwise.
+%% @doc     Return `true' if `Term' is a process identifier; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_pid(Term :: term()) -> boolean().
+is_pid(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a reference; `false', otherwise.
+%% @doc     Return `true' if `Term' is a reference; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_reference(Term :: term()) -> boolean().
+is_reference(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term  the term to test
+%% @returns `true' if `Term' is a tuple; `false', otherwise.
+%% @doc     Return `true' if `Term' is a tuple; `false', otherwise.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_tuple(Term :: term()) -> boolean().
+is_tuple(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   List  the list to get the length of
+%% @returns the length of the list
+%% @doc     Return the length of a list.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec length(List :: list()) -> non_neg_integer().
+length(_List) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   String  a string representation of a float
+%% @returns the float represented by the string
+%% @doc     Parse a string to a floating point number.
+%% Errors with `badarg' if the string is not a valid float representation.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec list_to_float(String :: string()) -> float().
+list_to_float(_String) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns the node name of the local node
+%% @doc     Return the name of the local node.
+%% If the node is not alive, `nonode@nohost' is returned.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec node() -> node().
+node() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Number  the number to round
+%% @returns `Number' rounded to the nearest integer
+%% @doc     Return the integer closest to `Number'.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec round(Number :: number()) -> integer().
+round(_Number) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns the pid of the calling process
+%% @doc     Return the pid of the calling process.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec self() -> pid().
+self() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Index   the one-based index of the element to replace
+%% @param   Tuple   the original tuple
+%% @param   Value   the new value to set
+%% @returns a new tuple with the element at position `Index' replaced by `Value'
+%% @doc     Return a new tuple with element at `Index' replaced by `Value'.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec setelement(Index :: pos_integer(), Tuple :: tuple(), Value :: term()) -> tuple().
+setelement(_Index, _Tuple, _Value) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   TupleOrBinary  a tuple or a binary
+%% @returns the size of the tuple or binary
+%% @doc     Return the size of a tuple or binary.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec size(TupleOrBinary :: tuple() | binary()) -> non_neg_integer().
+size(_TupleOrBinary) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Reason  the reason for the exception
+%% @doc     Raises an exception of class `throw' with reason `Reason'.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec throw(Reason :: term()) -> no_return().
+throw(_Reason) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   List    a nonempty list
+%% @returns the tail of the list (all elements except the first)
+%% @doc     Return the tail of a list (the list without its first element).
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec tl(List :: nonempty_list()) -> term().
+tl(_List) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Number  the number to truncate
+%% @returns the integer part of `Number'
+%% @doc     Return the integer part of `Number' by truncating towards zero.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec trunc(Number :: number()) -> integer().
+trunc(_Number) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Tuple  the tuple to get the size of
+%% @returns the number of elements in the tuple
+%% @doc     Return the number of elements in a tuple.
+%%
+%% This function may be used in a guard expression.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec tuple_size(Tuple :: tuple()) -> non_neg_integer().
+tuple_size(_Tuple) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Tuple  the tuple to convert
+%% @returns a list containing the elements of the tuple
+%% @doc     Convert a tuple to a list of its elements.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec tuple_to_list(Tuple :: tuple()) -> [term()].
+tuple_to_list(_Tuple) ->
     erlang:nif_error(undefined).

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -18,6 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
+/**
+ * When adding a new function here, add also doc + typespec + function stub that
+ * calls erlang:nif_error(undefined).
+ */
+
 %readonly-tables
 
 %{

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -18,6 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
+/**
+ * When adding a new function here, add also doc + typespec + function stub that
+ * calls erlang:nif_error(undefined).
+ */
+
 %readonly-tables
 %define lookup-function-name nif_in_word_set
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -238,6 +238,7 @@ compile_erlang(prime_ext)
 compile_erlang(prime_smp)
 compile_erlang(test_try_case_end)
 compile_erlang(test_exception_classes)
+compile_erlang(test_erlang_builtins)
 compile_erlang(test_recursion_and_try_catch)
 compile_erlang(test_fun_info)
 compile_erlang(test_func_info)
@@ -787,6 +788,7 @@ set(erlang_test_beams
     prime_smp.beam
     test_try_case_end.beam
     test_exception_classes.beam
+    test_erlang_builtins.beam
     test_recursion_and_try_catch.beam
     test_fun_info.beam
     test_func_info.beam

--- a/tests/erlang_tests/test_erlang_builtins.erl
+++ b/tests/erlang_tests/test_erlang_builtins.erl
@@ -1,0 +1,223 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_erlang_builtins).
+
+-export([start/0, id/1]).
+
+start() ->
+    ok = test_abs(),
+    ok = test_byte_size(),
+    ok = test_element(),
+    ok = test_error(),
+    ok = test_error2(),
+    ok = test_hd(),
+    ok = test_is_atom(),
+    ok = test_is_binary(),
+    ok = test_is_boolean(),
+    ok = test_is_float(),
+    ok = test_is_function(),
+    ok = test_is_function2(),
+    ok = test_is_integer(),
+    ok = test_is_list(),
+    ok = test_is_number(),
+    ok = test_is_pid(),
+    ok = test_is_reference(),
+    ok = test_is_tuple(),
+    ok = test_length(),
+    ok = test_list_to_float(),
+    ok = test_node(),
+    ok = test_round(),
+    ok = test_self(),
+    ok = test_setelement(),
+    ok = test_size(),
+    ok = test_throw(),
+    ok = test_tl(),
+    ok = test_trunc(),
+    ok = test_tuple_size(),
+    ok = test_tuple_to_list(),
+    0.
+
+id(X) -> X.
+
+test_abs() ->
+    3 = erlang:abs(id(-3)),
+    3 = erlang:abs(id(3)),
+    2.5 = erlang:abs(id(-2.5)),
+    ok.
+
+test_byte_size() ->
+    5 = erlang:byte_size(id(<<"hello">>)),
+    0 = erlang:byte_size(id(<<>>)),
+    ok.
+
+test_element() ->
+    a = erlang:element(1, id({a, b, c})),
+    c = erlang:element(3, id({a, b, c})),
+    ok.
+
+test_error() ->
+    try
+        erlang:error(id(test_reason))
+    catch
+        error:test_reason -> ok
+    end.
+
+test_error2() ->
+    try
+        erlang:error(id(test_reason), id([arg1]))
+    catch
+        error:test_reason -> ok
+    end.
+
+test_hd() ->
+    1 = erlang:hd(id([1, 2, 3])),
+    a = erlang:hd(id([a])),
+    ok.
+
+test_is_atom() ->
+    true = erlang:is_atom(id(hello)),
+    false = erlang:is_atom(id(42)),
+    ok.
+
+test_is_binary() ->
+    true = erlang:is_binary(id(<<"hello">>)),
+    false = erlang:is_binary(id(42)),
+    ok.
+
+test_is_boolean() ->
+    true = erlang:is_boolean(id(true)),
+    true = erlang:is_boolean(id(false)),
+    false = erlang:is_boolean(id(hello)),
+    ok.
+
+test_is_float() ->
+    true = erlang:is_float(id(1.0)),
+    false = erlang:is_float(id(1)),
+    ok.
+
+test_is_function() ->
+    true = erlang:is_function(id(fun id/1)),
+    false = erlang:is_function(id(42)),
+    ok.
+
+test_is_function2() ->
+    true = erlang:is_function(id(fun id/1), id(1)),
+    false = erlang:is_function(id(fun id/1), id(2)),
+    false = erlang:is_function(id(42), id(1)),
+    ok.
+
+test_is_integer() ->
+    true = erlang:is_integer(id(42)),
+    false = erlang:is_integer(id(1.0)),
+    ok.
+
+test_is_list() ->
+    true = erlang:is_list(id([1, 2, 3])),
+    true = erlang:is_list(id([])),
+    false = erlang:is_list(id(42)),
+    ok.
+
+test_is_number() ->
+    true = erlang:is_number(id(42)),
+    true = erlang:is_number(id(1.0)),
+    false = erlang:is_number(id(hello)),
+    ok.
+
+test_is_pid() ->
+    true = erlang:is_pid(id(self())),
+    false = erlang:is_pid(id(42)),
+    ok.
+
+test_is_reference() ->
+    true = erlang:is_reference(id(make_ref())),
+    false = erlang:is_reference(id(42)),
+    ok.
+
+test_is_tuple() ->
+    true = erlang:is_tuple(id({a, b})),
+    false = erlang:is_tuple(id(42)),
+    ok.
+
+test_length() ->
+    3 = erlang:length(id([a, b, c])),
+    0 = erlang:length(id([])),
+    ok.
+
+test_list_to_float() ->
+    F = erlang:list_to_float(id("1.5")),
+    true = erlang:is_float(F),
+    true = (F > 1.4 andalso F < 1.6),
+    ok.
+
+test_node() ->
+    Node = erlang:node(),
+    true = erlang:is_atom(Node),
+    ok.
+
+test_round() ->
+    2 = erlang:round(id(1.6)),
+    1 = erlang:round(id(1.4)),
+    -2 = erlang:round(id(-1.6)),
+    5 = erlang:round(id(5)),
+    ok.
+
+test_self() ->
+    Pid = erlang:self(),
+    true = erlang:is_pid(Pid),
+    ok.
+
+test_setelement() ->
+    {x, b, c} = erlang:setelement(1, id({a, b, c}), id(x)),
+    {a, x, c} = erlang:setelement(2, id({a, b, c}), id(x)),
+    ok.
+
+test_size() ->
+    3 = erlang:size(id({a, b, c})),
+    5 = erlang:size(id(<<"hello">>)),
+    ok.
+
+test_throw() ->
+    try
+        erlang:throw(id(test_value))
+    catch
+        throw:test_value -> ok
+    end.
+
+test_tl() ->
+    [2, 3] = erlang:tl(id([1, 2, 3])),
+    [] = erlang:tl(id([a])),
+    ok.
+
+test_trunc() ->
+    1 = erlang:trunc(id(1.9)),
+    -1 = erlang:trunc(id(-1.9)),
+    5 = erlang:trunc(id(5)),
+    ok.
+
+test_tuple_size() ->
+    3 = erlang:tuple_size(id({a, b, c})),
+    0 = erlang:tuple_size(id({})),
+    ok.
+
+test_tuple_to_list() ->
+    [a, b, c] = erlang:tuple_to_list(id({a, b, c})),
+    [] = erlang:tuple_to_list(id({})),
+    ok.

--- a/tests/test.c
+++ b/tests/test.c
@@ -214,6 +214,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(prime_ext, 1999),
     TEST_CASE_EXPECTED(test_try_case_end, 256),
     TEST_CASE(test_exception_classes),
+    TEST_CASE(test_erlang_builtins),
     TEST_CASE_EXPECTED(test_recursion_and_try_catch, 3628800),
     TEST_CASE(test_fun_info),
     TEST_CASE_EXPECTED(test_func_info, 89),


### PR DESCRIPTION
Also fix documentation for `erlang:raise/3`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
