### PR TITLE
Fix REGISTER_PORT_COLLECTION and details in build-instructions.md

### DIFF
--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -782,8 +782,9 @@ To add support for a new peripheral or protocol using an AtomVM port, you need t
   * `void <moniker>_init(GlobalContext *global);`
     * This function will be called once, when the application is started.
   * `Context *<moniker>_create_port(GlobalContext *global, term opts);`
-    * This function will be called to locate the Nif during a function call.
-    Example:
+    * This function is called when the `erlang:open_port/2` function is called with your
+    port name.  For example: `open_port({spawn, "my_port"}, []).`
+    * `<moniker>_init` and `<moniker>_create_port` function declarations:
 
     ```c
         void my_port_init(GlobalContext *global);
@@ -794,10 +795,10 @@ To add support for a new peripheral or protocol using an AtomVM port, you need t
     Instructions for implementing Ports is outside of the scope of this document.
     ```
 
-* Add the `REGISTER_PORT_COLLECTION` using the parameters `NAME`, `INIT_CB`, `DESTROY_CB`, `RESOLVE_NIF_CB` macro to the end of your nif code. Example:
+* Add the `REGISTER_PORT_DRIVER` using the parameters `NAME`, `INIT_CB`, `DESTROY_CB`, `CREATE_PORT_CB` macro to the end of your port code. Example:
 
     ```c
-        REGISTER_PORT_COLLECTION(my_port, my_port_init, NULL, my_port_create_port);
+        REGISTER_PORT_DRIVER(my_port, my_port_init, NULL, my_port_create_port);
     ```
 
 


### PR DESCRIPTION
This fixes an error build-instructions where REGISTER_PORT_COLLECTION should be REGISTER_PORT_DRIVER.

It also fixes some details about the callback functions for REGISTER_PORT_DRIVER.  Let me know if I got any of the details wrong or if there are any problems.

Thank you for the great project.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
