### PR TITLE
Fix: benign gen_server start race crash reports

### DIFF
--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -125,22 +125,22 @@ init_it(Starter, Name, Module, Args, Options) ->
             init_it(Starter, Module, Args, Options)
     catch
         error:badarg:S ->
-            ErrorT =
-                case whereis(Name) of
-                    undefined ->
-                        badarg;
-                    Pid when is_pid(Pid) ->
-                        {already_started, Pid}
-                end,
-            crash_report(
-                io_lib:format("gen_server:init_it/5: Error initializing module ~p under name ~p", [
-                    Module, Name
-                ]),
-                Starter,
-                ErrorT,
-                S
-            ),
-            proc_lib:init_ack(Starter, {error, ErrorT})
+            case whereis(Name) of
+                undefined ->
+                    crash_report(
+                        io_lib:format(
+                            "gen_server:init_it/5: Error initializing module ~p under name ~p", [
+                                Module, Name
+                            ]
+                        ),
+                        Starter,
+                        badarg,
+                        S
+                    ),
+                    proc_lib:init_ack(Starter, {error, badarg});
+                Pid when is_pid(Pid) ->
+                    proc_lib:init_ack(Starter, {error, {already_started, Pid}})
+            end
     end.
 
 init_it(Starter, Module, Args, Options) ->


### PR DESCRIPTION
Fixes https://github.com/atomvm/AtomVM/issues/1001

This typically happens, due to timer_manager startup race for say: 

```
:erlang.send_after(1, self(), :show_hello)
:erlang.send_after(5000, self(), :show_cat)
```

Or when starting up an Supervisor tree with lots of things going on:

```
=============
=============
CRASH REPORT
CRASH REPORT
gen_server:init_it/5: Error initializing module timer_manager under name timer_manager
gen_server:init_it/5: Error initializing module timer_manager under name timer_manager
Error: {already_started,<0.36.0>}
Error: {already_started,<0.36.0>}
Parent: <0.33.0>
Parent: <0.34.0>
Pid: <0.37.0>
Pid: <0.38.0>
Stacktrace: undefined
Stacktrace: undefined
=============
=============
=============
CRASH REPORT
gen_server:init_it/5: Error initializing module timer_manager under name timer_manager
Error: {already_started,<0.36.0>}
Parent: <0.35.0>
Pid: <0.39.0>
Stacktrace: undefined

```

And is very confusing! and can send one on wild goose hunts for what looks like a crash - but is normal behaviour.

I have test at hand that captures io output etc - but it seems extensive and perhaps flappy prone to have a 400 line test for this.

Avoid emitting a crash report in gen_server:init_it/5 when erlang:register/2 loses a race to another process and whereis(Name) returns an existing pid.

This keeps {error, {already_started, Pid}} behavior unchanged for callers, while preserving crash reports for genuine registration failures where the name is still undefined.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
