### PR TITLE
Fix: broken builds - back out prune

### DIFF
--- a/CMakeModules/BuildElixir.cmake
+++ b/CMakeModules/BuildElixir.cmake
@@ -81,6 +81,10 @@ macro(pack_runnable avm_name main)
     else()
         set(INCLUDE_LINES "")
     endif()
+    set(PACKBEAM_PRUNE_ARGS "")
+    if(AVM_PRUNE_RUNNABLES)
+        set(PACKBEAM_PRUNE_ARGS "-p")
+    endif()
 
     foreach(archive_name ${ARGN})
         if(${archive_name} STREQUAL "exavmlib")
@@ -94,7 +98,7 @@ macro(pack_runnable avm_name main)
     add_custom_command(
         OUTPUT ${avm_name}.avm
         DEPENDS ${avm_name}_main ${ARCHIVE_TARGETS} PackBEAM Elixir.${main}.beam ${ARCHIVES}
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create -s Elixir.${main} ${INCLUDE_LINES} ${avm_name}.avm Elixir.${main}.beam ${ARCHIVES}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create ${PACKBEAM_PRUNE_ARGS} -s Elixir.${main} ${INCLUDE_LINES} ${avm_name}.avm Elixir.${main}.beam ${ARCHIVES}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
     )

--- a/CMakeModules/BuildErlang.cmake
+++ b/CMakeModules/BuildErlang.cmake
@@ -285,11 +285,15 @@ macro(pack_runnable avm_name main)
     else()
         set(INCLUDE_LINES "")
     endif()
+    set(PACKBEAM_PRUNE_ARGS "")
+    if(AVM_PRUNE_RUNNABLES)
+        set(PACKBEAM_PRUNE_ARGS "-p")
+    endif()
 
     add_custom_command(
         OUTPUT ${avm_name}.avm
         DEPENDS ${avm_name}_main ${main}.beam ${pack_runnable_${avm_name}_archives} ${pack_runnable_${avm_name}_archive_targets} PackBEAM
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create -s ${main} ${INCLUDE_LINES} ${avm_name}.avm ${main}.beam ${pack_runnable_${avm_name}_archives}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create ${PACKBEAM_PRUNE_ARGS} -s ${main} ${INCLUDE_LINES} ${avm_name}.avm ${main}.beam ${pack_runnable_${avm_name}_archives}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
     )
@@ -417,11 +421,15 @@ macro(pack_uf2 avm_name main)
     else()
         set(INCLUDE_LINES "")
     endif()
+    set(PACKBEAM_PRUNE_ARGS "")
+    if(AVM_PRUNE_RUNNABLES)
+        set(PACKBEAM_PRUNE_ARGS "-p")
+    endif()
 
     add_custom_command(
         OUTPUT ${avm_name}.avm
         DEPENDS ${avm_name}_main ${main}.beam ${pack_uf2_${avm_name}_archives} ${pack_uf2_${avm_name}_archive_targets} PackBEAM
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create ${INCLUDE_LINES} -s ${main} ${avm_name}.avm ${main}.beam ${pack_uf2_${avm_name}_archives}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create ${INCLUDE_LINES} ${PACKBEAM_PRUNE_ARGS} -s ${main} ${avm_name}.avm ${main}.beam ${pack_uf2_${avm_name}_archives}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
     )

--- a/CMakeModules/BuildGleam.cmake
+++ b/CMakeModules/BuildGleam.cmake
@@ -59,6 +59,10 @@ macro(pack_gleam_runnable avm_name main)
     else()
         set(INCLUDE_LINES "")
     endif()
+    set(PACKBEAM_PRUNE_ARGS "")
+    if(AVM_PRUNE_RUNNABLES)
+        set(PACKBEAM_PRUNE_ARGS "-p")
+    endif()
 
     foreach(archive_name ${ARGN})
         if(${archive_name} STREQUAL "gleam_avm")
@@ -75,7 +79,7 @@ macro(pack_gleam_runnable avm_name main)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gleam.toml ${CMAKE_CURRENT_SOURCE_DIR}/manifest.toml ${CMAKE_CURRENT_BINARY_DIR}/
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR}/src
         COMMAND gleam export erlang-shipment
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create -s ${main} ${INCLUDE_LINES} ${avm_name}.avm ${BEAMS} ${ARCHIVES}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/packbeam create ${PACKBEAM_PRUNE_ARGS} -s ${main} ${INCLUDE_LINES} ${avm_name}.avm ${BEAMS} ${ARCHIVES}
         COMMENT "Packing gleam runnable ${avm_name}.avm"
     )
 

--- a/examples/elixir/stm32/CMakeLists.txt
+++ b/examples/elixir/stm32/CMakeLists.txt
@@ -22,4 +22,7 @@ project(examples_elixir_stm32)
 
 include(BuildElixir)
 
+# STM32 examples bundle runtime libs in the same AVM and targets are flash-constrained.
+set(AVM_PRUNE_RUNNABLES ON)
+
 pack_runnable(MultiBlink MultiBlink estdlib eavmlib exavmlib)

--- a/examples/erlang/stm32/CMakeLists.txt
+++ b/examples/erlang/stm32/CMakeLists.txt
@@ -22,6 +22,9 @@ project(examples_erlang_stm32)
 
 include(BuildErlang)
 
+# STM32 examples bundle runtime libs in the same AVM and targets are flash-constrained.
+set(AVM_PRUNE_RUNNABLES ON)
+
 pack_runnable(blink_weact_studio_blackpill blink_weact_studio_blackpill eavmlib)
 pack_runnable(blink_weact_studio_h562 blink_weact_studio_h562 eavmlib)
 pack_runnable(blink_weact_studio_h743 blink_weact_studio_h743 eavmlib)


### PR DESCRIPTION
Backs out the prune option from https://github.com/atomvm/AtomVM/pull/2133

We need to be careful about exactly what and why we prune.

Build artifacts were incomplete.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
