### PR TITLE
Bump test_min_heap_size timeout

### DIFF
--- a/tests/erlang_tests/test_min_heap_size.erl
+++ b/tests/erlang_tests/test_min_heap_size.erl
@@ -45,7 +45,7 @@ test_min_heap_size(MinSize) ->
     ok =
         receive
             {'DOWN', Ref1, process, Pid1, normal} -> ok
-        after 500 -> timeout
+        after 5000 -> timeout
         end,
     ok.
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
