### PR TITLE
Add `filename:join/1` and `filename:split/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 encoding/decoding options, also Elixir `(url_)encode64`/`(url_)decode64` have been added to `Base`.
 - Added `nanosecond` and `native` time unit support to `erlang:system_time/1`, `erlang:monotonic_time/1`, and `calendar:system_time_to_universal_time/2`
 - Added `erlang:system_time/0`, `erlang:monotonic_time/0`, and `os:system_time/0,1` NIFs
+- Added `filename:join/1` and `filename:split/1`
 
 ### Changed
 

--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(ERLANG_MODULES
     erts_debug
     ets
     file
+    filename
     gen
     gen_event
     gen_server
@@ -60,7 +61,6 @@ set(ERLANG_MODULES
     net
     proc_lib
     sys
-    file
     logger
     logger_std_h
     proplists

--- a/libs/estdlib/src/filename.erl
+++ b/libs/estdlib/src/filename.erl
@@ -1,0 +1,113 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of a subset of the Erlang/OTP filename interface.
+%%
+%% This module implements a strict subset of the Erlang/OTP filename
+%% interface.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(filename).
+
+-export([
+    join/1,
+    split/1
+]).
+
+%%-----------------------------------------------------------------------------
+%% @param   Components list of path components to join
+%% @returns the path formed by joining the components with "/"
+%% @doc     Join a list of path components.
+%%
+%%          If a component is absolute (starts with "/"), all preceding
+%%          components are discarded.  Redundant directory separators are
+%%          removed from the result.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec join(Components :: [string()]) -> string().
+join([]) ->
+    error(function_clause);
+join([Name]) ->
+    normalize(Name);
+join([Name | Rest]) ->
+    join([do_join(Name, hd(Rest)) | tl(Rest)]).
+
+%% @private
+do_join(_Left, Right) when hd(Right) =:= $/ ->
+    normalize(Right);
+do_join(Left, Right) ->
+    normalize(Left ++ "/" ++ Right).
+
+%%-----------------------------------------------------------------------------
+%% @param   Name a path to split into its components
+%% @returns list of path components
+%% @doc     Split a path into its components.
+%%
+%%          If the path is absolute, the first component is "/".
+%%          Redundant directory separators are treated as a single separator.
+%%          Trailing separators are ignored.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec split(Name :: string()) -> [string()].
+split([]) ->
+    [];
+split([$/ | Rest]) ->
+    ["/" | split_rel(skip_slashes(Rest))];
+split(Name) ->
+    split_rel(Name).
+
+%% @private
+%% Split a relative path (no leading slashes) into components.
+split_rel([]) ->
+    [];
+split_rel(Name) ->
+    {Component, Rest} = take_component(Name, []),
+    case {Component, Rest} of
+        {[], _} ->
+            split_rel(skip_slashes(Rest));
+        {C, []} ->
+            [lists:reverse(C)];
+        {C, [_ | Tail]} ->
+            [lists:reverse(C) | split_rel(skip_slashes(Tail))]
+    end.
+
+%% @private
+%% Collect characters up to the next "/" into a reversed accumulator.
+take_component([], Acc) ->
+    {Acc, []};
+take_component([$/ | _] = Rest, Acc) ->
+    {Acc, Rest};
+take_component([C | Rest], Acc) ->
+    take_component(Rest, [C | Acc]).
+
+%% @private
+%% Drop all leading "/" characters.
+skip_slashes([$/ | Rest]) -> skip_slashes(Rest);
+skip_slashes(Rest) -> Rest.
+
+%% @private
+%% Collapse every run of consecutive "/" into a single "/".
+normalize([]) ->
+    [];
+normalize([$/, $/ | Rest]) ->
+    normalize([$/ | Rest]);
+normalize([C | Rest]) ->
+    [C | normalize(Rest)].

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -52,6 +52,7 @@ set(ERLANG_MODULES
     test_supervisor
     test_lists_subtraction
     test_file
+    test_filename
     test_tcp_socket
     test_udp_socket
     notify_init_server

--- a/tests/libs/estdlib/test_filename.erl
+++ b/tests/libs/estdlib/test_filename.erl
@@ -1,0 +1,107 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_filename).
+
+-export([test/0]).
+
+-include("etest.hrl").
+
+test() ->
+    ok = test_join(),
+    ok = test_split(),
+    ok.
+
+test_join() ->
+    %% Empty list raises function_clause
+    ?ASSERT_ERROR(filename:join([]), function_clause),
+
+    %% Single element: returned as-is (normalized)
+    ?ASSERT_MATCH(filename:join(["foo"]), "foo"),
+    ?ASSERT_MATCH(filename:join(["/"]), "/"),
+    ?ASSERT_MATCH(filename:join(["/usr"]), "/usr"),
+
+    %% Basic joining with separator
+    ?ASSERT_MATCH(filename:join(["foo", "bar"]), "foo/bar"),
+    ?ASSERT_MATCH(filename:join(["a", "b", "c"]), "a/b/c"),
+
+    %% Absolute path component discards all preceding components
+    ?ASSERT_MATCH(filename:join(["a", "/b"]), "/b"),
+    ?ASSERT_MATCH(filename:join(["a", "b", "/c"]), "/c"),
+    ?ASSERT_MATCH(filename:join(["x", "y", "/z", "w"]), "/z/w"),
+    ?ASSERT_MATCH(filename:join(["/usr", "local", "bin"]), "/usr/local/bin"),
+
+    %% Trailing separators on a component are stripped (normalized)
+    ?ASSERT_MATCH(filename:join(["foo/", "bar"]), "foo/bar"),
+    ?ASSERT_MATCH(filename:join(["/usr/", "local"]), "/usr/local"),
+    ?ASSERT_MATCH(filename:join(["a//", "b"]), "a/b"),
+
+    %% Redundant separators within a component are normalized
+    ?ASSERT_MATCH(filename:join(["foo//bar", "baz"]), "foo/bar/baz"),
+    ?ASSERT_MATCH(filename:join(["foo", "bar//baz"]), "foo/bar/baz"),
+
+    %% Leading redundant separators on an absolute component are normalized
+    ?ASSERT_MATCH(filename:join(["//foo", "bar"]), "/foo/bar"),
+    ?ASSERT_MATCH(filename:join(["a", "//b"]), "/b"),
+
+    %% Root "/" joined with a component
+    ?ASSERT_MATCH(filename:join(["/", "foo"]), "/foo"),
+
+    %% Dot and dotdot components are not resolved (passed through)
+    ?ASSERT_MATCH(filename:join([".", "foo"]), "./foo"),
+    ?ASSERT_MATCH(filename:join(["foo", "."]), "foo/."),
+    ?ASSERT_MATCH(filename:join(["foo", ".."]), "foo/.."),
+
+    ok.
+
+test_split() ->
+    %% Empty string returns empty list
+    ?ASSERT_MATCH(filename:split(""), []),
+
+    %% Root returns single-element list
+    ?ASSERT_MATCH(filename:split("/"), ["/"]),
+
+    %% Simple relative paths
+    ?ASSERT_MATCH(filename:split("foo"), ["foo"]),
+    ?ASSERT_MATCH(filename:split("foo/bar"), ["foo", "bar"]),
+    ?ASSERT_MATCH(filename:split("a/b/c"), ["a", "b", "c"]),
+
+    %% Absolute paths: first component is "/"
+    ?ASSERT_MATCH(filename:split("/usr/local/bin"), ["/", "usr", "local", "bin"]),
+    ?ASSERT_MATCH(filename:split("/foo"), ["/", "foo"]),
+
+    %% Trailing separators are ignored
+    ?ASSERT_MATCH(filename:split("foo/"), ["foo"]),
+    ?ASSERT_MATCH(filename:split("/usr/local/"), ["/", "usr", "local"]),
+    ?ASSERT_MATCH(filename:split("foo//"), ["foo"]),
+
+    %% Redundant separators are treated as a single separator
+    ?ASSERT_MATCH(filename:split("foo//bar"), ["foo", "bar"]),
+    ?ASSERT_MATCH(filename:split("/usr//local"), ["/", "usr", "local"]),
+
+    %% Leading redundant separators are normalized (same as single "/")
+    ?ASSERT_MATCH(filename:split("//usr/local"), ["/", "usr", "local"]),
+
+    %% Dot and dotdot components are not resolved (passed through)
+    ?ASSERT_MATCH(filename:split("./foo"), [".", "foo"]),
+    ?ASSERT_MATCH(filename:split("foo/./bar"), ["foo", ".", "bar"]),
+    ?ASSERT_MATCH(filename:split("foo/../bar"), ["foo", "..", "bar"]),
+
+    ok.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -83,7 +83,8 @@ get_non_networking_tests(_OTPVersion) ->
         test_supervisor,
         test_lists_subtraction,
         test_os,
-        test_file
+        test_file,
+        test_filename
     ].
 
 get_networking_tests(OTPVersion) when


### PR DESCRIPTION
Also remove duplicate `file` entry in `libs/estdlib/src/CMakeLists.txt`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
