### PR TITLE
Add binary:longest_common_prefix/1 NIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added WiFi support for ESP32P4 via esp-wifi-external for build with ESP-IDF v5.4 and later
 - Added Process.link/1 and unlink/1 to Elixir Process.ex
 - Added `erlang:module_loaded/1`
+- Added `binary:longest_common_prefix/1`
 - Added `binary:replace/3`, `binary:replace/4`
 - Added `binary:match/2` and `binary:match/3`
 - Added `supervisor:which_children/1` and `supervisor:count_children/1`

--- a/libs/estdlib/src/binary.erl
+++ b/libs/estdlib/src/binary.erl
@@ -31,6 +31,7 @@
     decode_hex/1,
     encode_hex/1, encode_hex/2,
     list_to_bin/1,
+    longest_common_prefix/1,
     part/3,
     split/2, split/3,
     match/2, match/3,
@@ -104,6 +105,17 @@ encode_hex(Data, uppercase) ->
     <<(integer_to_binary(B, 16)) || <<B:4>> <= Data>>;
 encode_hex(Data, lowercase) ->
     <<<<(hd(string:to_lower(integer_to_list(B, 16)))):8>> || <<B:4>> <= Data>>.
+
+%%-----------------------------------------------------------------------------
+%% @param   Binaries non-empty list of binaries
+%% @returns length of the longest common prefix of all binaries in the list
+%% @doc     Returns the length of the longest common prefix of the binaries in
+%%          the list.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec longest_common_prefix(Binaries :: [binary(), ...]) -> non_neg_integer().
+longest_common_prefix(_Binaries) ->
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @equiv match(Binary, Pattern, [])

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -158,6 +158,7 @@ static term nif_binary_part_3(Context *ctx, int argc, term argv[]);
 static term nif_binary_split(Context *ctx, int argc, term argv[]);
 static term nif_binary_replace(Context *ctx, int argc, term argv[]);
 static term nif_binary_match(Context *ctx, int argc, term argv[]);
+static term nif_binary_longest_common_prefix_1(Context *ctx, int argc, term argv[]);
 static term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term argv[]);
 static term nif_os_getenv_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_delete_element_2(Context *ctx, int argc, term argv[]);
