### PR TITLE
Add binary:list_to_bin/1 for Kernel.ex support

### DIFF
--- a/libs/estdlib/src/binary.erl
+++ b/libs/estdlib/src/binary.erl
@@ -30,6 +30,7 @@
     copy/1, copy/2,
     decode_hex/1,
     encode_hex/1, encode_hex/2,
+    list_to_bin/1,
     part/3,
     split/2, split/3,
     match/2, match/3,
@@ -130,6 +131,17 @@ match(_Binary, _Pattern) ->
     {non_neg_integer(), non_neg_integer()} | nomatch.
 match(_Binary, _Pattern, _Options) ->
     erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   ByteList iolist to convert to binary
+%% @returns binary representation of ByteList
+%% @doc     Works exactly as {@link erlang:list_to_binary/1}.
+%%          This function is provided for completeness.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec list_to_bin(ByteList :: iolist()) -> binary().
+list_to_bin(_ByteList) ->
+    erlang:nif_error(undef).
 
 %%-----------------------------------------------------------------------------
 %% @param   Binary binary to extract a subbinary from

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -43,6 +43,7 @@ binary:replace/3, &binary_replace_nif
 binary:replace/4, &binary_replace_nif
 binary:match/2, &binary_match_nif
 binary:match/3, &binary_match_nif
+binary:list_to_bin/1, &list_to_binary_nif
 calendar:system_time_to_universal_time/2, &system_time_to_universal_time_nif
 os:getenv/1, &os_getenv_nif
 os:system_time/0, &system_time_nif

--- a/tests/libs/estdlib/test_binary.erl
+++ b/tests/libs/estdlib/test_binary.erl
@@ -27,6 +27,7 @@
 test() ->
     ok = test_split(),
     ok = test_hex(),
+    ok = test_list_to_bin(),
     ok.
 
 test_split() ->
@@ -34,6 +35,12 @@ test_split() ->
     ?ASSERT_MATCH(binary:split(<<"foobar">>, <<"ooz">>), [<<"foobar">>]),
     ?ASSERT_MATCH(binary:split(<<"foobar">>, <<"o">>), [<<"f">>, <<"obar">>]),
     ?ASSERT_MATCH(binary:split(<<"foobar">>, <<"o">>, [global]), [<<"f">>, <<>>, <<"bar">>]),
+    ok.
+
+test_list_to_bin() ->
+    ?ASSERT_MATCH(binary:list_to_bin([]), <<>>),
+    ?ASSERT_MATCH(binary:list_to_bin([104, 101, 108, 108, 111]), <<"hello">>),
+    ?ASSERT_MATCH(binary:list_to_bin([<<"hel">>, [108, 111]]), <<"hello">>),
     ok.
 
 test_hex() ->


### PR DESCRIPTION
Full Kernel.ex uses :binary.list_to_bin/1 for regex: https://github.com/elixir-lang/elixir/blob/0df45fdba16e6ab8f59a30e9f0c1e281a24c7ef2/lib/elixir/lib/kernel.ex#L6658 even though it's identical to :erlang.list_to_binary/1

So let's add small implementation/route for that..

- Add `binary:list_to_bin/1` NIF routed to the existing `nif_erlang_list_to_binary_1` implementation via `nifs.gperf`
- Export and stub `list_to_bin/1` in `libs/estdlib/src/binary.erl`
- Add tests in `tests/libs/estdlib/test_binary.erl`

Elixir's `Kernel.ex` makes four calls into the `:binary` module: `:binary.match/2`, `:binary.split/3`, `:binary.last/1`, and `:binary.list_to_bin/1`. The first three were already supported; this PR adds the missing `list_to_bin/1`, completing full `:binary` coverage for `Kernel.ex`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
