### PR TITLE
CI: Fix rp2 - PANIC should fail job

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -84,6 +84,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build-atomvmlib
     strategy:
+      fail-fast: false
       matrix:
         board: ["pico", "pico_w", "pico2", "pico2_w"]
         platform: [""]

--- a/src/platforms/rp2/tests/run-tests.ts
+++ b/src/platforms/rp2/tests/run-tests.ts
@@ -89,7 +89,12 @@ mcu.uart[0].onByte = (value) => {
   if (char === "\n") {
     if (currentLine === "OK" || currentLine === "OK\r") {
       process.exit(0);
-    } else if (currentLine === "FAIL" || currentLine === "FAIL\r") {
+    } else if (
+      currentLine === "FAIL" ||
+      currentLine === "FAIL\r" ||
+      currentLine === "*** PANIC ***" ||
+      currentLine === "*** PANIC ***\r"
+    ) {
       process.exit(1);
     }
     currentLine = "";


### PR DESCRIPTION
https://github.com/petermm/AtomVM/actions/runs/22891950676/job/66417004036

<img width="1292" height="958" alt="Screenshot 2026-03-10 at 08 56 34" src="https://github.com/user-attachments/assets/e3e4398a-c0cf-415a-8939-7a0fb7107c32" />

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