@@ -346,6 +347,11 @@ static const struct Nif binary_replace_nif = {
 static const struct Nif binary_match_nif = {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_binary_match
+};
+
+static const struct Nif binary_longest_common_prefix_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_binary_longest_common_prefix_1
 };
 
 static const struct Nif make_ref_nif = {
@@ -3705,6 +3711,42 @@ static term nif_binary_match(Context *ctx, int argc, term argv[])
     term_put_tuple_element(result_tuple, 0, term_from_int(match_slice.pos));
     term_put_tuple_element(result_tuple, 1, term_from_int(match_slice.len));
     return result_tuple;
+}
+
+static term nif_binary_longest_common_prefix_1(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term list = argv[0];
+    VALIDATE_VALUE(list, term_is_nonempty_list);
+
+    term first_term = term_get_list_head(list);
+    VALIDATE_VALUE(first_term, term_is_binary);
+
+    size_t prefix_len = term_binary_size(first_term);
+    const uint8_t *first_data = (const uint8_t *) term_binary_data(first_term);
+
+    term rest = term_get_list_tail(list);
+    while (term_is_nonempty_list(rest)) {
+        term bin_term = term_get_list_head(rest);
+        VALIDATE_VALUE(bin_term, term_is_binary);
+
+        size_t bin_size = term_binary_size(bin_term);
+        const uint8_t *bin_data = (const uint8_t *) term_binary_data(bin_term);
+        size_t max_common = (bin_size < prefix_len) ? bin_size : prefix_len;
+
+        size_t common = 0;
+        while (common < max_common && first_data[common] == bin_data[common]) {
+            common++;
+        }
+        prefix_len = common;
+
+        rest = term_get_list_tail(rest);
+    }
+
+    VALIDATE_VALUE(rest, term_is_nil);
+
+    return term_from_int(prefix_len);
 }
 
 static term nif_erlang_throw(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -44,6 +44,7 @@ binary:replace/4, &binary_replace_nif
 binary:match/2, &binary_match_nif
 binary:match/3, &binary_match_nif
 binary:list_to_bin/1, &list_to_binary_nif
+binary:longest_common_prefix/1, &binary_longest_common_prefix_nif
 calendar:system_time_to_universal_time/2, &system_time_to_universal_time_nif
 os:getenv/1, &os_getenv_nif
 os:system_time/0, &system_time_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -354,6 +354,7 @@ compile_erlang(test_binary_split)
 compile_erlang(test_split_binary)
 compile_erlang(test_binary_replace)
 compile_erlang(test_binary_match)
+compile_erlang(test_binary_longest_common_prefix)
 
 compile_erlang(test_zlib_compress)
 
@@ -903,6 +904,7 @@ set(erlang_test_beams
     test_split_binary.beam
     test_binary_replace.beam
     test_binary_match.beam
+    test_binary_longest_common_prefix.beam
 
     test_zlib_compress.beam
 

--- a/tests/erlang_tests/test_binary_longest_common_prefix.erl
+++ b/tests/erlang_tests/test_binary_longest_common_prefix.erl
@@ -1,0 +1,82 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Peter M <petermm@gmail.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_binary_longest_common_prefix).
+
+-export([start/0, id/1, fail_with_badarg/1]).
+-define(ID(Arg), ?MODULE:id(Arg)).
+
+start() ->
+    % Basic cases: two binaries with a common prefix
+    2 = binary:longest_common_prefix(?ID([<<"erlang">>, <<"ergonomy">>])),
+    0 = binary:longest_common_prefix(?ID([<<"erlang">>, <<"foo">>])),
+    6 = binary:longest_common_prefix(?ID([<<"erlang">>, <<"erlang">>])),
+
+    % One binary shorter than prefix
+    3 = binary:longest_common_prefix(?ID([<<"foobar">>, <<"foo">>])),
+    3 = binary:longest_common_prefix(?ID([<<"foo">>, <<"foobar">>])),
+
+    % Single-element list: returns length of that binary
+    6 = binary:longest_common_prefix(?ID([<<"erlang">>])),
+    0 = binary:longest_common_prefix(?ID([<<>>])),
+
+    % Empty binaries in the list
+    0 = binary:longest_common_prefix(?ID([<<>>, <<"erlang">>])),
+    0 = binary:longest_common_prefix(?ID([<<"erlang">>, <<>>])),
+    0 = binary:longest_common_prefix(?ID([<<>>, <<>>])),
+
+    % More than two binaries
+    2 = binary:longest_common_prefix(?ID([<<"erlang">>, <<"ergonomy">>, <<"ermine">>])),
+    0 = binary:longest_common_prefix(?ID([<<"erlang">>, <<"ergonomy">>, <<"foo">>])),
+    5 = binary:longest_common_prefix(?ID([<<"hello">>, <<"hello">>, <<"hello">>])),
+
+    % All identical
+    4 = binary:longest_common_prefix(?ID([<<"test">>, <<"test">>, <<"test">>])),
+
+    % Prefix is full match for some but not others
+    3 = binary:longest_common_prefix(?ID([<<"abc">>, <<"abcdef">>])),
+    3 = binary:longest_common_prefix(?ID([<<"abcdef">>, <<"abc">>])),
+
+    % Error cases: empty list is badarg
+    ok = fail_with_badarg(fun() -> binary:longest_common_prefix(?ID([])) end),
+
+    % Error cases: not a list
+    ok = fail_with_badarg(fun() -> binary:longest_common_prefix(?ID(not_a_list)) end),
+    ok = fail_with_badarg(fun() -> binary:longest_common_prefix(?ID(42)) end),
+
+    % Error cases: list contains non-binary
+    ok = fail_with_badarg(fun() -> binary:longest_common_prefix(?ID([<<"ok">>, not_a_binary])) end),
+    ok = fail_with_badarg(fun() -> binary:longest_common_prefix(?ID([not_a_binary, <<"ok">>])) end),
+    ok = fail_with_badarg(fun() -> binary:longest_common_prefix(?ID([42])) end),
+
+    % Error cases: improper list
+    ok = fail_with_badarg(fun() -> binary:longest_common_prefix(?ID([<<"a">> | <<"b">>])) end),
+
+    0.
+
+id(X) -> X.
+
+fail_with_badarg(Fun) ->
+    try Fun() of
+        Ret -> {unexpected, Ret}
+    catch
+        error:badarg -> ok;
+        C:E -> {unexpected, C, E}
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -328,6 +328,7 @@ struct Test tests[] = {
     TEST_CASE(test_split_binary),
     TEST_CASE(test_binary_replace),
     TEST_CASE(test_binary_match),
+    TEST_CASE(test_binary_longest_common_prefix),
 
     TEST_CASE(test_zlib_compress),
 


### PR DESCRIPTION
According to my somewhat thorough research this is the only missing NIF in the code path for IEX autocomplete.

I would totally accept this not landing, if it's deemed outside scope..
LLM suggested the function could also be useful for matching MQTT topics etc, but immediate benefit is enabling IEX autocomplete, and such - perhaps useful for the AtomVM editor/simulator in the browser;-)

Implement binary:longest_common_prefix/1 as a NIF, matching OTP behavior. Returns the length of the longest common byte prefix across a list of binaries.

Pure linear scan with no heap allocation — just compares bytes and returns an integer Uses memcmp fast path with byte-level fallback
Validates input: raises badarg for empty lists, non-binaries, and improper lists

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
