### PR TITLE
JIT: Fix use-after-free register bug in do_get_tail

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -3149,7 +3149,7 @@ do_get_tail(
     MSt10 = MMod:free_native_registers(MSt9, [MatchStateReg0]),
     {MSt11, BSBinaryReg} = MMod:and_(MSt10, {free, BSBinaryReg}, ?TERM_PRIMARY_CLEAR_MASK),
     {MSt12, TailBytesReg1} = MMod:get_array_element(MSt11, BSBinaryReg, 1),
-    MSt13 = MMod:sub(MSt12, TailBytesReg0, BSOffseBytesReg),
+    MSt13 = MMod:sub(MSt12, TailBytesReg1, BSOffseBytesReg),
     MSt14 = MMod:add(MSt13, BSBinaryReg, ?TERM_PRIMARY_BOXED),
     {MSt15, ResultTerm} = MMod:call_primitive(MSt14, ?PRIM_TERM_MAYBE_CREATE_SUB_BINARY, [
         ctx, BSBinaryReg, {free, BSOffseBytesReg}, TailBytesReg1


### PR DESCRIPTION
TailBytesReg0 is freed at line 3151 via {free, TailBytesReg0} in the call_primitive for PRIM_TERM_SUB_BINARY_HEAP_SIZE. After that call, the physical register is no longer preserved across subsequent calls and may be reallocated.

Line 3163 was using TailBytesReg0 (the freed register) instead of TailBytesReg1 (freshly loaded at line 3162 via get_array_element).

Both registers were potentially always the same or have the same value across backends and this bug hasn't been observed.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
