### PR TITLE
JIT: Fix missing untag of BSBinaryReg in do_get_tail

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -3134,7 +3134,10 @@ do_get_tail(
 ) ->
     MSt1 = cond_raise_badarg({BSOffsetReg, '&', 2#111, '!=', 0}, MMod, MSt0),
     {MSt2, BSOffseBytesReg} = MMod:shift_right(MSt1, BSOffsetReg, 3),
-    {MSt3, TailBytesReg0} = MMod:get_array_element(MSt2, BSBinaryReg, 1),
+    % BSBinaryReg is a tagged binary term from the match state;
+    % untag it before using as a pointer for get_array_element
+    {MSt2b, BSBinaryPtrReg} = MMod:and_(MSt2, BSBinaryReg, ?TERM_PRIMARY_CLEAR_MASK),
+    {MSt3, TailBytesReg0} = MMod:get_array_element(MSt2b, {free, BSBinaryPtrReg}, 1),
     MSt4 = MMod:sub(MSt3, TailBytesReg0, BSOffseBytesReg),
     {MSt5, HeapSizeReg} = MMod:call_primitive(MSt4, ?PRIM_TERM_SUB_BINARY_HEAP_SIZE, [
         BSBinaryReg, {free, TailBytesReg0}


### PR DESCRIPTION
BSBinaryReg holds a tagged binary term (from match state element 1). In do_get_tail, it was used directly as a base pointer in get_array_element, causing ldr to use an address offset by the tag bits (TERM_PRIMARY_BOXED = 0x02).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
