### PR TITLE
JIT: add register value caching across all backends

### DIFF
--- a/libs/jit/src/CMakeLists.txt
+++ b/libs/jit/src/CMakeLists.txt
@@ -25,6 +25,7 @@ include(BuildErlang)
 set(ERLANG_MODULES
     jit
     jit_precompile
+    jit_regs
     jit_stream_binary
     jit_stream_flash
     jit_stream_mmap

--- a/libs/jit/src/jit_aarch64.erl
+++ b/libs/jit/src/jit_aarch64.erl
@@ -138,7 +138,8 @@
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
     labels :: [{integer() | reference(), integer()}],
-    variant :: non_neg_integer()
+    variant :: non_neg_integer(),
+    regs :: jit_regs:regs()
 }).
 
 -type state() :: #state{}.
@@ -268,7 +269,8 @@ new(Variant, StreamModule, Stream) ->
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
         labels = [],
-        variant = Variant
+        variant = Variant,
+        regs = jit_regs:new()
     }.
 
 %%-----------------------------------------------------------------------------
@@ -537,8 +539,8 @@ call_primitive_last(
     % registers used for parameters
     ParamRegs = lists:sublist(?PARAMETER_REGS, length(Args)),
     ArgsRegs = args_regs(Args),
-    ArgsMask = regs_to_mask(ArgsRegs),
-    ParamMask = regs_to_mask(ParamRegs),
+    ArgsMask = jit_regs:regs_to_mask(ArgsRegs, fun reg_bit/1),
+    ParamMask = jit_regs:regs_to_mask(ParamRegs, fun reg_bit/1),
     ScratchMask = ?AVAILABLE_REGS_MASK band (bnot (ArgsMask bor ParamMask)),
     Temp = first_avail(ScratchMask),
     TempBit = reg_bit(Temp),
@@ -554,7 +556,10 @@ call_primitive_last(
     Stream1 = StreamModule:append(Stream0, PrepCall),
     State1 = set_args(
         State0#state{
-            stream = Stream1, available_regs = AvailableRegs1, used_regs = UsedRegs
+            stream = Stream1,
+            available_regs = AvailableRegs1,
+            used_regs = UsedRegs,
+            regs = jit_regs:invalidate_reg(State0#state.regs, Temp)
         },
         Args
     ),
@@ -564,7 +569,8 @@ call_primitive_last(
     State1#state{
         stream = Stream3,
         available_regs = ?AVAILABLE_REGS_MASK,
-        used_regs = 0
+        used_regs = 0,
+        regs = jit_regs:invalidate_all(State1#state.regs)
     }.
 
 %%-----------------------------------------------------------------------------
@@ -679,7 +685,8 @@ jump_to_continuation(
     State#state{
         stream = Stream1,
         available_regs = ?AVAILABLE_REGS_MASK,
-        used_regs = 0
+        used_regs = 0,
+        regs = jit_regs:invalidate_all(State#state.regs)
     }.
 
 %% @private
@@ -733,7 +740,9 @@ if_block(
         Stream2,
         Replacements
     ),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs);
+    State4 = merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs),
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State4#state{regs = MergedRegs};
 if_block(
     #state{stream_module = StreamModule, stream = Stream0} = State0,
     Cond,
@@ -748,7 +757,9 @@ if_block(
     BranchOffset = OffsetAfter - (Offset + BranchInstrOffset),
     NewBranchInstr = rewrite_branch_instruction(CC, BranchOffset),
     Stream3 = StreamModule:replace(Stream2, Offset + BranchInstrOffset, NewBranchInstr),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs).
+    State3 = merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs),
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State3#state{regs = MergedRegs}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit an if else block, i.e. emit a test of a condition and
@@ -786,7 +797,8 @@ if_else_block(
     StateElse = State2#state{
         stream = Stream4,
         used_regs = State1#state.used_regs,
-        available_regs = State1#state.available_regs
+        available_regs = State1#state.available_regs,
+        regs = State1#state.regs
     },
     State3 = BlockFalseFn(StateElse),
     Stream5 = State3#state.stream,
@@ -795,7 +807,9 @@ if_else_block(
     FinalJumpOffset = OffsetFinal - ElseJumpOffset,
     NewElseJumpInstr = jit_aarch64_asm:b(FinalJumpOffset),
     Stream6 = StreamModule:replace(Stream5, ElseJumpOffset, NewElseJumpInstr),
-    merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs).
+    State4 = merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs),
+    MergedRegs = jit_regs:merge(State2#state.regs, State3#state.regs),
+    State4#state{regs = MergedRegs}.
 
 %% @private
 -spec if_block_cond(state(), condition()) ->
@@ -1055,7 +1069,8 @@ if_block_cond(
     >>,
     Stream1 = StreamModule:append(Stream0, Code),
     State1 = if_block_free_reg(RegOrTuple, State0),
-    State2 = State1#state{stream = Stream1},
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream1, regs = Regs1},
     {State2, eq, byte_size(TestCode)};
 if_block_cond(
     #state{
@@ -1076,7 +1091,8 @@ if_block_cond(
     OffsetAfter = StreamModule:offset(Stream2),
     I3 = jit_aarch64_asm:bcc(eq, 0),
     Stream3 = StreamModule:append(Stream2, I3),
-    State2 = State1#state{stream = Stream3},
+    Regs1b = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream3, regs = Regs1b},
     {State2, eq, OffsetAfter - OffsetBefore};
 if_block_cond(
     #state{
@@ -1130,18 +1146,22 @@ merge_used_regs(#state{used_regs = UR} = State, OtherUR) ->
 %%-----------------------------------------------------------------------------
 -spec shift_right(#state{}, maybe_free_aarch64_register(), non_neg_integer()) ->
     {#state{}, aarch64_register()}.
-shift_right(#state{stream_module = StreamModule, stream = Stream0} = State, {free, Reg}, Shift) when
+shift_right(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, {free, Reg}, Shift
+) when
     ?IS_GPR(Reg) andalso is_integer(Shift)
 ->
     I = jit_aarch64_asm:lsr(Reg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 shift_right(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     Reg,
     Shift
@@ -1152,9 +1172,13 @@ shift_right(
     Bit = reg_bit(ResultReg),
     I = jit_aarch64_asm:lsr(ResultReg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State#state{
-            stream = Stream1, available_regs = Available band (bnot Bit), used_regs = Used bor Bit
+            stream = Stream1,
+            available_regs = Available band (bnot Bit),
+            used_regs = Used bor Bit,
+            regs = Regs1
         },
         ResultReg
     }.
@@ -1168,12 +1192,15 @@ shift_right(
 %% @return new state
 %%-----------------------------------------------------------------------------
 -spec shift_left(state(), aarch64_register(), non_neg_integer()) -> state().
-shift_left(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Shift) when
+shift_left(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Shift
+) when
     is_atom(Reg)
 ->
     I = jit_aarch64_asm:lsl(Reg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a call to a function pointer with arguments. This function converts
@@ -1205,7 +1232,7 @@ call_func_ptr(
         end,
         [FuncPtrTuple | Args]
     ),
-    FreeMask = regs_to_mask(FreeRegs),
+    FreeMask = jit_regs:regs_to_mask(FreeRegs, fun reg_bit/1),
     UsedRegs1 = UsedRegs0 band (bnot FreeMask),
     SavedRegs = [?LR_REG, ?CTX_REG, ?JITSTATE_REG, ?NATIVE_INTERFACE_REG | mask_to_list(UsedRegs1)],
     {SavedRegsOdd, Stream1} = push_registers(SavedRegs, StreamModule, Stream0),
@@ -1251,12 +1278,14 @@ call_func_ptr(
     ResultBit = reg_bit(ResultReg),
     AvailableRegs2 = AvailableRegs1 band (bnot ResultBit),
     AvailableRegs3 = AvailableRegs2 band ?AVAILABLE_REGS_MASK,
+    Regs1 = jit_regs:invalidate_all(State0#state.regs),
     UsedRegs2 = UsedRegs1 bor ResultBit,
     {
         State1#state{
             stream = Stream6,
             available_regs = AvailableRegs3,
-            used_regs = UsedRegs2
+            used_regs = UsedRegs2,
+            regs = Regs1
         },
         ResultReg
     }.
@@ -1291,8 +1320,8 @@ set_args(
 ) ->
     ParamRegs = parameter_regs(Args),
     ArgsRegs = args_regs(Args),
-    ParamMask = regs_to_mask(ParamRegs),
-    ArgsMask = regs_to_mask(ArgsRegs),
+    ParamMask = jit_regs:regs_to_mask(ParamRegs, fun reg_bit/1),
+    ArgsMask = jit_regs:regs_to_mask(ArgsRegs, fun reg_bit/1),
     AvailableScratchMask =
         ?SCRATCH_REGS_MASK band (bnot (ParamMask bor ArgsMask bor UsedRegs)),
     AvailableScratchGP = mask_to_list(AvailableScratchMask),
@@ -1304,7 +1333,7 @@ set_args(
         end
      || Arg <- Args
     ],
-    SetArgsCode = set_args0(Args1, ArgsRegs, ParamRegs, AvailableScratchGP, []),
+    SetArgsCode = set_args0(Args1, ArgsRegs, ParamRegs, AvailableScratchGP, #{}, []),
     Stream1 = StreamModule:append(Stream0, SetArgsCode),
     NewUsedMask = lists:foldl(
         fun
@@ -1365,49 +1394,64 @@ replace_reg0([Other | T], Reg, Replacement, Acc) ->
 
 %% @private
 -spec set_args0(
-    [arg()], [aarch64_register() | imm], [aarch64_register()], [aarch64_register()], [binary()]
+    [arg()], [aarch64_register() | imm], [aarch64_register()], [aarch64_register()], map(), [
+        binary()
+    ]
 ) -> binary().
-set_args0([], [], [], _AvailGP, Acc) ->
+set_args0([], [], [], _AvailGP, _LoadedImm, Acc) ->
     list_to_binary(lists:reverse(Acc));
-set_args0([{free, FreeVal} | ArgsT], ArgsRegs, ParamRegs, AvailGP, Acc) ->
-    set_args0([FreeVal | ArgsT], ArgsRegs, ParamRegs, AvailGP, Acc);
-set_args0([ctx | ArgsT], [?CTX_REG | ArgsRegs], [?CTX_REG | ParamRegs], AvailGP, Acc) ->
-    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, Acc);
+set_args0([{free, FreeVal} | ArgsT], ArgsRegs, ParamRegs, AvailGP, LoadedImm, Acc) ->
+    set_args0([FreeVal | ArgsT], ArgsRegs, ParamRegs, AvailGP, LoadedImm, Acc);
+set_args0([ctx | ArgsT], [?CTX_REG | ArgsRegs], [?CTX_REG | ParamRegs], AvailGP, LoadedImm, Acc) ->
+    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, Acc);
 set_args0(
     [jit_state | ArgsT],
     [?JITSTATE_REG | ArgsRegs],
     [?JITSTATE_REG | ParamRegs],
     AvailGP,
+    LoadedImm,
     Acc
 ) ->
-    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, Acc);
+    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, Acc);
 set_args0(
-    [jit_state | ArgsT], [?JITSTATE_REG | ArgsRegs], [ParamReg | ParamRegs], AvailGP, Acc
+    [jit_state | ArgsT], [?JITSTATE_REG | ArgsRegs], [ParamReg | ParamRegs], AvailGP, LoadedImm, Acc
 ) ->
     false = lists:member(ParamReg, ArgsRegs),
-    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, [
+    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, [
         jit_aarch64_asm:mov(ParamReg, ?JITSTATE_REG) | Acc
     ]);
 % ctx is special as we need it to access x_reg/y_reg/fp_reg
-set_args0([Arg | ArgsT], [_ArgReg | ArgsRegs], [?CTX_REG | ParamRegs], AvailGP, Acc) ->
+set_args0([Arg | ArgsT], [_ArgReg | ArgsRegs], [?CTX_REG | ParamRegs], AvailGP, LoadedImm, Acc) ->
     false = lists:member(?CTX_REG, ArgsRegs),
     J = set_args1(Arg, ?CTX_REG),
-    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, [J | Acc]);
+    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, [J | Acc]);
 set_args0(
     [Arg | ArgsT],
     [_ArgReg | ArgsRegs],
     [ParamReg | ParamRegs],
     [Avail | AvailGPT] = AvailGP,
+    LoadedImm,
     Acc
 ) ->
-    J = set_args1(Arg, ParamReg),
-    case lists:member(ParamReg, ArgsRegs) of
-        false ->
-            set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, [J | Acc]);
-        true ->
-            I = jit_aarch64_asm:mov(Avail, ParamReg),
-            NewArgsT = replace_reg(ArgsT, ParamReg, Avail),
-            set_args0(NewArgsT, ArgsRegs, ParamRegs, AvailGPT, [J, I | Acc])
+    case is_integer(Arg) andalso maps:find(Arg, LoadedImm) of
+        {ok, CachedReg} ->
+            J = jit_aarch64_asm:mov(ParamReg, CachedReg),
+            set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, [J | Acc]);
+        _ ->
+            J = set_args1(Arg, ParamReg),
+            NewLoadedImm =
+                case is_integer(Arg) of
+                    true -> LoadedImm#{Arg => ParamReg};
+                    false -> LoadedImm
+                end,
+            case lists:member(ParamReg, ArgsRegs) of
+                false ->
+                    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, NewLoadedImm, [J | Acc]);
+                true ->
+                    I = jit_aarch64_asm:mov(Avail, ParamReg),
+                    NewArgsT = replace_reg(ArgsT, ParamReg, Avail),
+                    set_args0(NewArgsT, ArgsRegs, ParamRegs, AvailGPT, NewLoadedImm, [J, I | Acc])
+            end
     end.
 
 %% @private
@@ -1445,8 +1489,21 @@ set_args1({avm_int64_t, Value}, Reg) when is_integer(Value) ->
     (state(), Src :: value() | vm_register(), Dest :: vm_register()) -> state();
     (state(), Src :: {free, {ptr, aarch64_register(), 1}}, Dest :: {fp_reg, non_neg_integer()}) ->
         state().
-move_to_vm_register(State, Src, Dest) ->
-    move_to_vm_register_emit(State, Src, Dest).
+move_to_vm_register(#state{regs = Regs0} = State, Src, Dest) ->
+    VmLoc = jit_regs:vm_dest_to_contents(Dest, ?MAX_REG),
+    Regs1 =
+        case VmLoc of
+            unknown -> Regs0;
+            _ -> jit_regs:invalidate_vm_loc(Regs0, VmLoc)
+        end,
+    State1 = move_to_vm_register_emit(State#state{regs = Regs1}, Src, Dest),
+    case {Src, VmLoc} of
+        {Reg, Contents} when is_atom(Reg), Contents =/= unknown ->
+            #state{regs = Regs2} = State1,
+            State1#state{regs = jit_regs:set_contents(Regs2, Reg, Contents)};
+        _ ->
+            State1
+    end.
 
 % Native register to VM register
 move_to_vm_register_emit(State0, Src, {x_reg, extra}) when is_atom(Src) ->
@@ -1461,14 +1518,17 @@ move_to_vm_register_emit(State0, Src, {ptr, Reg}) when is_atom(Src) ->
     I1 = jit_aarch64_asm:str(Src, {Reg, 0}),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State0#state{stream = Stream1};
-move_to_vm_register_emit(#state{available_regs = Available} = State0, Src, {y_reg, Y}) when
+move_to_vm_register_emit(
+    #state{available_regs = Available, regs = Regs0} = State0, Src, {y_reg, Y}
+) when
     is_atom(Src)
 ->
     Temp = first_avail(Available),
     I1 = jit_aarch64_asm:ldr(Temp, ?Y_REGS),
     I2 = jit_aarch64_asm:str(Src, {Temp, Y * ?WORD_SIZE}),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, <<I1/binary, I2/binary>>),
-    State0#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State0#state{stream = Stream1, regs = Regs1};
 % Source is an integer
 move_to_vm_register_emit(State, 0, Dest) ->
     move_to_vm_register_emit(State, xzr, Dest);
@@ -1483,7 +1543,8 @@ move_to_vm_register_emit(#state{available_regs = AR0} = State0, N, Dest) when
     State1 = move_to_vm_register_emit(
         State0#state{stream = Stream1, available_regs = AT}, Temp, Dest
     ),
-    State1#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 % Source is a VM register
 move_to_vm_register_emit(#state{available_regs = AR0} = State0, {x_reg, extra}, Dest) ->
     Temp = first_avail(AR0),
@@ -1494,7 +1555,8 @@ move_to_vm_register_emit(#state{available_regs = AR0} = State0, {x_reg, extra}, 
     State1 = move_to_vm_register_emit(
         State0#state{stream = Stream1, available_regs = AT}, Temp, Dest
     ),
-    State1#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 move_to_vm_register_emit(#state{available_regs = AR0} = State0, {x_reg, X}, Dest) ->
     Temp = first_avail(AR0),
     TempBit = reg_bit(Temp),
@@ -1504,7 +1566,8 @@ move_to_vm_register_emit(#state{available_regs = AR0} = State0, {x_reg, X}, Dest
     State1 = move_to_vm_register_emit(
         State0#state{stream = Stream1, available_regs = AT}, Temp, Dest
     ),
-    State1#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 move_to_vm_register_emit(#state{available_regs = AR0} = State0, {ptr, Reg}, Dest) ->
     Temp = first_avail(AR0),
     TempBit = reg_bit(Temp),
@@ -1514,7 +1577,8 @@ move_to_vm_register_emit(#state{available_regs = AR0} = State0, {ptr, Reg}, Dest
     State1 = move_to_vm_register_emit(
         State0#state{stream = Stream1, available_regs = AT}, Temp, Dest
     ),
-    State1#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 move_to_vm_register_emit(#state{available_regs = AR0} = State0, {y_reg, Y}, Dest) ->
     Temp = first_avail(AR0),
     TempBit = reg_bit(Temp),
@@ -1525,7 +1589,8 @@ move_to_vm_register_emit(#state{available_regs = AR0} = State0, {y_reg, Y}, Dest
     State1 = move_to_vm_register_emit(
         State0#state{stream = Stream1, available_regs = AT}, Temp, Dest
     ),
-    State1#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 % term_to_float
 move_to_vm_register_emit(
     #state{stream_module = StreamModule, available_regs = Available, stream = Stream0} = State0,
@@ -1539,7 +1604,8 @@ move_to_vm_register_emit(
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
     State1 = free_native_register(State0, Reg),
-    State1#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a move of an array element (reg[x]) to a vm or a native register.
@@ -1557,7 +1623,8 @@ move_to_vm_register_emit(
     vm_register() | aarch64_register()
 ) -> state().
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available, regs = Regs0} =
+        State,
     Reg,
     Index,
     {x_reg, X}
@@ -1566,9 +1633,12 @@ move_array_element(
     I1 = jit_aarch64_asm:ldr(Temp, {Reg, Index * ?WORD_SIZE}),
     I2 = jit_aarch64_asm:str(Temp, ?X_REG(X)),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
+    State#state{stream = Stream1, regs = Regs2};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available, regs = Regs0} =
+        State,
     Reg,
     Index,
     {ptr, Dest}
@@ -1577,9 +1647,10 @@ move_array_element(
     I1 = jit_aarch64_asm:ldr(Temp, {Reg, Index * ?WORD_SIZE}),
     I2 = jit_aarch64_asm:str(Temp, {Dest, 0}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} =
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available, regs = Regs0} =
         State,
     Reg,
     Index,
@@ -1594,9 +1665,12 @@ move_array_element(
     I3 = jit_aarch64_asm:str(Temp2, {Temp1, Y * ?WORD_SIZE}),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp1),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp2),
+    State#state{stream = Stream1, regs = Regs3};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} =
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available, regs = Regs0} =
         State,
     {free, Reg},
     Index,
@@ -1608,19 +1682,24 @@ move_array_element(
     I3 = jit_aarch64_asm:str(Reg, {Temp, Y * ?WORD_SIZE}),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Reg),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp),
+    State#state{stream = Stream1, regs = Regs3};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0} = State, Reg, Index, Dest
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Index, Dest
 ) when is_atom(Dest) andalso is_integer(Index) ->
     I1 = jit_aarch64_asm:ldr(Dest, {Reg, Index * ?WORD_SIZE}),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Dest),
+    State#state{stream = Stream1, regs = Regs1};
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -1632,17 +1711,21 @@ move_array_element(
     AvailableRegs1 = AvailableRegs0 bor Bit,
     UsedRegs1 = UsedRegs0 band (bnot Bit),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, IndexReg),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs2
     };
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -1654,17 +1737,20 @@ move_array_element(
     AvailableRegs1 = AvailableRegs0 bor Bit,
     UsedRegs1 = UsedRegs0 band (bnot Bit),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, IndexReg),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs1
     };
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -1680,10 +1766,14 @@ move_array_element(
     Stream1 = StreamModule:append(
         Stream0, <<I1/binary, I2/binary, I3/binary>>
     ),
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
+    Regs3 = jit_regs:invalidate_reg(Regs2, IndexReg),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs3
     }.
 
 %%-----------------------------------------------------------------------------
@@ -1701,20 +1791,23 @@ move_array_element(
 get_array_element(
     #state{
         stream_module = StreamModule,
-        stream = Stream0
+        stream = Stream0,
+        regs = Regs0
     } = State,
     {free, Reg},
     Index
 ) ->
     I1 = jit_aarch64_asm:ldr(Reg, {Reg, Index * ?WORD_SIZE}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary>>),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 get_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     Index
@@ -1723,11 +1816,13 @@ get_array_element(
     Bit = reg_bit(ElemReg),
     I1 = jit_aarch64_asm:ldr(ElemReg, {Reg, Index * ?WORD_SIZE}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ElemReg),
     {
         State#state{
             stream = Stream1,
             available_regs = Available band (bnot Bit),
-            used_regs = UsedRegs0 bor Bit
+            used_regs = UsedRegs0 bor Bit,
+            regs = Regs1
         },
         ElemReg
     }.
@@ -1796,7 +1891,8 @@ move_to_array_element(
 ) when is_integer(IndexVal) andalso is_integer(Offset) ->
     move_to_array_element(State, Value, BaseReg, IndexVal + Offset);
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Available, regs = Regs0} =
+        State,
     ValueReg,
     BaseReg,
     IndexReg,
@@ -1806,7 +1902,8 @@ move_to_array_element(
     I1 = jit_aarch64_asm:add(Temp, IndexReg, Offset),
     I2 = jit_aarch64_asm:str(ValueReg, {BaseReg, Temp, lsl, 3}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
     State0,
     Value,
@@ -1819,7 +1916,8 @@ move_to_array_element(
     I1 = jit_aarch64_asm:add(Temp, IndexReg, Offset),
     I2 = jit_aarch64_asm:str(ValueReg, {BaseReg, Temp, lsl, 3}),
     Stream1 = (State1#state.stream_module):append(State1#state.stream, <<I1/binary, I2/binary>>),
-    State2 = State1#state{stream = Stream1},
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream1, regs = Regs1},
     free_native_register(State2, ValueReg).
 
 %%-----------------------------------------------------------------------------
@@ -1834,45 +1932,76 @@ move_to_array_element(
 -spec move_to_native_register(state(), value() | cp) -> {state(), aarch64_register()}.
 move_to_native_register(State, Reg) when ?IS_GPR(Reg) ->
     {State, Reg};
-move_to_native_register(State, Value) ->
-    move_to_native_register_emit(State, Value).
+move_to_native_register(#state{regs = Regs} = State, Value) ->
+    Contents = jit_regs:value_to_contents(Value, ?MAX_REG),
+    case Contents =/= unknown andalso jit_regs:find_reg_with_contents(Regs, Contents) of
+        {ok, CachedReg} ->
+            Bit = reg_bit(CachedReg),
+            case State#state.used_regs band Bit of
+                0 ->
+                    case State#state.available_regs band Bit of
+                        0 ->
+                            move_to_native_register_emit(State, Value, Contents);
+                        _ ->
+                            {
+                                State#state{
+                                    used_regs = State#state.used_regs bor Bit,
+                                    available_regs = State#state.available_regs band (bnot Bit)
+                                },
+                                CachedReg
+                            }
+                    end;
+                _ ->
+                    {State, CachedReg}
+            end;
+        _ ->
+            move_to_native_register_emit(State, Value, Contents)
+    end.
 
 move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    cp
+    cp,
+    Contents
 ) ->
     Reg = first_avail(Available),
     Bit = reg_bit(Reg),
     I1 = jit_aarch64_asm:ldr(Reg, ?CP),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             used_regs = Used bor Bit,
-            available_regs = Available band (bnot Bit)
+            available_regs = Available band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
 move_to_native_register_emit(
-    #state{stream_module = StreamModule, stream = Stream0} = State,
-    {ptr, Reg}
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State,
+    {ptr, Reg},
+    _Contents
 ) when is_atom(Reg) ->
     I1 = jit_aarch64_asm:ldr(Reg, {Reg, 0}),
     Stream1 = StreamModule:append(Stream0, I1),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    Imm
+    Imm,
+    Contents
 ) when
     is_integer(Imm)
 ->
@@ -1880,11 +2009,13 @@ move_to_native_register_emit(
     Bit = reg_bit(Reg),
     I1 = jit_aarch64_asm:mov(Reg, Imm),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             used_regs = Used bor Bit,
-            available_regs = Available band (bnot Bit)
+            available_regs = Available band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
@@ -1893,19 +2024,23 @@ move_to_native_register_emit(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {x_reg, extra}
+    {x_reg, extra},
+    Contents
 ) ->
     Reg = first_avail(Available),
     Bit = reg_bit(Reg),
     I1 = jit_aarch64_asm:ldr(Reg, ?X_REG(?MAX_REG)),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             used_regs = Used bor Bit,
-            available_regs = Available band (bnot Bit)
+            available_regs = Available band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
@@ -1914,9 +2049,11 @@ move_to_native_register_emit(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {x_reg, X}
+    {x_reg, X},
+    Contents
 ) when
     X < ?MAX_REG
 ->
@@ -1924,11 +2061,13 @@ move_to_native_register_emit(
     Bit = reg_bit(Reg),
     I1 = jit_aarch64_asm:ldr(Reg, ?X_REG(X)),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             used_regs = Used bor Bit,
-            available_regs = Available band (bnot Bit)
+            available_regs = Available band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
@@ -1937,9 +2076,11 @@ move_to_native_register_emit(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {y_reg, Y}
+    {y_reg, Y},
+    Contents
 ) ->
     Reg = first_avail(Available),
     Bit = reg_bit(Reg),
@@ -1947,11 +2088,13 @@ move_to_native_register_emit(
     I2 = jit_aarch64_asm:ldr(Reg, {Reg, Y * ?WORD_SIZE}),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             available_regs = Available band (bnot Bit),
-            used_regs = Used bor Bit
+            used_regs = Used bor Bit,
+            regs = Regs1
         },
         Reg
     }.
@@ -1967,17 +2110,20 @@ move_to_native_register_emit(
 %%-----------------------------------------------------------------------------
 -spec move_to_native_register(state(), value(), aarch64_register()) -> state().
 move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0} = State, RegSrc, RegDst
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, RegSrc, RegDst
 ) when is_atom(RegSrc) ->
     I = jit_aarch64_asm:mov(RegDst, RegSrc),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1};
+    SrcContents = jit_regs:get_contents(Regs0, RegSrc),
+    Regs1 = jit_regs:set_contents(Regs0, RegDst, SrcContents),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0} = State, RegSrc, RegDst
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, RegSrc, RegDst
 ) when is_integer(RegSrc) ->
     I = jit_aarch64_asm:mov(RegDst, RegSrc),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:set_contents(Regs0, RegDst, {imm, RegSrc}),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_native_register(
     #state{stream_module = StreamModule, stream = Stream0} = State, {ptr, Reg}, RegDst
 ) when ?IS_GPR(Reg) ->
@@ -2022,7 +2168,8 @@ copy_to_native_register(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     Reg
 ) when is_atom(Reg) ->
@@ -2030,9 +2177,14 @@ copy_to_native_register(
     Bit = reg_bit(SaveReg),
     I1 = jit_aarch64_asm:mov(SaveReg, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
+    SrcContents = jit_regs:get_contents(Regs0, Reg),
+    Regs1 = jit_regs:set_contents(Regs0, SaveReg, SrcContents),
     {
         State#state{
-            stream = Stream1, available_regs = Available band (bnot Bit), used_regs = Used bor Bit
+            stream = Stream1,
+            available_regs = Available band (bnot Bit),
+            used_regs = Used bor Bit,
+            regs = Regs1
         },
         SaveReg
     };
@@ -2041,7 +2193,8 @@ copy_to_native_register(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Available,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     {ptr, Reg}
 ) when is_atom(Reg) ->
@@ -2049,9 +2202,13 @@ copy_to_native_register(
     Bit = reg_bit(SaveReg),
     I1 = jit_aarch64_asm:ldr(SaveReg, {Reg, 0}),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:invalidate_reg(Regs0, SaveReg),
     {
         State#state{
-            stream = Stream1, available_regs = Available band (bnot Bit), used_regs = Used bor Bit
+            stream = Stream1,
+            available_regs = Available band (bnot Bit),
+            used_regs = Used bor Bit,
+            regs = Regs1
         },
         SaveReg
     };
@@ -2067,7 +2224,8 @@ copy_to_native_register(State, Reg) ->
 %%-----------------------------------------------------------------------------
 -spec move_to_cp(state(), vm_register()) -> state().
 move_to_cp(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     {y_reg, Y}
 ) ->
     Reg = first_avail(Avail),
@@ -2076,7 +2234,8 @@ move_to_cp(
     I3 = jit_aarch64_asm:str(Reg, ?CP),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Increment the stack pointer (SP) by a given offset.
@@ -2087,7 +2246,8 @@ move_to_cp(
 %%-----------------------------------------------------------------------------
 -spec increment_sp(state(), integer()) -> state().
 increment_sp(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Offset
 ) ->
     Reg = first_avail(Avail),
@@ -2096,7 +2256,8 @@ increment_sp(
     I3 = jit_aarch64_asm:str(Reg, ?Y_REGS),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Set the continuation address to point to a specific label. The actual
@@ -2113,29 +2274,29 @@ set_continuation_to_label(
         stream = Stream0,
         available_regs = Avail,
         branches = Branches,
-        labels = Labels
+        labels = Labels,
+        regs = Regs0
     } = State,
     Label
 ) ->
     Temp = first_avail(Avail),
     Offset = StreamModule:offset(Stream0),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     case lists:keyfind(Label, 1, Labels) of
         {Label, LabelOffset} ->
-            % Label is already known, emit direct adr without relocation
             Rel = LabelOffset - Offset,
             I1 = jit_aarch64_asm:adr(Temp, Rel),
             I2 = jit_aarch64_asm:str(Temp, ?JITSTATE_CONTINUATION),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1};
+            State#state{stream = Stream1, regs = Regs1};
         false ->
-            % Label not yet known, emit placeholder and add relocation
             I1 = jit_aarch64_asm:adr(Temp, 0),
             Reloc = {Label, Offset, {adr, Temp}},
             I2 = jit_aarch64_asm:str(Temp, ?JITSTATE_CONTINUATION),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1, branches = [Reloc | Branches]}
+            State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}
     end.
 
 %%-----------------------------------------------------------------------------
@@ -2152,7 +2313,8 @@ set_continuation_to_offset(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        branches = Branches
+        branches = Branches,
+        regs = Regs0
     } = State
 ) ->
     Temp = first_avail(Avail),
@@ -2163,7 +2325,8 @@ set_continuation_to_offset(
     I2 = jit_aarch64_asm:str(Temp, ?JITSTATE_CONTINUATION),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    {State#state{stream = Stream1, branches = [Reloc | Branches]}, OffsetRef}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Implement a continuation entry point. On AArch64 this is a nop
@@ -2189,7 +2352,8 @@ get_module_index(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State
 ) ->
     Reg = first_avail(Avail),
@@ -2198,9 +2362,13 @@ get_module_index(
     I2 = jit_aarch64_asm:ldr_w(Reg, ?MODULE_INDEX(Reg)),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
     {
         State#state{
-            stream = Stream1, available_regs = Avail band (bnot Bit), used_regs = UsedRegs0 bor Bit
+            stream = Stream1,
+            available_regs = Avail band (bnot Bit),
+            used_regs = UsedRegs0 bor Bit,
+            regs = Regs1
         },
         Reg
     }.
@@ -2241,17 +2409,23 @@ op_imm(#state{stream_module = StreamModule, stream = Stream0} = State, Op, RegA,
 %% @param Val immediate value to AND
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
-and_(#state{stream_module = StreamModule, stream = Stream0} = State, {free, Reg}, SrcReg) when
+and_(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State,
+    {free, Reg},
+    SrcReg
+) when
     is_atom(SrcReg)
 ->
     I1 = jit_aarch64_asm:and_(Reg, Reg, SrcReg),
     Stream1 = StreamModule:append(Stream0, I1),
-    {State#state{stream = Stream1}, Reg};
-and_(State, {free, Reg}, Val) ->
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
+and_(#state{regs = Regs0} = State, {free, Reg}, Val) ->
     NewState = op_imm(State, and_, Reg, Reg, Val),
-    {NewState, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {NewState#state{regs = Regs1}, Reg};
 and_(
-    #state{available_regs = Avail, used_regs = UR} = State,
+    #state{available_regs = Avail, used_regs = UR, regs = Regs0} = State,
     Reg,
     Val
 ) ->
@@ -2264,7 +2438,8 @@ and_(
         Reg,
         Val
     ),
-    {NewState, ResultReg}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
+    {NewState#state{regs = Regs1}, ResultReg}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Perform bitwise OR of a register with an immediate value.
@@ -2274,14 +2449,17 @@ and_(
 %% @param Val immediate value to OR
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
-or_(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, SrcReg) when
+or_(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, SrcReg) when
     is_atom(SrcReg)
 ->
     I1 = jit_aarch64_asm:orr(Reg, Reg, SrcReg),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1};
-or_(State, Reg, Val) ->
-    op_imm(State, orr, Reg, Reg, Val).
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1};
+or_(#state{regs = Regs0} = State, Reg, Val) ->
+    NewState = op_imm(State, orr, Reg, Reg, Val),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    NewState#state{regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Add an immediate value to a register.
@@ -2292,8 +2470,10 @@ or_(State, Reg, Val) ->
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec add(state(), aarch64_register(), integer()) -> state().
-add(State, Reg, Val) ->
-    op_imm(State, add, Reg, Reg, Val).
+add(#state{regs = Regs0} = State, Reg, Val) ->
+    NewState = op_imm(State, add, Reg, Reg, Val),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    NewState#state{regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Subtract an immediate value from a register.
@@ -2304,12 +2484,17 @@ add(State, Reg, Val) ->
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec sub(state(), aarch64_register(), integer() | aarch64_register()) -> state().
-sub(State, Reg, Val) when is_integer(Val) ->
-    op_imm(State, sub, Reg, Reg, Val);
-sub(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) when is_atom(Val) ->
+sub(#state{regs = Regs0} = State, Reg, Val) when is_integer(Val) ->
+    NewState = op_imm(State, sub, Reg, Reg, Val),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    NewState#state{regs = Regs1};
+sub(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) when
+    is_atom(Val)
+->
     I1 = jit_aarch64_asm:sub(Reg, Reg, Val),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Multiply a register by a constant value. Uses optimized instruction
@@ -2325,46 +2510,51 @@ mul(State, _Reg, 1) ->
     State;
 mul(State, Reg, 2) ->
     shift_left(State, Reg, 1);
-mul(#state{available_regs = Avail} = State, Reg, 3) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 3) ->
     Temp = first_avail(Avail),
     I1 = jit_aarch64_asm:lsl(Temp, Reg, 1),
     I2 = jit_aarch64_asm:add(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 4) ->
     shift_left(State, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 5) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 5) ->
     Temp = first_avail(Avail),
     I1 = jit_aarch64_asm:lsl(Temp, Reg, 2),
     I2 = jit_aarch64_asm:add(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State0, Reg, 6) ->
     State1 = mul(State0, Reg, 3),
     mul(State1, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 7) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 7) ->
     Temp = first_avail(Avail),
     I1 = jit_aarch64_asm:lsl(Temp, Reg, 3),
     I2 = jit_aarch64_asm:sub(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 8) ->
     shift_left(State, Reg, 3);
-mul(#state{available_regs = Avail} = State, Reg, 9) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 9) ->
     Temp = first_avail(Avail),
     I1 = jit_aarch64_asm:lsl(Temp, Reg, 3),
     I2 = jit_aarch64_asm:add(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State0, Reg, 10) ->
     State1 = mul(State0, Reg, 5),
     mul(State1, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 15) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 15) ->
     Temp = first_avail(Avail),
     I1 = jit_aarch64_asm:lsl(Temp, Reg, 4),
     I2 = jit_aarch64_asm:sub(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 16) ->
     shift_left(State, Reg, 4);
 mul(State, Reg, 32) ->
@@ -2372,16 +2562,17 @@ mul(State, Reg, 32) ->
 mul(State, Reg, 64) ->
     shift_left(State, Reg, 6);
 mul(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Reg,
     Val
 ) ->
     Temp = first_avail(Avail),
-    % multiply by decomposing by power of 2
     I1 = jit_aarch64_asm:mov(Temp, Val),
     I2 = jit_aarch64_asm:mul(Reg, Reg, Temp),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Decrement the reduction count and schedule the next process if it
@@ -2393,9 +2584,11 @@ mul(
 %%-----------------------------------------------------------------------------
 -spec decrement_reductions_and_maybe_schedule_next(state()) -> state().
 decrement_reductions_and_maybe_schedule_next(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State0
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State0
 ) ->
     Temp = first_avail(Avail),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     % Load reduction count
     I1 = jit_aarch64_asm:ldr_w(Temp, ?JITSTATE_REDUCTIONCOUNT),
     % Decrement reduction count
@@ -2412,7 +2605,7 @@ decrement_reductions_and_maybe_schedule_next(
     I6 = jit_aarch64_asm:str(Temp, ?JITSTATE_CONTINUATION),
     % Append the instructions to the stream
     Stream2 = StreamModule:append(Stream1, <<I4/binary, I5/binary, I6/binary>>),
-    State1 = State0#state{stream = Stream2},
+    State1 = State0#state{stream = Stream2, regs = Regs1},
     State2 = call_primitive_last(State1, ?PRIM_SCHEDULE_NEXT_CP, [ctx, jit_state]),
     % Rewrite the branch and adr instructions
     #state{stream = Stream3} = State2,
@@ -2422,7 +2615,10 @@ decrement_reductions_and_maybe_schedule_next(
     Stream4 = StreamModule:replace(
         Stream3, BNEOffset, <<NewI4/binary, NewI5/binary>>
     ),
-    merge_used_regs(State2#state{stream = Stream4}, State1#state.used_regs).
+    State3 = merge_used_regs(State2#state{stream = Stream4}, State1#state.used_regs),
+    %% The schedule_next path is a tail call (dead end), so the register tracking
+    %% from the non-taken path (State1) is what matters at the continuation.
+    State3#state{regs = State1#state.regs}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a call to a label with automatic scheduling. Decrements reductions
@@ -2613,10 +2809,6 @@ reg_bit(r15) -> ?REG_BIT_R15;
 reg_bit(r16) -> ?REG_BIT_R16;
 reg_bit(r17) -> ?REG_BIT_R17.
 
-regs_to_mask([]) -> 0;
-regs_to_mask([imm | T]) -> regs_to_mask(T);
-regs_to_mask([Reg | T]) -> reg_bit(Reg) bor regs_to_mask(T).
-
 %% first_avail returns the first available register from a bitmask.
 %% Order: [r7, r8, r9, r10, r11, r12, r13, r14, r15, r3, r4, r5, r6]
 first_avail(Mask) when Mask band ?REG_BIT_R7 =/= 0 -> r7;
@@ -2697,9 +2889,10 @@ args_regs(Args) ->
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec add_label(state(), integer() | reference()) -> state().
-add_label(#state{stream_module = StreamModule, stream = Stream} = State, Label) ->
+add_label(#state{stream_module = StreamModule, stream = Stream, regs = Regs0} = State, Label) ->
     Offset = StreamModule:offset(Stream),
-    add_label(State, Label, Offset).
+    Regs1 = jit_regs:invalidate_all(Regs0),
+    add_label(State#state{regs = Regs1}, Label, Offset).
 
 %%-----------------------------------------------------------------------------
 %% @doc Add a label at a specific offset

--- a/libs/jit/src/jit_armv6m.erl
+++ b/libs/jit/src/jit_armv6m.erl
@@ -139,7 +139,8 @@
     used_regs :: non_neg_integer(),
     labels :: [{integer() | reference(), integer()}],
     variant :: non_neg_integer(),
-    literal_pool :: [{non_neg_integer(), armv6m_register(), non_neg_integer()}]
+    literal_pool :: [{non_neg_integer(), armv6m_register(), non_neg_integer()}],
+    regs :: jit_regs:regs()
 }).
 
 -type state() :: #state{}.
@@ -278,7 +279,8 @@ new(Variant, StreamModule, Stream) ->
         used_regs = 0,
         labels = [],
         variant = Variant,
-        literal_pool = []
+        literal_pool = [],
+        regs = jit_regs:new()
     }.
 
 %%-----------------------------------------------------------------------------
@@ -630,7 +632,8 @@ call_primitive(
     StateCall = State#state{
         stream = Stream1,
         available_regs = Available band (bnot TempBit),
-        used_regs = Used bor TempBit
+        used_regs = Used bor TempBit,
+        regs = jit_regs:invalidate_reg(State#state.regs, TempReg)
     },
     call_func_ptr(StateCall, {free, TempReg}, Args);
 call_primitive(
@@ -663,8 +666,8 @@ call_primitive_last(
     % registers used for parameters
     ParamRegs = lists:sublist(?PARAMETER_REGS, length(Args)),
     ArgsRegs = args_regs(Args),
-    ParamMask = regs_to_mask(ParamRegs),
-    ArgsMask = regs_to_mask(ArgsRegs),
+    ParamMask = jit_regs:regs_to_mask(ParamRegs, fun reg_bit/1),
+    ArgsMask = jit_regs:regs_to_mask(ArgsRegs, fun reg_bit/1),
     ScratchMask = ?AVAILABLE_REGS_MASK band (bnot (ArgsMask bor ParamMask)),
     Temp = first_avail(ScratchMask),
     TempBit = reg_bit(Temp),
@@ -674,7 +677,10 @@ call_primitive_last(
     Stream1 = StreamModule:append(Stream0, PrepCall),
 
     State1 = State0#state{
-        stream = Stream1, available_regs = AvailableRegs1, used_regs = UsedRegs
+        stream = Stream1,
+        available_regs = AvailableRegs1,
+        used_regs = UsedRegs,
+        regs = jit_regs:invalidate_reg(State0#state.regs, Temp)
     },
 
     % Preprocess offset special arg
@@ -719,7 +725,8 @@ call_primitive_last(
         end,
     State5 = State4#state{
         available_regs = ?AVAILABLE_REGS_MASK,
-        used_regs = 0
+        used_regs = 0,
+        regs = jit_regs:invalidate_all(State4#state.regs)
     },
     flush_literal_pool(State5).
 
@@ -775,7 +782,8 @@ return_if_not_equal_to_ctx(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     {free, Reg}
 ) ->
@@ -791,10 +799,12 @@ return_if_not_equal_to_ctx(
     I2 = jit_armv6m_asm:bcc(eq, 2 + byte_size(I3) + byte_size(I4)),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>),
     RegBit = reg_bit(Reg),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
     State#state{
         stream = Stream1,
         available_regs = AvailableRegs0 bor RegBit,
-        used_regs = UsedRegs0 band (bnot RegBit)
+        used_regs = UsedRegs0 band (bnot RegBit),
+        regs = Regs1
     }.
 
 %%-----------------------------------------------------------------------------
@@ -812,14 +822,15 @@ jump_to_label(
     Offset = StreamModule:offset(Stream0),
     {State1, CodeBlock} = branch_to_label_code(State0, Offset, Label, LabelLookupResult),
     Stream1 = StreamModule:append(Stream0, CodeBlock),
-    State2 = State1#state{stream = Stream1},
+    %% After unconditional jump, register tracking is dead until next label
+    State2 = State1#state{stream = Stream1, regs = jit_regs:invalidate_all(State1#state.regs)},
     flush_literal_pool(State2).
 
 jump_to_offset(#state{stream_module = StreamModule, stream = Stream0} = State, TargetOffset) ->
     Offset = StreamModule:offset(Stream0),
     CodeBlock = branch_to_offset_code(State, Offset, TargetOffset),
     Stream1 = StreamModule:append(Stream0, CodeBlock),
-    State2 = State#state{stream = Stream1},
+    State2 = State#state{stream = Stream1, regs = jit_regs:invalidate_all(State#state.regs)},
     flush_literal_pool(State2).
 
 %%-----------------------------------------------------------------------------
@@ -1034,7 +1045,9 @@ if_block(
         Stream2,
         Replacements
     ),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs);
+    State3 = merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs),
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State3#state{regs = MergedRegs};
 if_block(
     #state{stream_module = StreamModule, stream = Stream0} = State0,
     Cond,
@@ -1049,7 +1062,9 @@ if_block(
     BranchOffset = OffsetAfter - (Offset + BranchInstrOffset),
     NewBranchInstr = jit_armv6m_asm:bcc(CC, BranchOffset),
     Stream3 = StreamModule:replace(Stream2, Offset + BranchInstrOffset, NewBranchInstr),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs).
+    State3 = merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs),
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State3#state{regs = MergedRegs}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit an if else block, i.e. emit a test of a condition and
@@ -1088,7 +1103,8 @@ if_else_block(
     StateElse = State2#state{
         stream = Stream4,
         used_regs = State1#state.used_regs,
-        available_regs = State1#state.available_regs
+        available_regs = State1#state.available_regs,
+        regs = State1#state.regs
     },
     State3 = BlockFalseFn(StateElse),
     Stream5 = State3#state.stream,
@@ -1097,7 +1113,9 @@ if_else_block(
     FinalJumpOffset = OffsetFinal - ElseJumpOffset,
     NewElseJumpInstr = jit_armv6m_asm:b(FinalJumpOffset),
     Stream6 = StreamModule:replace(Stream5, ElseJumpOffset, NewElseJumpInstr),
-    merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs).
+    State4 = merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs),
+    MergedRegs = jit_regs:merge(State2#state.regs, State3#state.regs),
+    State4#state{regs = MergedRegs}.
 
 -spec if_block_cond(state(), condition()) ->
     {
@@ -1145,7 +1163,8 @@ if_block_cond(
     Code = <<I1/binary, I2/binary>>,
     Stream2 = StreamModule:append(Stream1, Code),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, le, Offset1 - Offset0 + byte_size(I1)};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0} = State0, {RegOrTuple, '<', 0}
@@ -1201,7 +1220,8 @@ if_block_cond(
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, 16#FFFF:16>>),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, CC, Offset1 - Offset0 + byte_size(I1)};
 if_block_cond(
     #state{stream_module = StreamModule, available_regs = Available} = State0,
@@ -1221,7 +1241,8 @@ if_block_cond(
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, 16#FFFF:16>>),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream1},
+    Regs2b = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream1, regs = Regs2b},
     {State3, CC, byte_size(I1)};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0} = State0,
@@ -1328,7 +1349,8 @@ if_block_cond(
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, 16#FFFF:16>>),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2c = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2c},
     {State3, CC, Offset1 - Offset0 + byte_size(I1)};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} = State0,
@@ -1349,7 +1371,8 @@ if_block_cond(
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, 16#FFFF:16>>),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2d = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2d},
     {State3, CC, Offset1 - Offset0 + byte_size(I1)};
 if_block_cond(
     #state{
@@ -1372,7 +1395,8 @@ if_block_cond(
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, 16#FFFF:16>>),
     State1 = if_block_free_reg(RegOrTuple, State0),
-    State2 = State1#state{stream = Stream1},
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream1, regs = Regs1},
     {State2, CC, byte_size(I1)};
 if_block_cond(
     #state{
@@ -1395,7 +1419,8 @@ if_block_cond(
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, 16#FFFF:16>>),
     State1 = if_block_free_reg(RegOrTuple, State0),
-    State2 = State1#state{stream = Stream1},
+    Regs1b = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream1, regs = Regs1b},
     {State2, CC, byte_size(I1)};
 if_block_cond(
     #state{
@@ -1430,7 +1455,8 @@ if_block_cond(
     Code = <<TestCode/binary, 16#FFFF:16>>,
     Stream1 = StreamModule:append(Stream0, Code),
     State1 = if_block_free_reg(RegOrTuple, State0),
-    State2 = State1#state{stream = Stream1},
+    Regs1c = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream1, regs = Regs1c},
     {State2, BranchCond, byte_size(TestCode)};
 if_block_cond(
     #state{
@@ -1448,7 +1474,8 @@ if_block_cond(
     CC = eq,
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, 16#FFFF:16>>),
-    State1 = State0#state{stream = Stream1},
+    Regs1d = jit_regs:invalidate_reg(State0#state.regs, Temp),
+    State1 = State0#state{stream = Stream1, regs = Regs1d},
     {State1, CC, byte_size(I1) + byte_size(I2)};
 if_block_cond(
     #state{
@@ -1464,7 +1491,8 @@ if_block_cond(
     CC = eq,
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, 16#FFFF:16>>),
-    State1 = State0#state{stream = Stream1},
+    Regs1 = jit_regs:invalidate_reg(State0#state.regs, Reg),
+    State1 = State0#state{stream = Stream1, regs = Regs1},
     State2 = if_block_free_reg(RegTuple, State1),
     {State2, CC, byte_size(I1) + byte_size(I2)};
 if_block_cond(
@@ -1492,8 +1520,9 @@ if_block_cond(
     CC = eq,
     ?ASSERT(byte_size(jit_armv6m_asm:bcc(CC, 0)) =:= 2),
     Stream4 = StreamModule:append(Stream3, <<16#FFFF:16>>),
+    Regs3 = jit_regs:invalidate_reg(State2#state.regs, Temp),
     State3 = State2#state{
-        stream = Stream4, available_regs = State2#state.available_regs bor TempBit
+        stream = Stream4, available_regs = State2#state.available_regs bor TempBit, regs = Regs3
     },
     {State3, CC, OffsetAfter - OffsetBefore};
 if_block_cond(
@@ -1560,18 +1589,22 @@ merge_used_regs(#state{used_regs = UR} = State, OtherUR) ->
 %%-----------------------------------------------------------------------------
 -spec shift_right(#state{}, maybe_free_armv6m_register(), non_neg_integer()) ->
     {#state{}, armv6m_register()}.
-shift_right(#state{stream_module = StreamModule, stream = Stream0} = State, {free, Reg}, Shift) when
+shift_right(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, {free, Reg}, Shift
+) when
     ?IS_GPR(Reg) andalso is_integer(Shift)
 ->
     I = jit_armv6m_asm:lsrs(Reg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 shift_right(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UR
+        used_regs = UR,
+        regs = Regs0
     } = State,
     Reg,
     Shift
@@ -1582,9 +1615,13 @@ shift_right(
     Bit = reg_bit(ResultReg),
     I = jit_armv6m_asm:lsrs(ResultReg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State#state{
-            stream = Stream1, available_regs = Avail band (bnot Bit), used_regs = UR bor Bit
+            stream = Stream1,
+            available_regs = Avail band (bnot Bit),
+            used_regs = UR bor Bit,
+            regs = Regs1
         },
         ResultReg
     }.
@@ -1597,12 +1634,15 @@ shift_right(
 %% @param Shift number of bits to shift
 %% @return new state
 %%-----------------------------------------------------------------------------
-shift_left(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Shift) when
+shift_left(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Shift
+) when
     is_atom(Reg)
 ->
     I = jit_armv6m_asm:lsls(Reg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a call to a function pointer with arguments. This function converts
@@ -1841,11 +1881,13 @@ call_func_ptr(
 
     ResultRegBit = reg_bit(ResultReg),
     AvailableRegs3Mask = (AvailableRegs1Mask band (bnot ResultRegBit)) band ?AVAILABLE_REGS_MASK,
+    Regs1 = jit_regs:invalidate_all(State0#state.regs),
     {
         State4#state{
             stream = Stream8,
             available_regs = AvailableRegs3Mask,
-            used_regs = UsedRegs2Mask
+            used_regs = UsedRegs2Mask,
+            regs = Regs1
         },
         ResultReg
     }.
@@ -2107,29 +2149,56 @@ set_registers_args1(State, Value, Reg, _StackOffset) when ?IS_SIGNED_OR_UNSIGNED
 %%-----------------------------------------------------------------------------
 -spec move_to_vm_register(state(), Src :: value() | vm_register(), Dest :: vm_register()) ->
     state().
+move_to_vm_register(#state{regs = Regs0} = State, Src, Dest) ->
+    VmLoc = jit_regs:vm_dest_to_contents(Dest, ?MAX_REG),
+    Regs1 =
+        case VmLoc of
+            unknown -> Regs0;
+            _ -> jit_regs:invalidate_vm_loc(Regs0, VmLoc)
+        end,
+    State1 = move_to_vm_register_emit(State#state{regs = Regs1}, Src, Dest),
+    case {Src, VmLoc} of
+        {Reg, Contents} when is_atom(Reg), Contents =/= unknown ->
+            #state{regs = Regs2} = State1,
+            State1#state{regs = jit_regs:set_contents(Regs2, Reg, Contents)};
+        _ ->
+            State1
+    end.
+
 % Native register to VM register
-move_to_vm_register(State0, Src, {x_reg, extra}) when is_atom(Src) ->
+move_to_vm_register_emit(State0, Src, {x_reg, extra}) when is_atom(Src) ->
     I1 = jit_armv6m_asm:str(Src, ?X_REG(?MAX_REG)),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State0#state{stream = Stream1};
-move_to_vm_register(State0, Src, {x_reg, X}) when is_atom(Src) ->
+move_to_vm_register_emit(State0, Src, {x_reg, X}) when is_atom(Src) ->
     I1 = jit_armv6m_asm:str(Src, ?X_REG(X)),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State0#state{stream = Stream1};
-move_to_vm_register(State0, Src, {ptr, Reg}) when is_atom(Src) ->
+move_to_vm_register_emit(State0, Src, {ptr, Reg}) when is_atom(Src) ->
     I1 = jit_armv6m_asm:str(Src, {Reg, 0}),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State0#state{stream = Stream1};
-move_to_vm_register(#state{available_regs = Avail} = State0, Src, {y_reg, Y}) when
+move_to_vm_register_emit(
+    #state{available_regs = Avail, regs = Regs0} = State0, Src, {y_reg, Y}
+) when
     is_atom(Src)
 ->
     Temp1 = first_avail(Avail),
     AT = Avail band (bnot reg_bit(Temp1)),
     Code = str_y_reg(Src, Y, Temp1, AT),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, Code),
-    State0#state{stream = Stream1};
+    % str_y_reg clobbers Temp1, and for large offsets also clobbers first_avail(AT)
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp1),
+    Regs2 =
+        case AT of
+            0 -> Regs1;
+            _ -> jit_regs:invalidate_reg(Regs1, first_avail(AT))
+        end,
+    State0#state{stream = Stream1, regs = Regs2};
 % Source is an integer to y_reg (optimized: ldr first, then movs)
-move_to_vm_register(#state{available_regs = Avail} = State0, N, {y_reg, Y}) when
+move_to_vm_register_emit(
+    #state{available_regs = Avail, regs = Regs0} = State0, N, {y_reg, Y}
+) when
     is_integer(N), N >= 0, N =< 255
 ->
     Temp1 = first_avail(Avail),
@@ -2139,9 +2208,16 @@ move_to_vm_register(#state{available_regs = Avail} = State0, N, {y_reg, Y}) when
     I1 = jit_armv6m_asm:movs(Temp2, N),
     YCode = str_y_reg(Temp2, Y, Temp1, AT),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, <<I1/binary, YCode/binary>>),
-    State0#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp1), Temp2),
+    % str_y_reg may clobber first_avail(AT) for large offsets
+    Regs2 =
+        case AT of
+            0 -> Regs1;
+            _ -> jit_regs:invalidate_reg(Regs1, first_avail(AT))
+        end,
+    State0#state{stream = Stream1, regs = Regs2};
 % Source is an integer (0-255 for movs, negative values need different handling)
-move_to_vm_register(#state{available_regs = AR0} = State0, N, Dest) when
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, N, Dest) when
     is_integer(N), N >= 0, N =< 255
 ->
     Temp = first_avail(AR0),
@@ -2149,47 +2225,64 @@ move_to_vm_register(#state{available_regs = AR0} = State0, N, Dest) when
     I1 = jit_armv6m_asm:movs(Temp, N),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 %% Handle large values using simple literal pool (branch-over pattern)
-move_to_vm_register(#state{available_regs = AR0} = State0, N, Dest) when
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, N, Dest) when
     is_integer(N)
 ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     State1 = mov_immediate(State0#state{available_regs = AT}, Temp, N),
     State2 = move_to_vm_register(State1, Temp, Dest),
-    State2#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State2#state{available_regs = AR0, regs = Regs1};
 % Source is a VM register
-move_to_vm_register(#state{available_regs = AR0} = State0, {x_reg, extra}, Dest) ->
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, {x_reg, extra}, Dest) ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     I1 = jit_armv6m_asm:ldr(Temp, ?X_REG(?MAX_REG)),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
-move_to_vm_register(#state{available_regs = AR0} = State0, {x_reg, X}, Dest) ->
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, {x_reg, X}, Dest) ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     I1 = jit_armv6m_asm:ldr(Temp, ?X_REG(X)),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
-move_to_vm_register(#state{available_regs = AR0} = State0, {ptr, Reg}, Dest) ->
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, {ptr, Reg}, Dest) ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     I1 = jit_armv6m_asm:ldr(Temp, {Reg, 0}),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
-move_to_vm_register(#state{available_regs = AR0} = State0, {y_reg, Y}, Dest) ->
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, {y_reg, Y}, Dest) ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     Code = ldr_y_reg(Temp, Y, AT),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, Code),
-    State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
+    % ldr_y_reg clobbers first_avail(AT) as a hidden temp for loading Y_REGS pointer
+    Regs0a =
+        case AT of
+            0 -> State0#state.regs;
+            _ -> jit_regs:invalidate_reg(State0#state.regs, first_avail(AT))
+        end,
+    State0a = State0#state{
+        stream = Stream1,
+        available_regs = AT,
+        regs = Regs0a
+    },
+    State1 = move_to_vm_register(State0a, Temp, Dest),
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 % term_to_float
-move_to_vm_register(
+move_to_vm_register_emit(
     #state{
         stream_module = StreamModule,
         available_regs = Avail,
@@ -2218,7 +2311,8 @@ move_to_vm_register(
     end,
     Stream1 = StreamModule:append(Stream0, Code),
     State1 = free_native_register(State0, Reg),
-    State1#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(State1#state.regs, Temp1), Temp2),
+    State1#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a move of an array element (reg[x]) to a vm or a native register.
@@ -2236,7 +2330,8 @@ move_to_vm_register(
     vm_register() | armv6m_register()
 ) -> state().
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Reg,
     Index,
     {x_reg, X}
@@ -2245,7 +2340,9 @@ move_array_element(
     I1 = jit_armv6m_asm:ldr(Temp, {Reg, Index * 4}),
     I2 = jit_armv6m_asm:str(Temp, ?X_REG(X)),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
+    State#state{stream = Stream1, regs = Regs2};
 move_array_element(
     #state{stream_module = StreamModule, available_regs = Avail} =
         State,
@@ -2269,9 +2366,13 @@ move_array_element(
     % str Temp2, [r0, #X*4]
     I3 = jit_armv6m_asm:str(Temp2, ?X_REG(X)),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, I2/binary, I3/binary>>),
-    State1#state{stream = Stream2};
+    Regs1 = jit_regs:invalidate_vm_loc(State1#state.regs, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp1),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp2),
+    State1#state{stream = Stream2, regs = Regs3};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Reg,
     Index,
     {ptr, Dest}
@@ -2280,7 +2381,8 @@ move_array_element(
     I1 = jit_armv6m_asm:ldr(Temp, {Reg, Index * 4}),
     I2 = jit_armv6m_asm:str(Temp, {Dest, 0}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_array_element(
     #state{stream_module = StreamModule, available_regs = Avail} =
         State,
@@ -2300,9 +2402,10 @@ move_array_element(
     I2 = jit_armv6m_asm:ldr(Temp, {Temp, LdrOffset}),
     I3 = jit_armv6m_asm:str(Temp, {Dest, 0}),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, I2/binary, I3/binary>>),
-    State1#state{stream = Stream2};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{stream = Stream2, regs = Regs1};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} =
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
         State,
     Reg,
     Index,
@@ -2316,7 +2419,10 @@ move_array_element(
     YCode = str_y_reg(Temp2, Y, Temp1, AT),
     Code = <<I1/binary, YCode/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp1),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp2),
+    State#state{stream = Stream1, regs = Regs3};
 move_array_element(
     #state{
         stream_module = StreamModule, available_regs = Avail
@@ -2341,9 +2447,12 @@ move_array_element(
     YCode = str_y_reg(Temp2, Y, Temp1, AT),
     Code = <<I1/binary, I2/binary, YCode/binary>>,
     Stream2 = StreamModule:append(Stream1, Code),
-    State1#state{stream = Stream2};
+    Regs1 = jit_regs:invalidate_vm_loc(State1#state.regs, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp1),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp2),
+    State1#state{stream = Stream2, regs = Regs3};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} =
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
         State,
     {free, Reg},
     Index,
@@ -2355,19 +2464,24 @@ move_array_element(
     YCode = str_y_reg(Reg, Y, Temp, AT),
     Code = <<I1/binary, YCode/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Reg),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp),
+    State#state{stream = Stream1, regs = Regs3};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0} = State, Reg, Index, Dest
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Index, Dest
 ) when is_atom(Dest) andalso is_integer(Index) ->
     I1 = jit_armv6m_asm:ldr(Dest, {Reg, Index * 4}),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Dest),
+    State#state{stream = Stream1, regs = Regs1};
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -2380,17 +2494,21 @@ move_array_element(
     AvailableRegs1 = AvailableRegs0 bor Bit,
     UsedRegs1 = UsedRegs0 band (bnot Bit),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, IndexReg),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs2
     };
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -2403,17 +2521,20 @@ move_array_element(
     AvailableRegs1 = AvailableRegs0 bor Bit,
     UsedRegs1 = UsedRegs0 band (bnot Bit),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, IndexReg),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs1
     };
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -2432,10 +2553,14 @@ move_array_element(
     Stream1 = StreamModule:append(
         Stream0, <<I1/binary, I2/binary, I3/binary>>
     ),
+    Regs1 = jit_regs:invalidate_reg(Regs0, IndexReg),
+    Regs2 = jit_regs:invalidate_vm_loc(Regs1, {y_reg, Y}),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs3
     }.
 
 %% @doc move reg[x] to a vm or native register
@@ -2444,14 +2569,16 @@ move_array_element(
 get_array_element(
     #state{
         stream_module = StreamModule,
-        stream = Stream0
+        stream = Stream0,
+        regs = Regs0
     } = State,
     {free, Reg},
     Index
 ) when Index * 4 =< 124 ->
     I1 = jit_armv6m_asm:ldr(Reg, {Reg, Index * 4}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary>>),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 get_array_element(
     #state{
         stream_module = StreamModule,
@@ -2469,13 +2596,16 @@ get_array_element(
     I1 = jit_armv6m_asm:add(Reg, Temp),
     I2 = jit_armv6m_asm:ldr(Reg, {Reg, 124}),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, I2/binary>>),
-    {State1#state{stream = Stream2}, Reg};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Reg),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
+    {State1#state{stream = Stream2, regs = Regs2}, Reg};
 get_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     Index
@@ -2484,11 +2614,13 @@ get_array_element(
     ElemBit = reg_bit(ElemReg),
     I1 = jit_armv6m_asm:ldr(ElemReg, {Reg, Index * 4}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ElemReg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot ElemBit),
-            used_regs = UsedRegs0 bor ElemBit
+            used_regs = UsedRegs0 bor ElemBit,
+            regs = Regs1
         },
         ElemReg
     };
@@ -2514,11 +2646,14 @@ get_array_element(
     I1 = jit_armv6m_asm:add(Temp, Reg),
     I2 = jit_armv6m_asm:ldr(ElemReg, {Temp, 124}),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, I2/binary>>),
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, ElemReg),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
     {
         State1#state{
             stream = Stream2,
             available_regs = Avail1,
-            used_regs = UsedRegs0 bor ElemBit
+            used_regs = UsedRegs0 bor ElemBit,
+            regs = Regs2
         },
         ElemReg
     }.
@@ -2552,9 +2687,11 @@ move_to_array_element(
     I1 = jit_armv6m_asm:add(Temp, Reg),
     I2 = jit_armv6m_asm:str(ValueReg, {Temp, 124}),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, I2/binary>>),
-    State1#state{stream = Stream2};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{stream = Stream2, regs = Regs1};
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State0,
     ValueReg,
     Reg,
     IndexReg
@@ -2564,7 +2701,8 @@ move_to_array_element(
     I2 = jit_armv6m_asm:lsls(Temp, Temp, 2),
     I3 = jit_armv6m_asm:str(ValueReg, {Reg, Temp}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
-    State0#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State0#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
     State0,
     Value,
@@ -2584,7 +2722,8 @@ move_to_array_element(
 ) when is_integer(IndexReg) andalso is_integer(Offset) andalso Offset div 8 =:= 0 ->
     move_to_array_element(State, Value, BaseReg, IndexReg + (Offset div 8));
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     ValueReg,
     BaseReg,
     IndexReg,
@@ -2595,7 +2734,8 @@ move_to_array_element(
     I2 = jit_armv6m_asm:lsls(Temp, Temp, 2),
     I3 = jit_armv6m_asm:str(ValueReg, {BaseReg, Temp}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
     State0,
     Value,
@@ -2611,77 +2751,128 @@ move_to_array_element(
     Stream1 = (State1#state.stream_module):append(
         State1#state.stream, <<I1/binary, I2/binary, I3/binary>>
     ),
-    State2 = State1#state{stream = Stream1},
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream1, regs = Regs1},
     free_native_register(State2, ValueReg).
 
 -spec move_to_native_register(state(), value() | cp) -> {state(), armv6m_register()}.
-move_to_native_register(
+move_to_native_register(State, Reg) when ?IS_GPR(Reg) ->
+    {State, Reg};
+move_to_native_register(#state{regs = Regs} = State, Value) ->
+    Contents = jit_regs:value_to_contents(Value, ?MAX_REG),
+    case Contents =/= unknown andalso jit_regs:find_reg_with_contents(Regs, Contents) of
+        {ok, CachedReg} ->
+            Bit = reg_bit(CachedReg),
+            case State#state.used_regs band Bit of
+                0 ->
+                    case State#state.available_regs band Bit of
+                        0 ->
+                            move_to_native_register_emit(State, Value, Contents);
+                        _ ->
+                            {
+                                State#state{
+                                    used_regs = State#state.used_regs bor Bit,
+                                    available_regs = State#state.available_regs band (bnot Bit)
+                                },
+                                CachedReg
+                            }
+                    end;
+                _ ->
+                    {State, CachedReg}
+            end;
+        _ ->
+            move_to_native_register_emit(State, Value, Contents)
+    end.
+
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    cp
+    cp,
+    Contents
 ) ->
     Reg = first_avail(Avail),
     Bit = reg_bit(Reg),
     I1 = jit_armv6m_asm:ldr(Reg, ?CP),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
-            stream = Stream1, used_regs = Used bor Bit, available_regs = Avail band (bnot Bit)
+            stream = Stream1,
+            used_regs = Used bor Bit,
+            available_regs = Avail band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
-move_to_native_register(State, Reg) when is_atom(Reg) ->
-    {State, Reg};
-move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0} = State, {ptr, Reg}
+move_to_native_register_emit(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State,
+    {ptr, Reg},
+    _Contents
 ) when is_atom(Reg) ->
     I1 = jit_armv6m_asm:ldr(Reg, {Reg, 0}),
     Stream1 = StreamModule:append(Stream0, I1),
-    {State#state{stream = Stream1}, Reg};
-move_to_native_register(
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
+move_to_native_register_emit(
     #state{
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State0,
-    Imm
+    Imm,
+    Contents
 ) when
     is_integer(Imm)
 ->
     Reg = first_avail(Avail),
     Bit = reg_bit(Reg),
-    State1 = State0#state{used_regs = Used bor Bit, available_regs = Avail band (bnot Bit)},
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
+    State1 = State0#state{
+        used_regs = Used bor Bit,
+        available_regs = Avail band (bnot Bit),
+        regs = Regs1
+    },
     {move_to_native_register(State1, Imm, Reg), Reg};
-move_to_native_register(
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {x_reg, extra}
+    {x_reg, extra},
+    Contents
 ) ->
     Reg = first_avail(Avail),
     Bit = reg_bit(Reg),
     I1 = jit_armv6m_asm:ldr(Reg, ?X_REG(?MAX_REG)),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
-            stream = Stream1, used_regs = Used bor Bit, available_regs = Avail band (bnot Bit)
+            stream = Stream1,
+            used_regs = Used bor Bit,
+            available_regs = Avail band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
-move_to_native_register(
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {x_reg, X}
+    {x_reg, X},
+    Contents
 ) when
     X < ?MAX_REG
 ->
@@ -2689,35 +2880,57 @@ move_to_native_register(
     Bit = reg_bit(Reg),
     I1 = jit_armv6m_asm:ldr(Reg, ?X_REG(X)),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
-            stream = Stream1, used_regs = Used bor Bit, available_regs = Avail band (bnot Bit)
+            stream = Stream1,
+            used_regs = Used bor Bit,
+            available_regs = Avail band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
-move_to_native_register(
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {y_reg, Y}
+    {y_reg, Y},
+    Contents
 ) ->
     Reg = first_avail(Avail),
     Bit = reg_bit(Reg),
     AvailT = Avail band (bnot Bit),
     Code = ldr_y_reg(Reg, Y, AvailT),
     Stream1 = StreamModule:append(Stream0, Code),
-    {State#state{stream = Stream1, available_regs = AvailT, used_regs = Used bor Bit}, Reg};
-move_to_native_register(
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
+    % ldr_y_reg clobbers first_avail(AvailT) as a hidden temp for loading Y_REGS pointer
+    Regs2 =
+        case AvailT of
+            0 -> Regs1;
+            _ -> jit_regs:invalidate_reg(Regs1, first_avail(AvailT))
+        end,
+    {
+        State#state{
+            stream = Stream1,
+            available_regs = AvailT,
+            used_regs = Used bor Bit,
+            regs = Regs2
+        },
+        Reg
+    };
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
         used_regs = Used
     } = State,
-    {fp_reg, F}
+    {fp_reg, F},
+    _Contents
 ) ->
     RegA = first_avail(Avail),
     BitA = reg_bit(RegA),
@@ -2737,13 +2950,18 @@ move_to_native_register(
 
 -spec move_to_native_register(state(), value(), armv6m_register()) -> state().
 move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0} = State, RegSrc, RegDst
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, RegSrc, RegDst
 ) when is_atom(RegSrc) ->
     I = jit_armv6m_asm:mov(RegDst, RegSrc),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1};
+    SrcContents = jit_regs:get_contents(Regs0, RegSrc),
+    Regs1 = jit_regs:set_contents(Regs0, RegDst, SrcContents),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_native_register(State, ValSrc, RegDst) when is_integer(ValSrc) ->
-    mov_immediate(State, RegDst, ValSrc);
+    State1 = mov_immediate(State, RegDst, ValSrc),
+    #state{regs = Regs0} = State1,
+    Regs1 = jit_regs:set_contents(Regs0, RegDst, {imm, ValSrc}),
+    State1#state{regs = Regs1};
 move_to_native_register(
     #state{stream_module = StreamModule, stream = Stream0} = State, {ptr, Reg}, RegDst
 ) when ?IS_GPR(Reg) ->
@@ -2765,13 +2983,20 @@ move_to_native_register(
     Stream1 = StreamModule:append(Stream0, I1),
     State#state{stream = Stream1};
 move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = AT} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = AT, regs = Regs0} =
+        State,
     {y_reg, Y},
     RegDst
 ) ->
     Code = ldr_y_reg(RegDst, Y, AT),
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    % ldr_y_reg clobbers first_avail(AT) as a hidden temp for loading Y_REGS pointer
+    Regs1 =
+        case AT of
+            0 -> Regs0;
+            _ -> jit_regs:invalidate_reg(Regs0, first_avail(AT))
+        end,
+    State#state{stream = Stream1, regs = Regs1};
 move_to_native_register(
     #state{
         stream_module = StreamModule,
@@ -2793,7 +3018,8 @@ copy_to_native_register(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     Reg
 ) when is_atom(Reg) ->
@@ -2801,11 +3027,14 @@ copy_to_native_register(
     SaveBit = reg_bit(SaveReg),
     I1 = jit_armv6m_asm:mov(SaveReg, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
+    SrcContents = jit_regs:get_contents(Regs0, Reg),
+    Regs1 = jit_regs:set_contents(Regs0, SaveReg, SrcContents),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot SaveBit),
-            used_regs = Used bor SaveBit
+            used_regs = Used bor SaveBit,
+            regs = Regs1
         },
         SaveReg
     };
@@ -2814,7 +3043,8 @@ copy_to_native_register(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     {ptr, Reg}
 ) when is_atom(Reg) ->
@@ -2822,11 +3052,13 @@ copy_to_native_register(
     SaveBit = reg_bit(SaveReg),
     I1 = jit_armv6m_asm:ldr(SaveReg, {Reg, 0}),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:invalidate_reg(Regs0, SaveReg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot SaveBit),
-            used_regs = Used bor SaveBit
+            used_regs = Used bor SaveBit,
+            regs = Regs1
         },
         SaveReg
     };
@@ -2834,7 +3066,8 @@ copy_to_native_register(State, Reg) ->
     move_to_native_register(State, Reg).
 
 move_to_cp(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     {y_reg, Y}
 ) ->
     Reg = first_avail(Avail),
@@ -2843,10 +3076,18 @@ move_to_cp(
     I2 = jit_armv6m_asm:str(Reg, ?CP),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1}.
+    % ldr_y_reg clobbers first_avail(AvailT) as a hidden temp for loading Y_REGS pointer
+    Regs1a = jit_regs:invalidate_reg(Regs0, Reg),
+    Regs1 =
+        case AvailT of
+            0 -> Regs1a;
+            _ -> jit_regs:invalidate_reg(Regs1a, first_avail(AvailT))
+        end,
+    State#state{stream = Stream1, regs = Regs1}.
 
 increment_sp(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Offset
 ) ->
     Reg = first_avail(Avail),
@@ -2855,7 +3096,8 @@ increment_sp(
     I3 = jit_armv6m_asm:str(Reg, ?Y_REGS),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 set_continuation_to_label(
     #state{
@@ -2892,7 +3134,8 @@ set_continuation_to_label(
 
     Code = <<I2/binary, I3/binary, I4/binary>>,
     Stream2 = StreamModule:append(State1#state.stream, Code),
-    State1#state{stream = Stream2}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(State#state.regs, Temp1), Temp2),
+    State1#state{stream = Stream2, regs = Regs1}.
 
 %% @doc Set the contination to a given offset
 %% Return a reference so the offset will be updated with update_branches
@@ -2903,7 +3146,8 @@ set_continuation_to_offset(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        branches = Branches
+        branches = Branches,
+        regs = Regs0
     } = State
 ) ->
     Temp = first_avail(Avail),
@@ -2920,7 +3164,8 @@ set_continuation_to_offset(
     I4 = jit_armv6m_asm:str(Temp, ?JITSTATE_CONTINUATION(TempJitState)),
     Code = <<I1/binary, I2/binary, I3/binary, I4/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    {State#state{stream = Stream1, branches = [Reloc | Branches]}, OffsetRef}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), TempJitState),
+    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
 
 %% @doc Implement a continuation entry point.
 %% TODO: push r4-r7 and lr
@@ -2947,7 +3192,8 @@ get_module_index(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State
 ) ->
     Reg = first_avail(Avail),
@@ -2960,11 +3206,13 @@ get_module_index(
     I2 = jit_armv6m_asm:ldr(Reg, ?MODULE_INDEX(Reg)),
     Code = <<I1a/binary, I1b/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempJitState), Reg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail1,
-            used_regs = UsedRegs0 bor RegBit
+            used_regs = UsedRegs0 bor RegBit,
+            regs = Regs1
         },
         Reg
     }.
@@ -2973,19 +3221,29 @@ get_module_index(
 %% JIT currentl calls this with two values: ?TERM_PRIMARY_CLEAR_MASK (-4) to
 %% clear bits and ?TERM_BOXED_TAG_MASK (0x3F). We can avoid any literal pool
 %% by using BICS for -4.
-and_(#state{stream_module = StreamModule, stream = Stream0} = State0, {free, Reg}, SrcReg) when
+and_(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0,
+    {free, Reg},
+    SrcReg
+) when
     is_atom(SrcReg)
 ->
     I = jit_armv6m_asm:ands(Reg, SrcReg),
     Stream1 = StreamModule:append(Stream0, I),
-    {State0#state{stream = Stream1}, Reg};
-and_(#state{stream_module = StreamModule, stream = Stream0} = State0, {free, Reg}, 16#FFFFFF) ->
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State0#state{stream = Stream1, regs = Regs1}, Reg};
+and_(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0,
+    {free, Reg},
+    16#FFFFFF
+) ->
     I1 = jit_armv6m_asm:lsls(Reg, Reg, 8),
     I2 = jit_armv6m_asm:lsrs(Reg, Reg, 8),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    {State0#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State0#state{stream = Stream1, regs = Regs1}, Reg};
 and_(
-    #state{stream_module = StreamModule, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0,
     {free, Reg},
     Val
 ) when Avail =/= 0 andalso Val < 0 andalso Val >= -256 ->
@@ -2996,9 +3254,10 @@ and_(
     Stream1 = State1#state.stream,
     I = jit_armv6m_asm:bics(Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    {State1#state{available_regs = AT bor TempBit, stream = Stream2}, Reg};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    {State1#state{available_regs = AT bor TempBit, stream = Stream2, regs = Regs1}, Reg};
 and_(
-    #state{stream_module = StreamModule, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0,
     {free, Reg},
     Val
 ) when Avail =/= 0 ->
@@ -3009,7 +3268,8 @@ and_(
     Stream1 = State1#state.stream,
     I = jit_armv6m_asm:ands(Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    {State1#state{available_regs = AT bor TempBit, stream = Stream2}, Reg};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    {State1#state{available_regs = AT bor TempBit, stream = Stream2, regs = Regs1}, Reg};
 and_(
     #state{stream_module = StreamModule, available_regs = 0} = State0,
     {free, Reg},
@@ -3029,9 +3289,10 @@ and_(
     % Restore r0 from r12
     Restore = jit_armv6m_asm:mov(r0, ?IP_REG),
     Stream4 = StreamModule:append(Stream3, Restore),
-    {State0#state{stream = Stream4}, Reg};
+    Regs1 = jit_regs:invalidate_reg(State0#state.regs, Reg),
+    {State0#state{stream = Stream4, regs = Regs1}, Reg};
 and_(
-    #state{stream_module = StreamModule, available_regs = 0} = State0,
+    #state{stream_module = StreamModule, available_regs = 0, regs = Regs0} = State0,
     {free, Reg},
     Val
 ) ->
@@ -3049,9 +3310,10 @@ and_(
     % Restore r0 from r12
     Restore = jit_armv6m_asm:mov(r0, ?IP_REG),
     Stream4 = StreamModule:append(Stream3, Restore),
-    {State0#state{stream = Stream4}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State0#state{stream = Stream4, regs = Regs1}, Reg};
 and_(
-    #state{stream_module = StreamModule, available_regs = Avail, used_regs = UR} =
+    #state{stream_module = StreamModule, available_regs = Avail, used_regs = UR, regs = Regs0} =
         State0,
     Reg,
     ?TERM_PRIMARY_CLEAR_MASK
@@ -3061,23 +3323,26 @@ and_(
     I1 = jit_armv6m_asm:lsrs(ResultReg, Reg, 2),
     I2 = jit_armv6m_asm:lsls(ResultReg, ResultReg, 2),
     Stream1 = StreamModule:append(State0#state.stream, <<I1/binary, I2/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State0#state{
             stream = Stream1,
             available_regs = Avail band (bnot ResultBit),
-            used_regs = UR bor ResultBit
+            used_regs = UR bor ResultBit,
+            regs = Regs1
         },
         ResultReg
     }.
 
-or_(#state{stream_module = StreamModule, stream = Stream0} = State0, Reg, SrcReg) when
+or_(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, Reg, SrcReg) when
     is_atom(SrcReg)
 ->
     I = jit_armv6m_asm:orrs(Reg, SrcReg),
     Stream1 = StreamModule:append(Stream0, I),
-    State0#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State0#state{stream = Stream1, regs = Regs1};
 or_(
-    #state{stream_module = StreamModule, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0,
     Reg,
     Val
 ) ->
@@ -3087,22 +3352,25 @@ or_(
     Stream1 = State1#state.stream,
     I = jit_armv6m_asm:orrs(Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    State1#state{available_regs = Avail, stream = Stream2}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    State1#state{available_regs = Avail, stream = Stream2, regs = Regs1}.
 
-add(#state{stream_module = StreamModule, stream = Stream0} = State0, Reg, Val) when
+add(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, Reg, Val) when
     (Val >= 0 andalso Val =< 255) orelse is_atom(Val)
 ->
     I = jit_armv6m_asm:adds(Reg, Reg, Val),
     Stream1 = StreamModule:append(Stream0, I),
-    State0#state{stream = Stream1};
-add(#state{stream_module = StreamModule, available_regs = Avail} = State0, Reg, Val) ->
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State0#state{stream = Stream1, regs = Regs1};
+add(#state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0, Reg, Val) ->
     Temp = first_avail(Avail),
     AT = Avail band (bnot reg_bit(Temp)),
     State1 = mov_immediate(State0#state{available_regs = AT}, Temp, Val),
     Stream1 = State1#state.stream,
     I = jit_armv6m_asm:adds(Reg, Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    State1#state{available_regs = Avail, stream = Stream2}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    State1#state{available_regs = Avail, stream = Stream2, regs = Regs1}.
 
 mov_immediate(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) when
     Val >= 0 andalso Val =< 255
@@ -3245,65 +3513,72 @@ flush_literal_pool(
     ),
     State#state{stream = Stream2, literal_pool = []}.
 
-sub(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) when
+sub(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) when
     (Val >= 0 andalso Val =< 255) orelse is_atom(Val)
 ->
     I1 = jit_armv6m_asm:subs(Reg, Reg, Val),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1};
-sub(#state{stream_module = StreamModule, available_regs = Avail} = State0, Reg, Val) ->
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1};
+sub(#state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0, Reg, Val) ->
     Temp = first_avail(Avail),
     AT = Avail band (bnot reg_bit(Temp)),
     State1 = mov_immediate(State0#state{available_regs = AT}, Temp, Val),
     Stream1 = State1#state.stream,
     I = jit_armv6m_asm:subs(Reg, Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    State1#state{available_regs = Avail, stream = Stream2}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    State1#state{available_regs = Avail, stream = Stream2, regs = Regs1}.
 
 mul(State, _Reg, 1) ->
     State;
 mul(State, Reg, 2) ->
     shift_left(State, Reg, 1);
-mul(#state{available_regs = Avail} = State, Reg, 3) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 3) ->
     Temp = first_avail(Avail),
     I1 = jit_armv6m_asm:lsls(Temp, Reg, 1),
     I2 = jit_armv6m_asm:adds(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 4) ->
     shift_left(State, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 5) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 5) ->
     Temp = first_avail(Avail),
     I1 = jit_armv6m_asm:lsls(Temp, Reg, 2),
     I2 = jit_armv6m_asm:adds(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State0, Reg, 6) ->
     State1 = mul(State0, Reg, 3),
     mul(State1, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 7) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 7) ->
     Temp = first_avail(Avail),
     I1 = jit_armv6m_asm:lsls(Temp, Reg, 3),
     I2 = jit_armv6m_asm:subs(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 8) ->
     shift_left(State, Reg, 3);
-mul(#state{available_regs = Avail} = State, Reg, 9) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 9) ->
     Temp = first_avail(Avail),
     I1 = jit_armv6m_asm:lsls(Temp, Reg, 3),
     I2 = jit_armv6m_asm:adds(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State0, Reg, 10) ->
     State1 = mul(State0, Reg, 5),
     mul(State1, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 15) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 15) ->
     Temp = first_avail(Avail),
     I1 = jit_armv6m_asm:lsls(Temp, Reg, 4),
     I2 = jit_armv6m_asm:subs(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 16) ->
     shift_left(State, Reg, 4);
 mul(State, Reg, 32) ->
@@ -3311,19 +3586,21 @@ mul(State, Reg, 32) ->
 mul(State, Reg, 64) ->
     shift_left(State, Reg, 6);
 mul(
-    #state{stream_module = StreamModule, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0,
     Reg,
     Val
 ) ->
     Temp = first_avail(Avail),
     TempBit = reg_bit(Temp),
     AT = Avail band (bnot TempBit),
-    % multiply by decomposing by power of 2
     State1 = mov_immediate(State0#state{available_regs = AT}, Temp, Val),
     Stream1 = State1#state.stream,
     I = jit_armv6m_asm:muls(Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    State1#state{stream = Stream2, available_regs = State1#state.available_regs bor TempBit}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State1#state{
+        stream = Stream2, available_regs = State1#state.available_regs bor TempBit, regs = Regs1
+    }.
 
 %%
 %% Analysis of AArch64 pattern and ARM Thumb mapping:
@@ -3406,7 +3683,9 @@ decrement_reductions_and_maybe_schedule_next(
     Stream5 = StreamModule:replace(
         Stream4, BNEOffset, <<NewI4/binary, NewI5/binary>>
     ),
-    merge_used_regs(State2#state{stream = Stream5}, State1#state.used_regs).
+    State3 = merge_used_regs(State2#state{stream = Stream5}, State1#state.used_regs),
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State3#state{regs = MergedRegs}.
 
 -spec call_or_schedule_next(state(), non_neg_integer()) -> state().
 call_or_schedule_next(State0, Label) ->
@@ -3564,7 +3843,8 @@ rewrite_cp_offset(
     State0#state{stream = Stream3}.
 
 set_bs(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State0,
     TermReg
 ) ->
     Temp = first_avail(Avail),
@@ -3572,7 +3852,8 @@ set_bs(
     I2 = jit_armv6m_asm:movs(Temp, 0),
     I3 = jit_armv6m_asm:str(Temp, ?BS_OFFSET),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
-    State0#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State0#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @param State current state
@@ -3759,15 +4040,16 @@ args_regs(Args) ->
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec add_label(state(), integer() | reference()) -> state().
-add_label(#state{stream_module = StreamModule, stream = Stream0} = State0, Label) ->
+add_label(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, Label) ->
     Offset0 = StreamModule:offset(Stream0),
+    Regs1 = jit_regs:invalidate_all(Regs0),
     {State1, Offset1} =
         if
             Offset0 rem 4 =:= 0 ->
-                {State0, Offset0};
+                {State0#state{regs = Regs1}, Offset0};
             true ->
                 Stream1 = StreamModule:append(Stream0, jit_armv6m_asm:nop()),
-                {State0#state{stream = Stream1}, Offset0 + 2}
+                {State0#state{stream = Stream1, regs = Regs1}, Offset0 + 2}
         end,
     add_label(State1, Label, Offset1).
 
@@ -3802,10 +4084,11 @@ add_label(
     DataOffset = JumpTableEntryStart + 8,
     AddInstrOffset = JumpTableEntryStart + 4,
 
-    % Calculate offset from 'add pc, pc, r3' instruction + 4 to target label
-    % PC when add instruction executes
+    % Calculate offset from 'add pc, r3' instruction to target label
+    % When 'add pc, r3' executes, PC reads as AddInstrOffset + 4
+    % Result goes through BXWritePC, so bit 0 must be 1 for Thumb mode
     AddPC = AddInstrOffset + 4,
-    RelativeOffset = LabelOffset - AddPC,
+    RelativeOffset = LabelOffset - AddPC + 1,
     DataBytes = <<RelativeOffset:32/little>>,
 
     Stream1 = StreamModule:replace(Stream0, DataOffset, DataBytes),

--- a/libs/jit/src/jit_regs.erl
+++ b/libs/jit/src/jit_regs.erl
@@ -1,0 +1,197 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025-2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% @doc Track CPU register contents for the JIT backend.
+%%
+%% This module maintains knowledge about what each CPU register holds
+%% (VM x/y register values, immediates, pointers), enabling the backend to
+%% skip redundant loads.
+%%
+%% Tracking must be invalidated at:
+%% - Labels (any offset can be a branch target)
+%% - Function calls (ABI clobbers caller-saved registers)
+%% - Branches (the target has unknown incoming register state)
+%%
+%% The tracked information includes:
+%% - `contents`: maps cpu_reg -> what the register holds
+
+-module(jit_regs).
+
+-export([
+    new/0,
+    get_contents/2,
+    set_contents/3,
+    invalidate_reg/2,
+    invalidate_all/1,
+    invalidate_volatile/2,
+    invalidate_vm_loc/2,
+    find_reg_with_contents/2,
+    merge/2,
+    stack_push/2,
+    stack_pop/1,
+    stack_clear/1,
+    stack_contents/1,
+    value_to_contents/2,
+    vm_dest_to_contents/2,
+    regs_to_mask/2
+]).
+
+-export_type([regs/0, contents/0]).
+
+-type vm_loc() ::
+    {x_reg, non_neg_integer()}
+    | {y_reg, non_neg_integer()}.
+
+%% What a CPU register holds
+-type contents() ::
+    vm_loc()
+    | {ptr, vm_loc()}
+    %% Register holds a known immediate value
+    | {imm, integer()}
+    %% Register holds the address of CP
+    | cp
+    %% Register holds the module index
+    | module_index
+    %% Unknown / clobbered
+    | unknown.
+
+-record(regs, {
+    contents = #{} :: #{atom() => contents()},
+    stack = [] :: [atom() | contents()]
+}).
+
+-opaque regs() :: #regs{}.
+
+%% @doc Create a new empty register tracking state.
+-spec new() -> regs().
+new() ->
+    #regs{}.
+
+%% @doc Get what a CPU register currently holds.
+-spec get_contents(regs(), atom()) -> contents().
+get_contents(#regs{contents = C}, Reg) ->
+    maps:get(Reg, C, unknown).
+
+%% @doc Record that a CPU register now holds the given contents.
+-spec set_contents(regs(), atom(), contents()) -> regs().
+set_contents(#regs{contents = C} = Regs, Reg, Contents) ->
+    Regs#regs{contents = C#{Reg => Contents}}.
+
+%% @doc Invalidate tracking for a single CPU register (e.g. it was clobbered).
+-spec invalidate_reg(regs(), atom()) -> regs().
+invalidate_reg(#regs{contents = C} = Regs, Reg) ->
+    Regs#regs{contents = maps:remove(Reg, C)}.
+
+%% @doc Invalidate all register tracking (e.g. at a label or unknown branch target).
+-spec invalidate_all(regs()) -> regs().
+invalidate_all(Regs) ->
+    Regs#regs{contents = #{}, stack = []}.
+
+%% @doc Invalidate registers that are volatile across a C function call.
+%% On x86-64 System V ABI, all our scratch registers (rax, rcx, rdx, rsi, rdi,
+%% r8, r9, r10, r11) are caller-saved, so after a C call they're all clobbered.
+%% However, the special registers (rdi=ctx, rsi=jit_state, rdx=native_interface)
+%% are restored by the JIT after the call via push/pop, so we keep their tracking.
+-spec invalidate_volatile(regs(), [atom()]) -> regs().
+invalidate_volatile(#regs{contents = C0} = Regs, PreservedRegs) ->
+    C1 = maps:filter(fun(Reg, _) -> lists:member(Reg, PreservedRegs) end, C0),
+    Regs#regs{contents = C1}.
+
+%% @doc Invalidate all CPU registers that reference a given VM location.
+%% Call this when a VM register is written to, so that any CPU register
+%% that was caching its old value is invalidated.
+-spec invalidate_vm_loc(regs(), vm_loc()) -> regs().
+invalidate_vm_loc(#regs{contents = C} = Regs, VmLoc) ->
+    C1 = maps:filter(fun(_Reg, Val) -> Val =/= VmLoc end, C),
+    Regs#regs{contents = C1}.
+
+%% @doc Find a CPU register that holds the given contents.
+%% Returns `{ok, Reg}` or `none`.
+-spec find_reg_with_contents(regs(), contents()) -> {ok, atom()} | none.
+find_reg_with_contents(#regs{contents = C}, Contents) ->
+    find_in_map(maps:iterator(C), Contents).
+
+find_in_map(Iterator, Contents) ->
+    case maps:next(Iterator) of
+        {Reg, Contents, _Next} -> {ok, Reg};
+        {_Reg, _Other, Next} -> find_in_map(Next, Contents);
+        none -> none
+    end.
+
+%% @doc Merge two register tracking states (for control flow merge points).
+%% Only keeps information that is consistent in both states.
+-spec merge(regs(), regs()) -> regs().
+merge(#regs{contents = C1}, #regs{contents = C2}) ->
+    %% Keep only entries that match in both maps
+    MergedContents = maps:filter(
+        fun(Reg, Val) -> maps:get(Reg, C2, undefined) =:= Val end,
+        C1
+    ),
+    #regs{contents = MergedContents, stack = []}.
+
+%% @doc Record a push to the C stack.
+-spec stack_push(regs(), atom() | contents()) -> regs().
+stack_push(#regs{stack = S} = Regs, Value) ->
+    Regs#regs{stack = [Value | S]}.
+
+%% @doc Record a pop from the C stack.
+-spec stack_pop(regs()) -> {atom() | contents(), regs()}.
+stack_pop(#regs{stack = [Top | Rest]} = Regs) ->
+    {Top, Regs#regs{stack = Rest}};
+stack_pop(#regs{stack = []} = Regs) ->
+    {unknown, Regs}.
+
+%% @doc Clear the C stack tracking.
+-spec stack_clear(regs()) -> regs().
+stack_clear(Regs) ->
+    Regs#regs{stack = []}.
+
+%% @doc Get the current C stack contents.
+-spec stack_contents(regs()) -> [atom() | contents()].
+stack_contents(#regs{stack = S}) -> S.
+
+%% @doc Convert a backend value to a contents descriptor for tracking.
+%% MaxReg is the maximum number of x registers (typically ?MAX_REG from jit.hrl).
+-spec value_to_contents(term(), non_neg_integer()) -> contents().
+value_to_contents(cp, _MaxReg) -> cp;
+value_to_contents({x_reg, N}, _MaxReg) when is_integer(N) -> {x_reg, N};
+value_to_contents({x_reg, extra}, MaxReg) -> {x_reg, MaxReg};
+value_to_contents({y_reg, N}, _MaxReg) -> {y_reg, N};
+value_to_contents(Imm, _MaxReg) when is_integer(Imm) -> {imm, Imm};
+value_to_contents({ptr, _}, _MaxReg) -> unknown;
+value_to_contents(_, _MaxReg) -> unknown.
+
+%% @doc Convert a VM destination register to a contents descriptor for tracking.
+%% MaxReg is the maximum number of x registers (typically ?MAX_REG from jit.hrl).
+-spec vm_dest_to_contents(term(), non_neg_integer()) -> contents().
+vm_dest_to_contents({x_reg, X}, MaxReg) when is_integer(X), X < MaxReg -> {x_reg, X};
+vm_dest_to_contents({x_reg, extra}, MaxReg) -> {x_reg, MaxReg};
+vm_dest_to_contents({y_reg, Y}, _MaxReg) -> {y_reg, Y};
+vm_dest_to_contents(_, _MaxReg) -> unknown.
+
+%% @doc Convert a list of register atoms to a bitmask.
+%% Skips non-register entries like `imm`, `jit_state`, and `stack`.
+%% RegBitFn maps register atoms to their bit positions.
+-spec regs_to_mask([atom()], fun((atom()) -> non_neg_integer())) -> non_neg_integer().
+regs_to_mask([], _RegBitFn) -> 0;
+regs_to_mask([imm | T], RegBitFn) -> regs_to_mask(T, RegBitFn);
+regs_to_mask([jit_state | T], RegBitFn) -> regs_to_mask(T, RegBitFn);
+regs_to_mask([stack | T], RegBitFn) -> regs_to_mask(T, RegBitFn);
+regs_to_mask([Reg | T], RegBitFn) -> RegBitFn(Reg) bor regs_to_mask(T, RegBitFn).

--- a/libs/jit/src/jit_riscv32.erl
+++ b/libs/jit/src/jit_riscv32.erl
@@ -112,9 +112,6 @@
 %%   - Zero register: zero (always 0)
 %%   - Available for JIT scratch: t0-t6 (7 temp registers)
 %%
-%% Note: RISC-V32 instructions are fixed 32-bit with uniform encoding,
-%% allowing access to all 32 registers.
-%%
 %% For more details, refer to the RISC-V ILP32 Procedure Call Standard.
 
 -type riscv32_register() ::
@@ -168,7 +165,8 @@
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
     labels :: [{integer() | reference(), integer()}],
-    variant :: non_neg_integer()
+    variant :: non_neg_integer(),
+    regs :: jit_regs:regs()
 }).
 
 -type state() :: #state{}.
@@ -205,9 +203,7 @@
 -define(FP_REGS, {?CTX_REG, 16#60}).
 -define(BS, {?CTX_REG, 16#64}).
 -define(BS_OFFSET, {?CTX_REG, 16#68}).
-% JITSTATE is in a1 register (no prolog, following aarch64 model)
 -define(JITSTATE_REG, a1).
-% Return address register (like LR in AArch64)
 -define(RA_REG, ra).
 -define(JITSTATE_MODULE_OFFSET, 0).
 -define(JITSTATE_CONTINUATION_OFFSET, 16#4).
@@ -218,9 +214,6 @@
 -define(JUMP_TABLE_ENTRY_SIZE, 8).
 
 %% RISC-V32 register mappings
-
-%% Use t3 as temporary for some operations
--define(IP_REG, t3).
 
 -define(IS_SINT8_T(X), is_integer(X) andalso X >= -128 andalso X =< 127).
 -define(IS_SINT32_T(X), is_integer(X) andalso X >= -16#80000000 andalso X < 16#80000000).
@@ -257,11 +250,6 @@
 %% AVAILABLE_REGS = [t6, t5, t4, t3, t2, t1, t0]
 -define(AVAILABLE_REGS_MASK,
     (?REG_BIT_T6 bor ?REG_BIT_T5 bor ?REG_BIT_T4 bor ?REG_BIT_T3 bor
-        ?REG_BIT_T2 bor ?REG_BIT_T1 bor ?REG_BIT_T0)
-).
-%% SCRATCH_REGS = [t6, t5, t4, t2, t1, t0]
--define(SCRATCH_REGS_MASK,
-    (?REG_BIT_T6 bor ?REG_BIT_T5 bor ?REG_BIT_T4 bor
         ?REG_BIT_T2 bor ?REG_BIT_T1 bor ?REG_BIT_T0)
 ).
 
@@ -303,7 +291,8 @@ new(Variant, StreamModule, Stream) ->
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
         labels = [],
-        variant = Variant
+        variant = Variant,
+        regs = jit_regs:new()
     }.
 
 %%-----------------------------------------------------------------------------
@@ -624,7 +613,8 @@ call_primitive(
     StateCall = State#state{
         stream = Stream1,
         available_regs = Available band (bnot TempBit),
-        used_regs = Used bor TempBit
+        used_regs = Used bor TempBit,
+        regs = jit_regs:invalidate_reg(State#state.regs, TempReg)
     },
     call_func_ptr(StateCall, {free, TempReg}, Args);
 call_primitive(
@@ -657,8 +647,8 @@ call_primitive_last(
     % registers used for parameters
     ParamRegs = lists:sublist(?PARAMETER_REGS, length(Args)),
     ArgsRegs = args_regs(Args),
-    ArgsRegsMask = regs_to_mask(ArgsRegs),
-    ParamMask = regs_to_mask(ParamRegs),
+    ArgsRegsMask = jit_regs:regs_to_mask(ArgsRegs, fun reg_bit/1),
+    ParamMask = jit_regs:regs_to_mask(ParamRegs, fun reg_bit/1),
     ScratchMask = ?AVAILABLE_REGS_MASK band (bnot (ArgsRegsMask bor ParamMask)),
     Temp = first_avail(ScratchMask),
     TempBit = reg_bit(Temp),
@@ -668,7 +658,10 @@ call_primitive_last(
     Stream1 = StreamModule:append(Stream0, PrepCall),
 
     State1 = State0#state{
-        stream = Stream1, available_regs = AvailableRegs1, used_regs = UsedMask
+        stream = Stream1,
+        available_regs = AvailableRegs1,
+        used_regs = UsedMask,
+        regs = jit_regs:invalidate_reg(State0#state.regs, Temp)
     },
 
     % Preprocess offset special arg
@@ -694,7 +687,8 @@ call_primitive_last(
         end,
     State4#state{
         available_regs = ?AVAILABLE_REGS_MASK,
-        used_regs = 0
+        used_regs = 0,
+        regs = jit_regs:invalidate_all(State4#state.regs)
     }.
 
 %%-----------------------------------------------------------------------------
@@ -750,10 +744,12 @@ return_if_not_equal_to_ctx(
     I1 = jit_riscv32_asm:beq(Reg, ?CTX_REG, 4 + byte_size(I2) + byte_size(I3)),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
     RegBit = reg_bit(Reg),
+    Regs1 = jit_regs:invalidate_reg(State#state.regs, Reg),
     State#state{
         stream = Stream1,
         available_regs = AvailableRegs0 bor RegBit,
-        used_regs = UsedRegs0 band (bnot RegBit)
+        used_regs = UsedRegs0 band (bnot RegBit),
+        regs = Regs1
     }.
 
 %%-----------------------------------------------------------------------------
@@ -771,13 +767,14 @@ jump_to_label(
     Offset = StreamModule:offset(Stream0),
     {State1, CodeBlock} = branch_to_label_code(State0, Offset, Label, LabelLookupResult),
     Stream1 = StreamModule:append(Stream0, CodeBlock),
-    State1#state{stream = Stream1}.
+    %% After unconditional jump, register tracking is dead until next label
+    State1#state{stream = Stream1, regs = jit_regs:invalidate_all(State1#state.regs)}.
 
 jump_to_offset(#state{stream_module = StreamModule, stream = Stream0} = State, TargetOffset) ->
     Offset = StreamModule:offset(Stream0),
     CodeBlock = branch_to_offset_code(State, Offset, TargetOffset),
     Stream1 = StreamModule:append(Stream0, CodeBlock),
-    State#state{stream = Stream1}.
+    State#state{stream = Stream1, regs = jit_regs:invalidate_all(State#state.regs)}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Jump to address in continuation pointer register
@@ -915,7 +912,9 @@ if_block(
         Stream2,
         Replacements
     ),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs);
+    State3 = merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs),
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State3#state{regs = MergedRegs};
 if_block(
     #state{stream_module = StreamModule, stream = Stream0} = State0,
     Cond,
@@ -931,7 +930,9 @@ if_block(
     BranchOffset = OffsetAfter - BranchInstrOffset,
     NewBranchInstr = apply(jit_riscv32_asm, BranchFunc, [Reg, Operand, BranchOffset]),
     Stream3 = StreamModule:replace(Stream2, BranchInstrOffset, NewBranchInstr),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs).
+    State3 = merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs),
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State3#state{regs = MergedRegs}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit an if else block, i.e. emit a test of a condition and
@@ -971,7 +972,8 @@ if_else_block(
     StateElse = State2#state{
         stream = Stream4,
         used_regs = State1#state.used_regs,
-        available_regs = State1#state.available_regs
+        available_regs = State1#state.available_regs,
+        regs = State1#state.regs
     },
     State3 = BlockFalseFn(StateElse),
     Stream5 = State3#state.stream,
@@ -983,7 +985,9 @@ if_else_block(
     %% If this fails, the if/else blocks are too large
     2 = byte_size(NewElseJumpInstr),
     Stream6 = StreamModule:replace(Stream5, ElseJumpOffset, NewElseJumpInstr),
-    merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs).
+    State4 = merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs),
+    MergedRegs = jit_regs:merge(State2#state.regs, State3#state.regs),
+    State4#state{regs = MergedRegs}.
 
 -spec if_block_cond(state(), condition()) ->
     {
@@ -1024,7 +1028,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, {bge, Reg, Temp}, BranchDelta};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} = State0,
@@ -1044,7 +1049,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, {bge, Reg, Temp}, BranchDelta};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} = State0,
@@ -1064,7 +1070,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, {bge, Temp, Reg}, BranchDelta};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0, available_regs = Available} = State0,
@@ -1084,7 +1091,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, {bge, Temp, Reg}, BranchDelta};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0} = State0,
@@ -1153,7 +1161,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, {beq, Reg, Temp}, BranchDelta};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0} = State0,
@@ -1190,7 +1199,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, {bne, Reg, Temp}, BranchDelta};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0} = State0,
@@ -1221,7 +1231,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, {bne, Reg, Temp}, BranchDelta};
 if_block_cond(
     #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State0,
@@ -1241,7 +1252,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State2 = if_block_free_reg(RegOrTuple, State1),
-    State3 = State2#state{stream = Stream2},
+    Regs2 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State3 = State2#state{stream = Stream2, regs = Regs2},
     {State3, {beq, Reg, Temp}, BranchDelta};
 if_block_cond(
     #state{
@@ -1263,7 +1275,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State1 = if_block_free_reg(RegOrTuple, State0),
-    State2 = State1#state{stream = Stream2},
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream2, regs = Regs1},
     {State2, {blt, Temp, zero}, byte_size(I1)};
 if_block_cond(
     #state{
@@ -1285,7 +1298,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State1 = if_block_free_reg(RegOrTuple, State0),
-    State2 = State1#state{stream = Stream2},
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream2, regs = Regs1},
     {State2, {bge, Temp, zero}, byte_size(I1)};
 if_block_cond(
     #state{
@@ -1320,7 +1334,8 @@ if_block_cond(
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
     State1 = if_block_free_reg(RegOrTuple, State0),
-    State2 = State1#state{stream = Stream2},
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream2, regs = Regs1},
     {State2, {beq, Temp, zero}, BranchDelta};
 if_block_cond(
     #state{
@@ -1337,7 +1352,8 @@ if_block_cond(
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
-    State1 = State0#state{stream = Stream2},
+    Regs1 = jit_regs:invalidate_reg(State0#state.regs, Temp),
+    State1 = State0#state{stream = Stream2, regs = Regs1},
     {State1, {beq, Temp, zero}, byte_size(I1) + byte_size(I2)};
 if_block_cond(
     #state{
@@ -1352,7 +1368,8 @@ if_block_cond(
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     BranchInstr = <<16#FFFFFFFF:32/little>>,
     Stream2 = StreamModule:append(Stream1, BranchInstr),
-    State1 = State0#state{stream = Stream2},
+    Regs1 = jit_regs:invalidate_reg(State0#state.regs, Reg),
+    State1 = State0#state{stream = Stream2, regs = Regs1},
     State2 = if_block_free_reg(RegTuple, State1),
     {State2, {beq, Reg, zero}, byte_size(I1) + byte_size(I2)};
 if_block_cond(
@@ -1402,9 +1419,11 @@ if_block_cond(
             BranchDelta = StreamModule:offset(Stream3) - OffsetBefore,
             BranchInstr = <<16#FFFFFFFF:32/little>>,
             Stream4 = StreamModule:append(Stream3, BranchInstr),
+            Regs4 = jit_regs:invalidate_reg(State3#state.regs, MaskReg),
             State4 = State3#state{
                 stream = Stream4,
-                available_regs = State3#state.available_regs bor reg_bit(Temp) bor reg_bit(MaskReg)
+                available_regs = State3#state.available_regs bor reg_bit(Temp) bor reg_bit(MaskReg),
+                regs = Regs4
             },
             {State4, {beq, Temp, MaskReg}, BranchDelta}
     end;
@@ -1448,7 +1467,8 @@ if_block_cond(
             BranchDelta = StreamModule:offset(Stream2) - OffsetBefore,
             BranchInstr = <<16#FFFFFFFF:32/little>>,
             Stream3 = StreamModule:append(Stream2, BranchInstr),
-            State3 = State2#state{stream = Stream3, available_regs = AvailRegs},
+            Regs3 = jit_regs:invalidate_reg(State2#state.regs, MaskReg),
+            State3 = State2#state{stream = Stream3, available_regs = AvailRegs, regs = Regs3},
             State4 = if_block_free_reg(RegTuple, State3),
             {State4, {beq, Reg, MaskReg}, BranchDelta}
     end.
@@ -1482,18 +1502,22 @@ merge_used_regs(#state{used_regs = UR} = State, OtherUR) ->
 %%-----------------------------------------------------------------------------
 -spec shift_right(#state{}, maybe_free_riscv32_register(), non_neg_integer()) ->
     {#state{}, riscv32_register()}.
-shift_right(#state{stream_module = StreamModule, stream = Stream0} = State, {free, Reg}, Shift) when
+shift_right(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, {free, Reg}, Shift
+) when
     ?IS_GPR(Reg) andalso is_integer(Shift)
 ->
     I = jit_riscv32_asm:srli(Reg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 shift_right(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UR
+        used_regs = UR,
+        regs = Regs0
     } = State,
     Reg,
     Shift
@@ -1504,11 +1528,13 @@ shift_right(
     ResultBit = reg_bit(ResultReg),
     I = jit_riscv32_asm:srli(ResultReg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot ResultBit),
-            used_regs = UR bor ResultBit
+            used_regs = UR bor ResultBit,
+            regs = Regs1
         },
         ResultReg
     }.
@@ -1521,12 +1547,15 @@ shift_right(
 %% @param Shift number of bits to shift
 %% @return new state
 %%-----------------------------------------------------------------------------
-shift_left(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Shift) when
+shift_left(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Shift
+) when
     is_atom(Reg)
 ->
     I = jit_riscv32_asm:slli(Reg, Reg, Shift),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a call to a function pointer with arguments. This function converts
@@ -1559,7 +1588,7 @@ call_func_ptr(
     ),
     FreeMask = regs_to_mask(FreeRegs),
     UsedRegs1Mask = UsedRegs0Mask band (bnot FreeMask),
-    % Save RA (like AArch64 saves LR) so it's preserved across jalr calls
+    % Save RA so it's preserved across jalr calls
     SavedRegs = [
         ?RA_REG, ?CTX_REG, ?JITSTATE_REG, ?NATIVE_INTERFACE_REG | mask_to_list(UsedRegs1Mask)
     ],
@@ -1717,11 +1746,13 @@ call_func_ptr(
 
     ResultRegBit = reg_bit(ResultReg),
     AvailableRegs3Mask = (AvailableRegs1Mask band (bnot ResultRegBit)) band ?AVAILABLE_REGS_MASK,
+    Regs1 = jit_regs:invalidate_all(State0#state.regs),
     {
         State4#state{
             stream = Stream8,
             available_regs = AvailableRegs3Mask,
-            used_regs = UsedRegs2Mask
+            used_regs = UsedRegs2Mask,
+            regs = Regs1
         },
         ResultReg
     }.
@@ -1782,7 +1813,7 @@ set_registers_args(
     ParamMask = regs_to_mask(ParamRegs),
     ArgsMask = regs_to_mask(ArgsRegs),
     AvailableScratchMask =
-        ?SCRATCH_REGS_MASK band (bnot (ParamMask bor ArgsMask bor UsedRegsMask)),
+        ?AVAILABLE_REGS_MASK band (bnot (ParamMask bor ArgsMask bor UsedRegsMask)),
     AvailableScratchGP = mask_to_list(AvailableScratchMask),
     State1 = set_registers_args0(
         State0, Args, ArgsRegs, ParamRegs, AvailableScratchGP, StackOffset
@@ -1957,31 +1988,58 @@ set_registers_args1(State, Value, Reg, _StackOffset) when ?IS_SIGNED_OR_UNSIGNED
 %%-----------------------------------------------------------------------------
 -spec move_to_vm_register(state(), Src :: value() | vm_register(), Dest :: vm_register()) ->
     state().
+move_to_vm_register(#state{regs = Regs0} = State, Src, Dest) ->
+    VmLoc = jit_regs:vm_dest_to_contents(Dest, ?MAX_REG),
+    Regs1 =
+        case VmLoc of
+            unknown -> Regs0;
+            _ -> jit_regs:invalidate_vm_loc(Regs0, VmLoc)
+        end,
+    State1 = move_to_vm_register_emit(State#state{regs = Regs1}, Src, Dest),
+    case {Src, VmLoc} of
+        {Reg, Contents} when is_atom(Reg), Contents =/= unknown ->
+            #state{regs = Regs2} = State1,
+            State1#state{regs = jit_regs:set_contents(Regs2, Reg, Contents)};
+        _ ->
+            State1
+    end.
+
 % Native register to VM register
-move_to_vm_register(State0, Src, {x_reg, extra}) when is_atom(Src) ->
+move_to_vm_register_emit(State0, Src, {x_reg, extra}) when is_atom(Src) ->
     {BaseReg, Off} = ?X_REG(?MAX_REG),
     I1 = jit_riscv32_asm:sw(BaseReg, Src, Off),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State0#state{stream = Stream1};
-move_to_vm_register(State0, Src, {x_reg, X}) when is_atom(Src) ->
+move_to_vm_register_emit(State0, Src, {x_reg, X}) when is_atom(Src) ->
     {BaseReg, Off} = ?X_REG(X),
     I1 = jit_riscv32_asm:sw(BaseReg, Src, Off),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State0#state{stream = Stream1};
-move_to_vm_register(State0, Src, {ptr, Reg}) when is_atom(Src) ->
+move_to_vm_register_emit(State0, Src, {ptr, Reg}) when is_atom(Src) ->
     I1 = jit_riscv32_asm:sw(Reg, Src, 0),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State0#state{stream = Stream1};
-move_to_vm_register(#state{available_regs = Avail} = State0, Src, {y_reg, Y}) when
+move_to_vm_register_emit(
+    #state{available_regs = Avail, regs = Regs0} = State0, Src, {y_reg, Y}
+) when
     is_atom(Src)
 ->
     Temp1 = first_avail(Avail),
     AT = Avail band (bnot reg_bit(Temp1)),
     Code = str_y_reg(Src, Y, Temp1, AT),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, Code),
-    State0#state{stream = Stream1};
+    % str_y_reg clobbers Temp1, and for large offsets also clobbers first_avail(AT)
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp1),
+    Regs2 =
+        case AT of
+            0 -> Regs1;
+            _ -> jit_regs:invalidate_reg(Regs1, first_avail(AT))
+        end,
+    State0#state{stream = Stream1, regs = Regs2};
 % Source is an integer to y_reg (optimized: ldr first, then movs)
-move_to_vm_register(#state{available_regs = Avail} = State0, N, {y_reg, Y}) when
+move_to_vm_register_emit(
+    #state{available_regs = Avail, regs = Regs0} = State0, N, {y_reg, Y}
+) when
     is_integer(N), N >= 0, N =< 255
 ->
     Temp1 = first_avail(Avail),
@@ -1991,9 +2049,16 @@ move_to_vm_register(#state{available_regs = Avail} = State0, N, {y_reg, Y}) when
     I1 = jit_riscv32_asm:li(Temp2, N),
     YCode = str_y_reg(Temp2, Y, Temp1, AT),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, <<I1/binary, YCode/binary>>),
-    State0#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp1), Temp2),
+    % str_y_reg may clobber first_avail(AT) for large offsets
+    Regs2 =
+        case AT of
+            0 -> Regs1;
+            _ -> jit_regs:invalidate_reg(Regs1, first_avail(AT))
+        end,
+    State0#state{stream = Stream1, regs = Regs2};
 % Source is an integer (0-255 for movs, negative values need different handling)
-move_to_vm_register(#state{available_regs = AR0} = State0, N, Dest) when
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, N, Dest) when
     is_integer(N), N >= 0, N =< 255
 ->
     Temp = first_avail(AR0),
@@ -2001,49 +2066,66 @@ move_to_vm_register(#state{available_regs = AR0} = State0, N, Dest) when
     I1 = jit_riscv32_asm:li(Temp, N),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 %% Handle large values using simple literal pool (branch-over pattern)
-move_to_vm_register(#state{available_regs = AR0} = State0, N, Dest) when
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, N, Dest) when
     is_integer(N)
 ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     State1 = mov_immediate(State0#state{available_regs = AT}, Temp, N),
     State2 = move_to_vm_register(State1, Temp, Dest),
-    State2#state{available_regs = AR0};
+    Regs1 = jit_regs:invalidate_reg(State2#state.regs, Temp),
+    State2#state{available_regs = AR0, regs = Regs1};
 % Source is a VM register
-move_to_vm_register(#state{available_regs = AR0} = State0, {x_reg, extra}, Dest) ->
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, {x_reg, extra}, Dest) ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     {BaseReg, Off} = ?X_REG(?MAX_REG),
     I1 = jit_riscv32_asm:lw(Temp, BaseReg, Off),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
-move_to_vm_register(#state{available_regs = AR0} = State0, {x_reg, X}, Dest) ->
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, {x_reg, X}, Dest) ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     {XReg, X_REGOffset} = ?X_REG(X),
     I1 = jit_riscv32_asm:lw(Temp, XReg, X_REGOffset),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
-move_to_vm_register(#state{available_regs = AR0} = State0, {ptr, Reg}, Dest) ->
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, {ptr, Reg}, Dest) ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     I1 = jit_riscv32_asm:lw(Temp, Reg, 0),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
     State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
-move_to_vm_register(#state{available_regs = AR0} = State0, {y_reg, Y}, Dest) ->
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
+move_to_vm_register_emit(#state{available_regs = AR0} = State0, {y_reg, Y}, Dest) ->
     Temp = first_avail(AR0),
     AT = AR0 band (bnot reg_bit(Temp)),
     Code = ldr_y_reg(Temp, Y, AT),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, Code),
-    State1 = move_to_vm_register(State0#state{stream = Stream1, available_regs = AT}, Temp, Dest),
-    State1#state{available_regs = AR0};
+    % ldr_y_reg clobbers first_avail(AT) as a hidden temp for loading Y_REGS pointer
+    Regs0a =
+        case AT of
+            0 -> State0#state.regs;
+            _ -> jit_regs:invalidate_reg(State0#state.regs, first_avail(AT))
+        end,
+    State0a = State0#state{
+        stream = Stream1,
+        available_regs = AT,
+        regs = Regs0a
+    },
+    State1 = move_to_vm_register(State0a, Temp, Dest),
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State1#state{available_regs = AR0, regs = Regs1};
 % term_to_float
-move_to_vm_register(
+move_to_vm_register_emit(
     #state{
         stream_module = StreamModule,
         available_regs = Avail,
@@ -2073,7 +2155,8 @@ move_to_vm_register(
     end,
     Stream1 = StreamModule:append(Stream0, Code),
     State1 = free_native_register(State0, Reg),
-    State1#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(State1#state.regs, Temp1), Temp2),
+    State1#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a move of an array element (reg[x]) to a vm or a native register.
@@ -2091,7 +2174,8 @@ move_to_vm_register(
     vm_register() | riscv32_register()
 ) -> state().
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Reg,
     Index,
     {x_reg, X}
@@ -2101,9 +2185,12 @@ move_array_element(
     {BaseReg, Off} = ?X_REG(X),
     I2 = jit_riscv32_asm:sw(BaseReg, Temp, Off),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
+    State#state{stream = Stream1, regs = Regs2};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Reg,
     Index,
     {ptr, Dest}
@@ -2112,9 +2199,10 @@ move_array_element(
     I1 = jit_riscv32_asm:lw(Temp, Reg, Index * 4),
     I2 = jit_riscv32_asm:sw(Dest, Temp, 0),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} =
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
         State,
     Reg,
     Index,
@@ -2128,9 +2216,12 @@ move_array_element(
     YCode = str_y_reg(Temp2, Y, Temp1, AT),
     Code = <<I1/binary, YCode/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp1),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp2),
+    State#state{stream = Stream1, regs = Regs3};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} =
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
         State,
     {free, Reg},
     Index,
@@ -2142,19 +2233,27 @@ move_array_element(
     YCode = str_y_reg(Reg, Y, Temp, AT),
     Code = <<I1/binary, YCode/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Reg),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp),
+    State#state{stream = Stream1, regs = Regs3};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0} = State, Reg, Index, Dest
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State,
+    Reg,
+    Index,
+    Dest
 ) when is_atom(Dest) andalso is_integer(Index) ->
     I1 = jit_riscv32_asm:lw(Dest, Reg, Index * 4),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Dest),
+    State#state{stream = Stream1, regs = Regs1};
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -2169,17 +2268,21 @@ move_array_element(
     AvailableRegs1 = AvailableRegs0 bor Bit,
     UsedRegs1 = UsedRegs0 band (bnot Bit),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>),
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, IndexReg),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs2
     };
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -2193,17 +2296,20 @@ move_array_element(
     AvailableRegs1 = AvailableRegs0 bor Bit,
     UsedRegs1 = UsedRegs0 band (bnot Bit),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, IndexReg),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs1
     };
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -2222,10 +2328,14 @@ move_array_element(
     Stream1 = StreamModule:append(
         Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>
     ),
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
+    Regs3 = jit_regs:invalidate_reg(Regs2, IndexReg),
     State#state{
         available_regs = AvailableRegs1,
         used_regs = UsedRegs1,
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs3
     }.
 
 %% @doc move reg[x] to a vm or native register
@@ -2236,20 +2346,23 @@ move_array_element(
 get_array_element(
     #state{
         stream_module = StreamModule,
-        stream = Stream0
+        stream = Stream0,
+        regs = Regs0
     } = State,
     {free, Reg},
     Index
 ) ->
     I1 = jit_riscv32_asm:lw(Reg, Reg, Index * 4),
     Stream1 = StreamModule:append(Stream0, <<I1/binary>>),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 get_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     Index
@@ -2258,11 +2371,13 @@ get_array_element(
     ElemBit = reg_bit(ElemReg),
     I1 = jit_riscv32_asm:lw(ElemReg, Reg, Index * 4),
     Stream1 = StreamModule:append(Stream0, <<I1/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ElemReg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot ElemBit),
-            used_regs = UsedRegs0 bor ElemBit
+            used_regs = UsedRegs0 bor ElemBit,
+            regs = Regs1
         },
         ElemReg
     }.
@@ -2281,7 +2396,8 @@ move_to_array_element(
     Stream1 = StreamModule:append(Stream0, I1),
     State0#state{stream = Stream1};
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State0,
     ValueReg,
     Reg,
     IndexReg
@@ -2292,7 +2408,8 @@ move_to_array_element(
     I3 = jit_riscv32_asm:add(Temp, Reg, Temp),
     I4 = jit_riscv32_asm:sw(Temp, ValueReg, 0),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>),
-    State0#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State0#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
     State0,
     Value,
@@ -2312,7 +2429,8 @@ move_to_array_element(
 ) when is_integer(IndexReg) andalso is_integer(Offset) andalso Offset div 8 =:= 0 ->
     move_to_array_element(State, Value, BaseReg, IndexReg + (Offset div 8));
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     ValueReg,
     BaseReg,
     IndexReg,
@@ -2324,7 +2442,8 @@ move_to_array_element(
     I3 = jit_riscv32_asm:add(Temp, BaseReg, Temp),
     I4 = jit_riscv32_asm:sw(Temp, ValueReg, 0),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
     State0,
     Value,
@@ -2341,79 +2460,130 @@ move_to_array_element(
     Stream1 = (State1#state.stream_module):append(
         State1#state.stream, <<I1/binary, I2/binary, I3/binary, I4/binary>>
     ),
-    State2 = State1#state{stream = Stream1},
+    Regs1 = jit_regs:invalidate_reg(State1#state.regs, Temp),
+    State2 = State1#state{stream = Stream1, regs = Regs1},
     free_native_register(State2, ValueReg).
 
 -spec move_to_native_register(state(), value() | cp) -> {state(), riscv32_register()}.
-move_to_native_register(
+move_to_native_register(State, Reg) when ?IS_GPR(Reg) ->
+    {State, Reg};
+move_to_native_register(#state{regs = Regs} = State, Value) ->
+    Contents = jit_regs:value_to_contents(Value, ?MAX_REG),
+    case Contents =/= unknown andalso jit_regs:find_reg_with_contents(Regs, Contents) of
+        {ok, CachedReg} ->
+            Bit = reg_bit(CachedReg),
+            case State#state.used_regs band Bit of
+                0 ->
+                    case State#state.available_regs band Bit of
+                        0 ->
+                            move_to_native_register_emit(State, Value, Contents);
+                        _ ->
+                            {
+                                State#state{
+                                    used_regs = State#state.used_regs bor Bit,
+                                    available_regs = State#state.available_regs band (bnot Bit)
+                                },
+                                CachedReg
+                            }
+                    end;
+                _ ->
+                    {State, CachedReg}
+            end;
+        _ ->
+            move_to_native_register_emit(State, Value, Contents)
+    end.
+
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    cp
+    cp,
+    Contents
 ) ->
     Reg = first_avail(Avail),
     RegBit = reg_bit(Reg),
     {BaseReg, Off} = ?CP,
     I1 = jit_riscv32_asm:lw(Reg, BaseReg, Off),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
-            stream = Stream1, used_regs = Used bor RegBit, available_regs = Avail band (bnot RegBit)
+            stream = Stream1,
+            used_regs = Used bor RegBit,
+            available_regs = Avail band (bnot RegBit),
+            regs = Regs1
         },
         Reg
     };
-move_to_native_register(State, Reg) when is_atom(Reg) ->
-    {State, Reg};
-move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0} = State, {ptr, Reg}
+move_to_native_register_emit(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State,
+    {ptr, Reg},
+    _Contents
 ) when is_atom(Reg) ->
     I1 = jit_riscv32_asm:lw(Reg, Reg, 0),
     Stream1 = StreamModule:append(Stream0, I1),
-    {State#state{stream = Stream1}, Reg};
-move_to_native_register(
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
+move_to_native_register_emit(
     #state{
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State0,
-    Imm
+    Imm,
+    Contents
 ) when
     is_integer(Imm)
 ->
     Reg = first_avail(Avail),
     RegBit = reg_bit(Reg),
-    State1 = State0#state{used_regs = Used bor RegBit, available_regs = Avail band (bnot RegBit)},
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
+    State1 = State0#state{
+        used_regs = Used bor RegBit,
+        available_regs = Avail band (bnot RegBit),
+        regs = Regs1
+    },
     {move_to_native_register(State1, Imm, Reg), Reg};
-move_to_native_register(
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {x_reg, extra}
+    {x_reg, extra},
+    Contents
 ) ->
     Reg = first_avail(Avail),
     RegBit = reg_bit(Reg),
     {BaseReg, Off} = ?X_REG(?MAX_REG),
     I1 = jit_riscv32_asm:lw(Reg, BaseReg, Off),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
-            stream = Stream1, used_regs = Used bor RegBit, available_regs = Avail band (bnot RegBit)
+            stream = Stream1,
+            used_regs = Used bor RegBit,
+            available_regs = Avail band (bnot RegBit),
+            regs = Regs1
         },
         Reg
     };
-move_to_native_register(
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {x_reg, X}
+    {x_reg, X},
+    Contents
 ) when
     X < ?MAX_REG
 ->
@@ -2422,35 +2592,57 @@ move_to_native_register(
     {BaseReg, Offset} = ?X_REG(X),
     I1 = jit_riscv32_asm:lw(Reg, BaseReg, Offset),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
-            stream = Stream1, used_regs = Used bor RegBit, available_regs = Avail band (bnot RegBit)
+            stream = Stream1,
+            used_regs = Used bor RegBit,
+            available_regs = Avail band (bnot RegBit),
+            regs = Regs1
         },
         Reg
     };
-move_to_native_register(
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {y_reg, Y}
+    {y_reg, Y},
+    Contents
 ) ->
     Reg = first_avail(Avail),
     RegBit = reg_bit(Reg),
     AvailT = Avail band (bnot RegBit),
     Code = ldr_y_reg(Reg, Y, AvailT),
     Stream1 = StreamModule:append(Stream0, Code),
-    {State#state{stream = Stream1, available_regs = AvailT, used_regs = Used bor RegBit}, Reg};
-move_to_native_register(
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
+    % ldr_y_reg clobbers first_avail(AvailT) as a hidden temp for loading Y_REGS pointer
+    Regs2 =
+        case AvailT of
+            0 -> Regs1;
+            _ -> jit_regs:invalidate_reg(Regs1, first_avail(AvailT))
+        end,
+    {
+        State#state{
+            stream = Stream1,
+            available_regs = AvailT,
+            used_regs = Used bor RegBit,
+            regs = Regs2
+        },
+        Reg
+    };
+move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
         used_regs = Used
     } = State,
-    {fp_reg, F}
+    {fp_reg, F},
+    _Contents
 ) ->
     RegA = first_avail(Avail),
     RegABit = reg_bit(RegA),
@@ -2473,13 +2665,18 @@ move_to_native_register(
 
 -spec move_to_native_register(state(), value(), riscv32_register()) -> state().
 move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0} = State, RegSrc, RegDst
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, RegSrc, RegDst
 ) when is_atom(RegSrc) ->
     I = jit_riscv32_asm:mv(RegDst, RegSrc),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1};
+    SrcContents = jit_regs:get_contents(Regs0, RegSrc),
+    Regs1 = jit_regs:set_contents(Regs0, RegDst, SrcContents),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_native_register(State, ValSrc, RegDst) when is_integer(ValSrc) ->
-    mov_immediate(State, RegDst, ValSrc);
+    State1 = mov_immediate(State, RegDst, ValSrc),
+    #state{regs = Regs0} = State1,
+    Regs1 = jit_regs:set_contents(Regs0, RegDst, {imm, ValSrc}),
+    State1#state{regs = Regs1};
 move_to_native_register(
     #state{stream_module = StreamModule, stream = Stream0} = State, {ptr, Reg}, RegDst
 ) when ?IS_GPR(Reg) ->
@@ -2503,13 +2700,20 @@ move_to_native_register(
     Stream1 = StreamModule:append(Stream0, I1),
     State#state{stream = Stream1};
 move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = AT} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = AT, regs = Regs0} =
+        State,
     {y_reg, Y},
     RegDst
 ) ->
     Code = ldr_y_reg(RegDst, Y, AT),
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    % ldr_y_reg clobbers first_avail(AT) as a hidden temp for loading Y_REGS pointer
+    Regs1 =
+        case AT of
+            0 -> Regs0;
+            _ -> jit_regs:invalidate_reg(Regs0, first_avail(AT))
+        end,
+    State#state{stream = Stream1, regs = Regs1};
 move_to_native_register(
     #state{
         stream_module = StreamModule,
@@ -2532,7 +2736,8 @@ copy_to_native_register(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     Reg
 ) when is_atom(Reg) ->
@@ -2540,11 +2745,14 @@ copy_to_native_register(
     SaveBit = reg_bit(SaveReg),
     I1 = jit_riscv32_asm:mv(SaveReg, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
+    SrcContents = jit_regs:get_contents(Regs0, Reg),
+    Regs1 = jit_regs:set_contents(Regs0, SaveReg, SrcContents),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot SaveBit),
-            used_regs = Used bor SaveBit
+            used_regs = Used bor SaveBit,
+            regs = Regs1
         },
         SaveReg
     };
@@ -2553,7 +2761,8 @@ copy_to_native_register(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     {ptr, Reg}
 ) when is_atom(Reg) ->
@@ -2561,11 +2770,13 @@ copy_to_native_register(
     SaveBit = reg_bit(SaveReg),
     I1 = jit_riscv32_asm:lw(SaveReg, Reg, 0),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:invalidate_reg(Regs0, SaveReg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot SaveBit),
-            used_regs = Used bor SaveBit
+            used_regs = Used bor SaveBit,
+            regs = Regs1
         },
         SaveReg
     };
@@ -2573,7 +2784,8 @@ copy_to_native_register(State, Reg) ->
     move_to_native_register(State, Reg).
 
 move_to_cp(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     {y_reg, Y}
 ) ->
     Reg = first_avail(Avail),
@@ -2583,10 +2795,18 @@ move_to_cp(
     I2 = jit_riscv32_asm:sw(BaseReg, Reg, Off),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1}.
+    % ldr_y_reg clobbers first_avail(AvailT) as a hidden temp for loading Y_REGS pointer
+    Regs1a = jit_regs:invalidate_reg(Regs0, Reg),
+    Regs1 =
+        case AvailT of
+            0 -> Regs1a;
+            _ -> jit_regs:invalidate_reg(Regs1a, first_avail(AvailT))
+        end,
+    State#state{stream = Stream1, regs = Regs1}.
 
 increment_sp(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Offset
 ) ->
     Reg = first_avail(Avail),
@@ -2597,7 +2817,8 @@ increment_sp(
     I3 = jit_riscv32_asm:sw(BaseReg2, Reg, Off2),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 set_continuation_to_label(
     #state{
@@ -2605,11 +2826,13 @@ set_continuation_to_label(
         stream = Stream0,
         available_regs = Avail,
         branches = Branches,
-        labels = Labels
+        labels = Labels,
+        regs = Regs0
     } = State,
     Label
 ) ->
     Temp = first_avail(Avail),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     Offset = StreamModule:offset(Stream0),
     case lists:keyfind(Label, 1, Labels) of
         {Label, LabelOffset} ->
@@ -2619,7 +2842,7 @@ set_continuation_to_label(
             I2 = jit_riscv32_asm:sw(?JITSTATE_REG, Temp, ?JITSTATE_CONTINUATION_OFFSET),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1};
+            State#state{stream = Stream1, regs = Regs1};
         false ->
             % Label not yet known, emit placeholder and add relocation
             % Reserve 8 bytes (2 x 32-bit instructions) with all-1s placeholder for flash programming
@@ -2629,7 +2852,7 @@ set_continuation_to_label(
             I2 = jit_riscv32_asm:sw(?JITSTATE_REG, Temp, ?JITSTATE_CONTINUATION_OFFSET),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1, branches = [Reloc | Branches]}
+            State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}
     end.
 
 %% @doc Set the contination to a given offset
@@ -2641,7 +2864,8 @@ set_continuation_to_offset(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        branches = Branches
+        branches = Branches,
+        regs = Regs0
     } = State
 ) ->
     Temp = first_avail(Avail),
@@ -2654,7 +2878,8 @@ set_continuation_to_offset(
     I2 = jit_riscv32_asm:sw(?JITSTATE_REG, Temp, ?JITSTATE_CONTINUATION_OFFSET),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    {State#state{stream = Stream1, branches = [Reloc | Branches]}, OffsetRef}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
 
 %% @doc Implement a continuation entry point.
 -spec continuation_entry_point(#state{}) -> #state{}.
@@ -2666,7 +2891,8 @@ get_module_index(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State
 ) ->
     Reg = first_avail(Avail),
@@ -2676,11 +2902,13 @@ get_module_index(
     I2 = jit_riscv32_asm:lw(Reg, Reg, 0),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot RegBit),
-            used_regs = UsedRegs0 bor RegBit
+            used_regs = UsedRegs0 bor RegBit,
+            regs = Regs1
         },
         Reg
     }.
@@ -2689,19 +2917,38 @@ get_module_index(
 %% JIT currentl calls this with two values: ?TERM_PRIMARY_CLEAR_MASK (-4) to
 %% clear bits and ?TERM_BOXED_TAG_MASK (0x3F). We can avoid any literal pool
 %% by using BICS for -4.
-and_(#state{stream_module = StreamModule, stream = Stream0} = State0, {free, Reg}, SrcReg) when
+and_(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0,
+    {free, Reg},
+    SrcReg
+) when
     is_atom(SrcReg)
 ->
     I = jit_riscv32_asm:and_(Reg, Reg, SrcReg),
     Stream1 = StreamModule:append(Stream0, I),
-    {State0#state{stream = Stream1}, Reg};
-and_(#state{stream_module = StreamModule, stream = Stream0} = State0, {free, Reg}, 16#FFFFFF) ->
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State0#state{stream = Stream1, regs = Regs1}, Reg};
+and_(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0,
+    {free, Reg},
+    16#FFFFFF
+) ->
     I1 = jit_riscv32_asm:slli(Reg, Reg, 8),
     I2 = jit_riscv32_asm:srli(Reg, Reg, 8),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    {State0#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State0#state{stream = Stream1, regs = Regs1}, Reg};
 and_(
-    #state{stream_module = StreamModule, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, {free, Reg}, Val
+) when
+    Val >= -2048 andalso Val =< 2047
+->
+    I = jit_riscv32_asm:andi(Reg, Reg, Val),
+    Stream1 = StreamModule:append(Stream0, I),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State0#state{stream = Stream1, regs = Regs1}, Reg};
+and_(
+    #state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0,
     {free, Reg},
     Val
 ) when Val < 0 andalso Val >= -256 ->
@@ -2713,9 +2960,10 @@ and_(
     I1 = jit_riscv32_asm:not_(Temp, Temp),
     I2 = jit_riscv32_asm:and_(Reg, Reg, Temp),
     Stream2 = StreamModule:append(Stream1, <<I1/binary, I2/binary>>),
-    {State1#state{available_regs = Avail, stream = Stream2}, Reg};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    {State1#state{available_regs = Avail, stream = Stream2, regs = Regs1}, Reg};
 and_(
-    #state{stream_module = StreamModule, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0,
     {free, Reg},
     Val
 ) when Avail =/= 0 ->
@@ -2725,50 +2973,10 @@ and_(
     Stream1 = State1#state.stream,
     I = jit_riscv32_asm:and_(Reg, Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    {State1#state{available_regs = Avail, stream = Stream2}, Reg};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    {State1#state{available_regs = Avail, stream = Stream2, regs = Regs1}, Reg};
 and_(
-    #state{stream_module = StreamModule, available_regs = 0} = State0,
-    {free, Reg},
-    Val
-) when Val < 0 andalso Val >= -256 ->
-    % No available registers, use a0 as temp and save it to t3
-    Stream0 = State0#state.stream,
-    % Save a0 to t3
-    Save = jit_riscv32_asm:mv(?IP_REG, a0),
-    Stream1 = StreamModule:append(Stream0, Save),
-    % Load immediate value into a0
-    State1 = mov_immediate(State0#state{stream = Stream1}, a0, bnot (Val)),
-    Stream2 = State1#state.stream,
-    % Perform BICS operation (RISC-V: not + and)
-    I1 = jit_riscv32_asm:not_(a0, a0),
-    I2 = jit_riscv32_asm:and_(Reg, Reg, a0),
-    Stream3 = StreamModule:append(Stream2, <<I1/binary, I2/binary>>),
-    % Restore a0 from t3
-    Restore = jit_riscv32_asm:mv(a0, ?IP_REG),
-    Stream4 = StreamModule:append(Stream3, Restore),
-    {State0#state{stream = Stream4}, Reg};
-and_(
-    #state{stream_module = StreamModule, available_regs = 0} = State0,
-    {free, Reg},
-    Val
-) ->
-    % No available registers, use a0 as temp and save it to t3
-    Stream0 = State0#state.stream,
-    % Save a0 to t3
-    Save = jit_riscv32_asm:mv(?IP_REG, a0),
-    Stream1 = StreamModule:append(Stream0, Save),
-    % Load immediate value into a0
-    State1 = mov_immediate(State0#state{stream = Stream1}, a0, Val),
-    Stream2 = State1#state.stream,
-    % Perform ANDS operation
-    I = jit_riscv32_asm:and_(Reg, Reg, a0),
-    Stream3 = StreamModule:append(Stream2, I),
-    % Restore a0 from t3
-    Restore = jit_riscv32_asm:mv(a0, ?IP_REG),
-    Stream4 = StreamModule:append(Stream3, Restore),
-    {State0#state{stream = Stream4}, Reg};
-and_(
-    #state{stream_module = StreamModule, available_regs = Avail, used_regs = UR} =
+    #state{stream_module = StreamModule, available_regs = Avail, used_regs = UR, regs = Regs0} =
         State0,
     Reg,
     ?TERM_PRIMARY_CLEAR_MASK
@@ -2777,23 +2985,33 @@ and_(
     ResultBit = reg_bit(ResultReg),
     I = jit_riscv32_asm:andi(ResultReg, Reg, -4),
     Stream1 = StreamModule:append(State0#state.stream, I),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State0#state{
             stream = Stream1,
             available_regs = Avail band (bnot ResultBit),
-            used_regs = UR bor ResultBit
+            used_regs = UR bor ResultBit,
+            regs = Regs1
         },
         ResultReg
     }.
 
-or_(#state{stream_module = StreamModule, stream = Stream0} = State0, Reg, SrcReg) when
+or_(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, Reg, SrcReg) when
     is_atom(SrcReg)
 ->
     I = jit_riscv32_asm:or_(Reg, Reg, SrcReg),
     Stream1 = StreamModule:append(Stream0, I),
-    State0#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State0#state{stream = Stream1, regs = Regs1};
+or_(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, Reg, Val) when
+    Val >= -2048 andalso Val =< 2047
+->
+    I = jit_riscv32_asm:ori(Reg, Reg, Val),
+    Stream1 = StreamModule:append(Stream0, I),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State0#state{stream = Stream1, regs = Regs1};
 or_(
-    #state{stream_module = StreamModule, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0,
     Reg,
     Val
 ) ->
@@ -2803,28 +3021,32 @@ or_(
     Stream1 = State1#state.stream,
     I = jit_riscv32_asm:or_(Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    State1#state{available_regs = Avail, stream = Stream2}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    State1#state{available_regs = Avail, stream = Stream2, regs = Regs1}.
 
-add(#state{stream_module = StreamModule, stream = Stream0} = State0, Reg, Val) when
+add(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, Reg, Val) when
     Val >= 0 andalso Val =< 255
 ->
     I = jit_riscv32_asm:addi(Reg, Reg, Val),
     Stream1 = StreamModule:append(Stream0, I),
-    State0#state{stream = Stream1};
-add(#state{stream_module = StreamModule, stream = Stream0} = State0, Reg, Val) when
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State0#state{stream = Stream1, regs = Regs1};
+add(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, Reg, Val) when
     is_atom(Val)
 ->
     I = jit_riscv32_asm:add(Reg, Reg, Val),
     Stream1 = StreamModule:append(Stream0, I),
-    State0#state{stream = Stream1};
-add(#state{stream_module = StreamModule, available_regs = Avail} = State0, Reg, Val) ->
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State0#state{stream = Stream1, regs = Regs1};
+add(#state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0, Reg, Val) ->
     Temp = first_avail(Avail),
     AT = Avail band (bnot reg_bit(Temp)),
     State1 = mov_immediate(State0#state{available_regs = AT}, Temp, Val),
     Stream1 = State1#state.stream,
     I = jit_riscv32_asm:add(Reg, Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    State1#state{available_regs = Avail, stream = Stream2}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    State1#state{available_regs = Avail, stream = Stream2, regs = Regs1}.
 
 mov_immediate(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) when
     Val >= -16#800, Val =< 16#7FF
@@ -2840,71 +3062,79 @@ mov_immediate(#state{stream_module = StreamModule, stream = Stream0} = State, Re
     Stream1 = StreamModule:append(Stream0, I),
     State#state{stream = Stream1}.
 
-sub(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) when
+sub(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) when
     Val >= 0 andalso Val =< 255
 ->
     I1 = jit_riscv32_asm:addi(Reg, Reg, -Val),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1};
-sub(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) when
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1};
+sub(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) when
     is_atom(Val)
 ->
     I = jit_riscv32_asm:sub(Reg, Reg, Val),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1};
-sub(#state{stream_module = StreamModule, available_regs = Avail} = State0, Reg, Val) ->
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1};
+sub(#state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0, Reg, Val) ->
     Temp = first_avail(Avail),
     AT = Avail band (bnot reg_bit(Temp)),
     State1 = mov_immediate(State0#state{available_regs = AT}, Temp, Val),
     Stream1 = State1#state.stream,
     I = jit_riscv32_asm:sub(Reg, Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    State1#state{available_regs = Avail, stream = Stream2}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Reg), Temp),
+    State1#state{available_regs = Avail, stream = Stream2, regs = Regs1}.
 
 mul(State, _Reg, 1) ->
     State;
 mul(State, Reg, 2) ->
     shift_left(State, Reg, 1);
-mul(#state{available_regs = Avail} = State, Reg, 3) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 3) ->
     Temp = first_avail(Avail),
     I1 = jit_riscv32_asm:slli(Temp, Reg, 1),
     I2 = jit_riscv32_asm:add(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 4) ->
     shift_left(State, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 5) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 5) ->
     Temp = first_avail(Avail),
     I1 = jit_riscv32_asm:slli(Temp, Reg, 2),
     I2 = jit_riscv32_asm:add(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State0, Reg, 6) ->
     State1 = mul(State0, Reg, 3),
     mul(State1, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 7) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 7) ->
     Temp = first_avail(Avail),
     I1 = jit_riscv32_asm:slli(Temp, Reg, 3),
     I2 = jit_riscv32_asm:sub(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 8) ->
     shift_left(State, Reg, 3);
-mul(#state{available_regs = Avail} = State, Reg, 9) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 9) ->
     Temp = first_avail(Avail),
     I1 = jit_riscv32_asm:slli(Temp, Reg, 3),
     I2 = jit_riscv32_asm:add(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State0, Reg, 10) ->
     State1 = mul(State0, Reg, 5),
     mul(State1, Reg, 2);
-mul(#state{available_regs = Avail} = State, Reg, 15) ->
+mul(#state{available_regs = Avail, regs = Regs0} = State, Reg, 15) ->
     Temp = first_avail(Avail),
     I1 = jit_riscv32_asm:slli(Temp, Reg, 4),
     I2 = jit_riscv32_asm:sub(Reg, Temp, Reg),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State#state{stream = Stream1, regs = Regs1};
 mul(State, Reg, 16) ->
     shift_left(State, Reg, 4);
 mul(State, Reg, 32) ->
@@ -2912,27 +3142,23 @@ mul(State, Reg, 32) ->
 mul(State, Reg, 64) ->
     shift_left(State, Reg, 6);
 mul(
-    #state{stream_module = StreamModule, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, available_regs = Avail, regs = Regs0} = State0,
     Reg,
     Val
 ) ->
     Temp = first_avail(Avail),
     AT = Avail band (bnot reg_bit(Temp)),
-    % multiply by decomposing by power of 2
     State1 = mov_immediate(State0#state{available_regs = AT}, Temp, Val),
     Stream1 = State1#state.stream,
     I = jit_riscv32_asm:mul(Reg, Reg, Temp),
     Stream2 = StreamModule:append(Stream1, I),
-    State1#state{stream = Stream2, available_regs = State1#state.available_regs bor reg_bit(Temp)}.
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), Reg),
+    State1#state{
+        stream = Stream2,
+        available_regs = State1#state.available_regs bor reg_bit(Temp),
+        regs = Regs1
+    }.
 
-%%
-%% Analysis of AArch64 pattern and RISC-V32 implementation:
-%%
-%% AArch64 layout (from call_ext_only_test):
-%%   0x0-0x8:  Decrement reductions, store back
-%%   0xc:      b.ne 0x20   ; Branch if reductions != 0 to continuation
-%%   0x10-0x1c: adr/str/ldr/br sequence for scheduling next process
-%%   0x20:     [CONTINUATION POINT] - Actual function starts here
 %%
 %% RISC-V32 implementation (no prolog/epilog needed due to 32 registers):
 %%   0x0-0x8:  Decrement reductions, store back
@@ -2946,9 +3172,11 @@ mul(
 %%
 -spec decrement_reductions_and_maybe_schedule_next(state()) -> state().
 decrement_reductions_and_maybe_schedule_next(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State0
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State0
 ) ->
     Temp = first_avail(Avail),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     % Load reduction count
     I1 = jit_riscv32_asm:lw(Temp, ?JITSTATE_REG, ?JITSTATE_REDUCTIONCOUNT_OFFSET),
     % Decrement reduction count
@@ -2967,7 +3195,7 @@ decrement_reductions_and_maybe_schedule_next(
     I6 = jit_riscv32_asm:sw(?JITSTATE_REG, Temp, ?JITSTATE_CONTINUATION_OFFSET),
     % Append the instructions to the stream
     Stream2 = StreamModule:append(Stream1, <<I4/binary, I5/binary, I6/binary>>),
-    State1 = State0#state{stream = Stream2},
+    State1 = State0#state{stream = Stream2, regs = Regs1},
     State2 = call_primitive_last(State1, ?PRIM_SCHEDULE_NEXT_CP, [ctx, jit_state]),
     % Rewrite the branch and adr instructions
     #state{stream = Stream3} = State2,
@@ -2991,7 +3219,10 @@ decrement_reductions_and_maybe_schedule_next(
         Stream3, BNEOffset, <<NewI4/binary, NewI5/binary>>
     ),
     StreamN = Stream4,
-    merge_used_regs(State2#state{stream = StreamN}, State1#state.used_regs).
+    State3 = merge_used_regs(State2#state{stream = StreamN}, State1#state.used_regs),
+    %% The schedule_next path is a tail call (dead end), so the register tracking
+    %% from the non-taken path (State1) is what matters at the continuation.
+    State3#state{regs = State1#state.regs}.
 
 -spec call_or_schedule_next(state(), non_neg_integer()) -> state().
 call_or_schedule_next(State0, Label) ->
@@ -3143,7 +3374,8 @@ rewrite_cp_offset(
     State0#state{stream = Stream1}.
 
 set_bs(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State0,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State0,
     TermReg
 ) ->
     Temp = first_avail(Avail),
@@ -3153,7 +3385,8 @@ set_bs(
     {BaseReg2, Off2} = ?BS_OFFSET,
     I3 = jit_riscv32_asm:sw(BaseReg2, Temp, Off2),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
-    State0#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State0#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @param State current state
@@ -3266,17 +3499,7 @@ str_y_reg(SrcReg, Y, TempReg1, AvailableMask) when AvailableMask =/= 0 ->
     I2 = jit_riscv32_asm:li(TempReg2, Offset),
     I3 = jit_riscv32_asm:add(TempReg2, TempReg2, TempReg1),
     I4 = jit_riscv32_asm:sw(TempReg2, SrcReg, 0),
-    <<I1/binary, I2/binary, I3/binary, I4/binary>>;
-str_y_reg(SrcReg, Y, TempReg1, 0) ->
-    % Large offset - no additional registers available, use IP_REG as second temp
-    Offset = Y * 4,
-    {BaseReg, Off} = ?Y_REGS,
-    I1 = jit_riscv32_asm:lw(TempReg1, BaseReg, Off),
-    I2 = jit_riscv32_asm:mv(?IP_REG, TempReg1),
-    I3 = jit_riscv32_asm:li(TempReg1, Offset),
-    I4 = jit_riscv32_asm:add(TempReg1, TempReg1, ?IP_REG),
-    I5 = jit_riscv32_asm:sw(TempReg1, SrcReg, 0),
-    <<I1/binary, I2/binary, I3/binary, I4/binary, I5/binary>>.
+    <<I1/binary, I2/binary, I3/binary, I4/binary>>.
 
 %% Helper function to generate ldr instruction with y_reg offset, handling large offsets
 ldr_y_reg(DstReg, Y, AvailableMask) when AvailableMask =/= 0 andalso Y * 4 =< 124 ->
@@ -3301,18 +3524,7 @@ ldr_y_reg(DstReg, Y, 0) when Y * 4 =< 124 ->
     {BaseReg, Off} = ?Y_REGS,
     I1 = jit_riscv32_asm:lw(DstReg, BaseReg, Off),
     I2 = jit_riscv32_asm:lw(DstReg, DstReg, Y * 4),
-    <<I1/binary, I2/binary>>;
-ldr_y_reg(DstReg, Y, 0) ->
-    % Large offset, no registers available - use IP_REG as temp register
-    % Note: IP_REG (t3) can only be used with mov, not ldr directly
-    Offset = Y * 4,
-    {BaseReg, Off} = ?Y_REGS,
-    I1 = jit_riscv32_asm:lw(DstReg, BaseReg, Off),
-    I2 = jit_riscv32_asm:mv(?IP_REG, DstReg),
-    I3 = jit_riscv32_asm:li(DstReg, Offset),
-    I4 = jit_riscv32_asm:add(DstReg, DstReg, ?IP_REG),
-    I5 = jit_riscv32_asm:lw(DstReg, DstReg, 0),
-    <<I1/binary, I2/binary, I3/binary, I4/binary, I5/binary>>.
+    <<I1/binary, I2/binary>>.
 
 reg_bit(a0) -> ?REG_BIT_A0;
 reg_bit(a1) -> ?REG_BIT_A1;
@@ -3416,9 +3628,10 @@ args_regs(Args) ->
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec add_label(state(), integer() | reference()) -> state().
-add_label(#state{stream_module = StreamModule, stream = Stream0} = State0, Label) ->
+add_label(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State0, Label) ->
     Offset0 = StreamModule:offset(Stream0),
-    add_label(State0, Label, Offset0).
+    Regs1 = jit_regs:invalidate_all(Regs0),
+    add_label(State0#state{regs = Regs1}, Label, Offset0).
 
 %%-----------------------------------------------------------------------------
 %% @doc Add a label at a specific offset

--- a/libs/jit/src/jit_x86_64.erl
+++ b/libs/jit/src/jit_x86_64.erl
@@ -119,7 +119,8 @@
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
     labels :: [{integer() | reference(), integer()}],
-    variant :: non_neg_integer()
+    variant :: non_neg_integer(),
+    regs :: jit_regs:regs()
 }).
 
 -type state() :: #state{}.
@@ -242,7 +243,8 @@ new(Variant, StreamModule, Stream) ->
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
         labels = [],
-        variant = Variant
+        variant = Variant,
+        regs = jit_regs:new()
     }.
 
 %%-----------------------------------------------------------------------------
@@ -475,7 +477,7 @@ call_primitive(
 ) ->
     % We need a register for the function pointer that should not be used as a parameter
     ParamRegs = lists:sublist(?PARAMETER_REGS, length(Args)),
-    ParamMask = regs_to_mask(ParamRegs),
+    ParamMask = jit_regs:regs_to_mask(ParamRegs, fun reg_bit/1),
     FreeFromParams = AvailableRegs0 band (bnot ParamMask),
     case FreeFromParams of
         0 ->
@@ -497,7 +499,8 @@ call_primitive(
                 State#state{
                     stream = Stream1,
                     available_regs = AvailableRegs0 band (bnot TempBit),
-                    used_regs = UsedRegs bor TempBit
+                    used_regs = UsedRegs bor TempBit,
+                    regs = jit_regs:invalidate_reg(State#state.regs, Temp)
                 },
                 {free, Temp},
                 Args
@@ -527,8 +530,8 @@ call_primitive_last(
     % registers used for parameters
     ParamRegs = lists:sublist(?PARAMETER_REGS, length(Args)),
     ArgsRegs = args_regs(Args),
-    ParamMask = regs_to_mask(ParamRegs),
-    ArgsMask = regs_to_mask(ArgsRegs),
+    ParamMask = jit_regs:regs_to_mask(ParamRegs, fun reg_bit/1),
+    ArgsMask = jit_regs:regs_to_mask(ArgsRegs, fun reg_bit/1),
     ScratchMask =
         ?AVAILABLE_REGS_MASK band (bnot (ArgsMask bor ParamMask)),
     Temp = first_avail(ScratchMask),
@@ -543,11 +546,18 @@ call_primitive_last(
                 jit_x86_64_asm:movq(?PRIMITIVE(N), Temp)
         end,
     Stream1 = StreamModule:append(Stream0, PrepCall),
-    State1 = set_args(
+    State1 = set_args2(
         State0#state{
-            stream = Stream1, available_regs = AvailableRegs1, used_regs = UsedRegs
+            stream = Stream1,
+            available_regs = AvailableRegs1,
+            used_regs = UsedRegs,
+            regs = jit_regs:invalidate_reg(State0#state.regs, Temp)
         },
-        Args
+        Args,
+        ParamRegs,
+        ArgsRegs,
+        ParamMask,
+        ArgsMask
     ),
     #state{stream = Stream2} = State1,
     Call = jit_x86_64_asm:jmpq({Temp}),
@@ -555,7 +565,8 @@ call_primitive_last(
     State1#state{
         stream = Stream3,
         available_regs = ?AVAILABLE_REGS_MASK,
-        used_regs = 0
+        used_regs = 0,
+        regs = jit_regs:invalidate_all(State1#state.regs)
     }.
 
 %%-----------------------------------------------------------------------------
@@ -586,10 +597,12 @@ return_if_not_equal_to_ctx(
     I2 = jit_x86_64_asm:jz(byte_size(I3) + byte_size(I4) + 2),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>),
     RegBit = reg_bit(Reg),
+    Regs1 = jit_regs:invalidate_reg(State#state.regs, Reg),
     State#state{
         stream = Stream1,
         available_regs = AvailableRegs0 bor RegBit,
-        used_regs = UsedRegs0 band (bnot RegBit)
+        used_regs = UsedRegs0 band (bnot RegBit),
+        regs = Regs1
     }.
 
 %%-----------------------------------------------------------------------------
@@ -614,7 +627,8 @@ jump_to_label(
             RelOffset = LabelOffset - Offset,
             I1 = jit_x86_64_asm:jmp(RelOffset),
             Stream1 = StreamModule:append(Stream0, I1),
-            State#state{stream = Stream1};
+            %% After unconditional jump, register tracking is dead until next label
+            State#state{stream = Stream1, regs = jit_regs:invalidate_all(State#state.regs)};
         false ->
             % Label not yet known, emit placeholder and add relocation
             {RelocOffset, I1} = jit_x86_64_asm:jmp_rel32(1),
@@ -622,7 +636,8 @@ jump_to_label(
             Stream1 = StreamModule:append(Stream0, I1),
             State#state{
                 stream = Stream1,
-                branches = [Reloc | AccBranches]
+                branches = [Reloc | AccBranches],
+                regs = jit_regs:invalidate_all(State#state.regs)
             }
     end.
 
@@ -631,7 +646,7 @@ jump_to_offset(#state{stream_module = StreamModule, stream = Stream0} = State, T
     RelOffset = TargetOffset - Offset,
     I1 = jit_x86_64_asm:jmp(RelOffset),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1}.
+    State#state{stream = Stream1, regs = jit_regs:invalidate_all(State#state.regs)}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Jump to a continuation address stored in a register.
@@ -671,7 +686,8 @@ jump_to_continuation(
     State#state{
         stream = Stream1,
         available_regs = ?AVAILABLE_REGS_MASK,
-        used_regs = 0
+        used_regs = 0,
+        regs = jit_regs:invalidate_all(State#state.regs)
     }.
 
 %%-----------------------------------------------------------------------------
@@ -712,7 +728,11 @@ if_block(
         Stream2,
         Replacements
     ),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs);
+    State3 = merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs),
+    %% At the merge point, only keep register tracking that is consistent
+    %% in both the taken (State2) and not-taken (State1) paths
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State3#state{regs = MergedRegs};
 if_block(
     #state{stream_module = StreamModule, stream = Stream0} = State0,
     Cond,
@@ -728,7 +748,9 @@ if_block(
     Stream3 = StreamModule:replace(Stream2, Offset + ReplaceDelta, <<
         (OffsetAfter - OffsetAfterCond)
     >>),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs).
+    State3 = merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs),
+    MergedRegs = jit_regs:merge(State1#state.regs, State2#state.regs),
+    State3#state{regs = MergedRegs}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit an if else block, i.e. emit a test of a condition and
@@ -764,7 +786,8 @@ if_else_block(
     StateElse = State2#state{
         stream = Stream4,
         used_regs = State1#state.used_regs,
-        available_regs = State1#state.available_regs
+        available_regs = State1#state.available_regs,
+        regs = State1#state.regs
     },
     State3 = BlockFalseFn(StateElse),
     Stream5 = State3#state.stream,
@@ -772,7 +795,10 @@ if_else_block(
     Stream6 = StreamModule:replace(Stream5, ElseJumpOffset + RelocJMPOffset, <<
         (OffsetFinal - OffsetAfter)
     >>),
-    merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs).
+    State4 = merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs),
+    %% Merge register tracking from both branches (true=State2, false=State3)
+    MergedRegs = jit_regs:merge(State2#state.regs, State3#state.regs),
+    State4#state{regs = MergedRegs}.
 
 -spec if_block_cond(state(), condition()) -> {state(), non_neg_integer()}.
 if_block_cond(#state{stream_module = StreamModule} = State0, Cond) ->
@@ -999,11 +1025,14 @@ if_block_cond0(State0, {RegOrTuple, '&', Mask, '!=', 0}) when ?IS_UINT8_T(Mask) 
     {RelocJZOffset, I2} = jit_x86_64_asm:jz_rel8(1),
     State1 = if_block_free_reg(RegOrTuple, State0),
     {State1, <<I1/binary, I2/binary>>, byte_size(I1) + RelocJZOffset};
-if_block_cond0(State0, {{free, Reg} = RegTuple, '&', Mask, '!=', Val}) when ?IS_UINT8_T(Mask) ->
+if_block_cond0(#state{regs = Regs0} = State0, {{free, Reg} = RegTuple, '&', Mask, '!=', Val}) when
+    ?IS_UINT8_T(Mask)
+->
     I1 = jit_x86_64_asm:andb(Mask, Reg),
     I2 = jit_x86_64_asm:cmpb(Val, Reg),
     {RelocJZOffset, I3} = jit_x86_64_asm:jz_rel8(1),
-    State1 = if_block_free_reg(RegTuple, State0),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State1 = if_block_free_reg(RegTuple, State0#state{regs = Regs1}),
     {State1, <<I1/binary, I2/binary, I3/binary>>, byte_size(I1) + byte_size(I2) + RelocJZOffset};
 if_block_cond0(State0, {Reg, '&', Mask, '!=', Val}) when ?IS_UINT8_T(Mask) ->
     Temp = first_avail(State0#state.available_regs),
@@ -1041,19 +1070,21 @@ merge_used_regs(#state{used_regs = UR} = State, OtherUR) ->
 -spec shift_right(#state{}, maybe_free_x86_64_register(), non_neg_integer()) ->
     {#state{}, x86_64_register()}.
 shift_right(
-    #state{stream_module = StreamModule, stream = Stream0} = State, {free, Reg}, Shift
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, {free, Reg}, Shift
 ) when
     ?IS_GPR(Reg) andalso is_integer(Shift)
 ->
     I = jit_x86_64_asm:shrq(Shift, Reg),
     Stream1 = StreamModule:append(Stream0, I),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 shift_right(
     #state{
         stream_module = StreamModule,
         available_regs = Avail,
         used_regs = UR,
-        stream = Stream0
+        stream = Stream0,
+        regs = Regs0
     } = State,
     Reg,
     Shift
@@ -1065,11 +1096,13 @@ shift_right(
     I1 = jit_x86_64_asm:movq(Reg, ResultReg),
     I2 = jit_x86_64_asm:shrq(Shift, ResultReg),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot Bit),
-            used_regs = UR bor Bit
+            used_regs = UR bor Bit,
+            regs = Regs1
         },
         ResultReg
     }.
@@ -1083,13 +1116,14 @@ shift_right(
 %% @return new state
 %%-----------------------------------------------------------------------------
 shift_left(
-    #state{stream_module = StreamModule, stream = Stream0} = State, Reg, Shift
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Shift
 ) when
     is_atom(Reg)
 ->
     I = jit_x86_64_asm:shlq(Shift, Reg),
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a call to a function pointer with arguments. This function converts
@@ -1200,23 +1234,33 @@ call_func_ptr(
     ResultBit = reg_bit(ResultReg),
     AvailableRegs2 = (AvailableRegs1 band (bnot ResultBit)) band ?AVAILABLE_REGS_MASK,
     UsedRegs2 = UsedRegs1 bor ResultBit,
+    Regs1 = jit_regs:invalidate_all(State0#state.regs),
     {
         State1#state{
             stream = Stream9,
             available_regs = AvailableRegs2,
-            used_regs = UsedRegs2
+            used_regs = UsedRegs2,
+            regs = Regs1
         },
         ResultReg
     }.
 
 -spec set_args(state(), [arg()]) -> state().
-set_args(
-    #state{stream = Stream0, stream_module = StreamModule, used_regs = UsedRegs} = State0, Args
-) ->
+set_args(State0, Args) ->
     ParamRegs = parameter_regs(Args),
     ArgsRegs = args_regs(Args),
-    ParamMask = regs_to_mask(ParamRegs),
-    ArgsMask = regs_to_mask(ArgsRegs),
+    ParamMask = jit_regs:regs_to_mask(ParamRegs, fun reg_bit/1),
+    ArgsMask = jit_regs:regs_to_mask(ArgsRegs, fun reg_bit/1),
+    set_args2(State0, Args, ParamRegs, ArgsRegs, ParamMask, ArgsMask).
+
+set_args2(
+    #state{stream = Stream0, stream_module = StreamModule, used_regs = UsedRegs} = State0,
+    Args,
+    ParamRegs,
+    ArgsRegs,
+    ParamMask,
+    ArgsMask
+) ->
     AvailableScratchGP =
         ?SCRATCH_REGS_MASK band (bnot (ParamMask bor ArgsMask bor UsedRegs)),
     Offset = StreamModule:offset(Stream0),
@@ -1227,7 +1271,7 @@ set_args(
         end
      || Arg <- Args
     ],
-    SetArgsCode = set_args0(Args1, ArgsRegs, ParamRegs, AvailableScratchGP, []),
+    SetArgsCode = set_args0(Args1, ArgsRegs, ParamRegs, AvailableScratchGP, #{}, []),
     Stream1 = StreamModule:append(Stream0, SetArgsCode),
     NewUsedMask = lists:foldl(
         fun
@@ -1290,47 +1334,64 @@ exchange_reg(Args, ArgsRegs, Reg1, Reg2) ->
     ),
     {NewArgs, NewArgsRegs}.
 
-set_args0([], [], [], _AvailGP, Acc) ->
+set_args0([], [], [], _AvailGP, _LoadedImm, Acc) ->
     list_to_binary(lists:reverse(Acc));
-set_args0([{free, FreeVal} | ArgsT], ArgsRegs, ParamRegs, AvailGP, Acc) ->
-    set_args0([FreeVal | ArgsT], ArgsRegs, ParamRegs, AvailGP, Acc);
-set_args0([ctx | ArgsT], [?CTX_REG | ArgsRegs], [?CTX_REG | ParamRegs], AvailGP, Acc) ->
-    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, Acc);
+set_args0([{free, FreeVal} | ArgsT], ArgsRegs, ParamRegs, AvailGP, LoadedImm, Acc) ->
+    set_args0([FreeVal | ArgsT], ArgsRegs, ParamRegs, AvailGP, LoadedImm, Acc);
+set_args0([ctx | ArgsT], [?CTX_REG | ArgsRegs], [?CTX_REG | ParamRegs], AvailGP, LoadedImm, Acc) ->
+    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, Acc);
 set_args0(
     [jit_state | ArgsT],
     [?JITSTATE_REG | ArgsRegs],
     [?JITSTATE_REG | ParamRegs],
     AvailGP,
+    LoadedImm,
     Acc
 ) ->
-    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, Acc);
+    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, Acc);
 set_args0(
-    [jit_state | ArgsT], [?JITSTATE_REG | ArgsRegs], [ParamReg | ParamRegs], AvailGP, Acc
+    [jit_state | ArgsT], [?JITSTATE_REG | ArgsRegs], [ParamReg | ParamRegs], AvailGP, LoadedImm, Acc
 ) ->
     false = lists:member(ParamReg, ArgsRegs),
-    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, [
+    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, [
         jit_x86_64_asm:movq(?JITSTATE_REG, ParamReg) | Acc
     ]);
 % ctx is special as we need it to access x_reg/y_reg/fp_reg
-set_args0([Arg | ArgsT], [_ArgReg | ArgsRegs], [?CTX_REG | ParamRegs], AvailGP, Acc) ->
+set_args0([Arg | ArgsT], [_ArgReg | ArgsRegs], [?CTX_REG | ParamRegs], AvailGP, LoadedImm, Acc) ->
     false = lists:member(?CTX_REG, ArgsRegs),
     J = set_args1(Arg, ?CTX_REG),
-    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, [J | Acc]);
+    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, [J | Acc]);
 set_args0(
     [Arg | ArgsT],
     [ArgReg | ArgsRegs],
     [ParamReg | ParamRegs],
     AvailGP,
+    LoadedImm,
     Acc
 ) ->
     case lists:member(ParamReg, ArgsRegs) of
         false ->
-            J = set_args1(Arg, ParamReg),
-            set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, [J | Acc]);
+            % Normal case: ParamReg is free, just move Arg to ParamReg
+            case is_integer(Arg) andalso maps:find(Arg, LoadedImm) of
+                {ok, SourceReg} ->
+                    J = jit_x86_64_asm:movq(SourceReg, ParamReg),
+                    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, LoadedImm, [J | Acc]);
+                _ ->
+                    J = set_args1(Arg, ParamReg),
+                    NewLoadedImm =
+                        case is_integer(Arg) of
+                            true -> LoadedImm#{Arg => ParamReg};
+                            false -> LoadedImm
+                        end,
+                    set_args0(ArgsT, ArgsRegs, ParamRegs, AvailGP, NewLoadedImm, [J | Acc])
+            end;
         true ->
+            % ParamReg is occupied by another argument that will go elsewhere
+            % Use xchg to swap ArgReg and ParamReg
+            % After xchg, the value from Arg (which was in ArgReg) is now in ParamReg
             I = jit_x86_64_asm:xchgq(ArgReg, ParamReg),
             {NewArgsT, NewArgsRegs} = exchange_reg(ArgsT, ArgsRegs, ParamReg, ArgReg),
-            set_args0(NewArgsT, NewArgsRegs, ParamRegs, AvailGP, [I | Acc])
+            set_args0(NewArgsT, NewArgsRegs, ParamRegs, AvailGP, LoadedImm, [I | Acc])
     end.
 
 set_args1(Reg, Reg) ->
@@ -1368,8 +1429,27 @@ set_args1({avm_int64_t, Value}, Reg) when is_integer(Value) ->
     (state(), Src :: value() | vm_register(), Dest :: vm_register()) -> state();
     (state(), Src :: {free, {ptr, x86_64_register(), 1}}, Dest :: {fp_reg, non_neg_integer()}) ->
         state().
-move_to_vm_register(State, Src, Dest) ->
-    move_to_vm_register_emit(State, Src, Dest).
+move_to_vm_register(#state{regs = Regs0} = State, Src, Dest) ->
+    %% Invalidate any CPU register tracking the old value of the destination VM register
+    VmLoc = vm_dest_to_contents(Dest),
+    Regs1 =
+        case VmLoc of
+            unknown -> Regs0;
+            _ -> jit_regs:invalidate_vm_loc(Regs0, VmLoc)
+        end,
+    State1 = move_to_vm_register_emit(State#state{regs = Regs1}, Src, Dest),
+    %% After storing a native register to a VM register, the native reg still holds
+    %% the VM register's value. Record this so subsequent loads can be skipped.
+    case {Src, VmLoc} of
+        {Reg, Contents} when is_atom(Reg), Contents =/= unknown ->
+            #state{regs = Regs2} = State1,
+            State1#state{regs = jit_regs:set_contents(Regs2, Reg, Contents)};
+        _ ->
+            State1
+    end.
+
+%% Convert a VM register destination to a contents descriptor.
+vm_dest_to_contents(Dest) -> jit_regs:vm_dest_to_contents(Dest, ?MAX_REG).
 
 % Src = 0, we can andq as an optimization
 move_to_vm_register_emit(State, 0, {x_reg, X}) when X < ?MAX_REG ->
@@ -1384,12 +1464,13 @@ move_to_vm_register_emit(State, 0, {ptr, Reg}) ->
     I1 = jit_x86_64_asm:andq(0, {0, Reg}),
     Stream1 = (State#state.stream_module):append(State#state.stream, I1),
     State#state{stream = Stream1};
-move_to_vm_register_emit(#state{available_regs = Avail} = State, 0, {y_reg, Y}) ->
+move_to_vm_register_emit(#state{available_regs = Avail, regs = Regs0} = State, 0, {y_reg, Y}) ->
     Temp = first_avail(Avail),
     I1 = jit_x86_64_asm:movq(?Y_REGS, Temp),
     I2 = jit_x86_64_asm:andq(0, {Y * 8, Temp}),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 % ?IS_SINT32_T(Src), we can use movq to set the value
 move_to_vm_register_emit(State, N, {x_reg, X}) when X < ?MAX_REG andalso ?IS_SINT32_T(N) ->
     Stream1 = (State#state.stream_module):append(
@@ -1406,40 +1487,46 @@ move_to_vm_register_emit(State, N, {ptr, Reg}) when ?IS_SINT32_T(N) ->
         State#state.stream, jit_x86_64_asm:movq(N, {0, Reg})
     ),
     State#state{stream = Stream1};
-move_to_vm_register_emit(#state{available_regs = Avail} = State, N, {y_reg, Y}) when
+move_to_vm_register_emit(#state{available_regs = Avail, regs = Regs0} = State, N, {y_reg, Y}) when
     ?IS_SINT32_T(N)
 ->
     Temp = first_avail(Avail),
     I1 = jit_x86_64_asm:movq(?Y_REGS, Temp),
     I2 = jit_x86_64_asm:movq(N, {Y * 8, Temp}),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 % ?is_integer(Src), we need to use movabsq
-move_to_vm_register_emit(#state{available_regs = Avail} = State, N, {x_reg, X}) when
+move_to_vm_register_emit(#state{available_regs = Avail, regs = Regs0} = State, N, {x_reg, X}) when
     X < ?MAX_REG andalso is_integer(N)
 ->
     Temp = first_avail(Avail),
     I1 = jit_x86_64_asm:movabsq(N, Temp),
     I2 = jit_x86_64_asm:movq(Temp, ?X_REG(X)),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
-move_to_vm_register_emit(#state{available_regs = Avail} = State, N, {x_reg, extra}) when
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
+move_to_vm_register_emit(
+    #state{available_regs = Avail, regs = Regs0} = State, N, {x_reg, extra}
+) when
     is_integer(N)
 ->
     Temp = first_avail(Avail),
     I1 = jit_x86_64_asm:movabsq(N, Temp),
     I2 = jit_x86_64_asm:movq(Temp, ?X_REG(?MAX_REG)),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
-move_to_vm_register_emit(#state{available_regs = Avail} = State, N, {ptr, Reg}) when
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
+move_to_vm_register_emit(#state{available_regs = Avail, regs = Regs0} = State, N, {ptr, Reg}) when
     is_integer(N)
 ->
     Temp = first_avail(Avail),
     I1 = jit_x86_64_asm:movabsq(N, Temp),
     I2 = jit_x86_64_asm:movq(Temp, {0, Reg}),
     Stream1 = (State#state.stream_module):append(State#state.stream, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
-move_to_vm_register_emit(#state{available_regs = Avail} = State, N, {y_reg, Y}) when
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
+move_to_vm_register_emit(#state{available_regs = Avail, regs = Regs0} = State, N, {y_reg, Y}) when
     is_integer(N)
 ->
     Temp1 = first_avail(Avail),
@@ -1450,7 +1537,8 @@ move_to_vm_register_emit(#state{available_regs = Avail} = State, N, {y_reg, Y}) 
     Stream1 = (State#state.stream_module):append(
         State#state.stream, <<I1/binary, I2/binary, I3/binary>>
     ),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp1), Temp2),
+    State#state{stream = Stream1, regs = Regs1};
 % is_atom(Src) (native register)
 move_to_vm_register_emit(State, Reg, {x_reg, X}) when is_atom(Reg) andalso X < ?MAX_REG ->
     I1 = jit_x86_64_asm:movq(Reg, ?X_REG(X)),
@@ -1464,7 +1552,7 @@ move_to_vm_register_emit(State, Reg, {ptr, Dest}) when is_atom(Reg) ->
     I1 = jit_x86_64_asm:movq(Reg, {0, Dest}),
     Stream1 = (State#state.stream_module):append(State#state.stream, I1),
     State#state{stream = Stream1};
-move_to_vm_register_emit(#state{available_regs = Avail} = State, Reg, {y_reg, Y}) when
+move_to_vm_register_emit(#state{available_regs = Avail, regs = Regs0} = State, Reg, {y_reg, Y}) when
     is_atom(Reg)
 ->
     Temp = first_avail(Avail),
@@ -1472,50 +1560,68 @@ move_to_vm_register_emit(#state{available_regs = Avail} = State, Reg, {y_reg, Y}
     I2 = jit_x86_64_asm:movq(Reg, {Y * 8, Temp}),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = (State#state.stream_module):append(State#state.stream, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 % Src is x_reg, store in temporary register and call move_to_vm_register_emit for the four cases
-move_to_vm_register_emit(#state{available_regs = Avail} = State0, {x_reg, X}, Dest) when
+move_to_vm_register_emit(
+    #state{available_regs = Avail, regs = Regs0} = State0, {x_reg, X}, Dest
+) when
     X < ?MAX_REG
 ->
     Temp = first_avail(Avail),
     TempBit = reg_bit(Temp),
     I1 = jit_x86_64_asm:movq(?X_REG(X), Temp),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     State1 = move_to_vm_register_emit(
-        State0#state{stream = Stream1, available_regs = Avail band (bnot TempBit)}, Temp, Dest
+        State0#state{stream = Stream1, available_regs = Avail band (bnot TempBit), regs = Regs1},
+        Temp,
+        Dest
     ),
     State1#state{available_regs = Avail};
-move_to_vm_register_emit(#state{available_regs = Avail} = State0, {x_reg, extra}, Dest) ->
+move_to_vm_register_emit(
+    #state{available_regs = Avail, regs = Regs0} = State0, {x_reg, extra}, Dest
+) ->
     Temp = first_avail(Avail),
     TempBit = reg_bit(Temp),
     I1 = jit_x86_64_asm:movq(?X_REG(?MAX_REG), Temp),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     State1 = move_to_vm_register_emit(
-        State0#state{stream = Stream1, available_regs = Avail band (bnot TempBit)}, Temp, Dest
+        State0#state{stream = Stream1, available_regs = Avail band (bnot TempBit), regs = Regs1},
+        Temp,
+        Dest
     ),
     State1#state{available_regs = Avail};
-move_to_vm_register_emit(#state{available_regs = Avail} = State0, {ptr, Reg}, Dest) ->
+move_to_vm_register_emit(#state{available_regs = Avail, regs = Regs0} = State0, {ptr, Reg}, Dest) ->
     Temp = first_avail(Avail),
     TempBit = reg_bit(Temp),
     I1 = jit_x86_64_asm:movq({0, Reg}, Temp),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, I1),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     State1 = move_to_vm_register_emit(
-        State0#state{stream = Stream1, available_regs = Avail band (bnot TempBit)}, Temp, Dest
+        State0#state{stream = Stream1, available_regs = Avail band (bnot TempBit), regs = Regs1},
+        Temp,
+        Dest
     ),
     State1#state{available_regs = Avail};
-move_to_vm_register_emit(#state{available_regs = Avail} = State0, {y_reg, Y}, Dest) ->
+move_to_vm_register_emit(#state{available_regs = Avail, regs = Regs0} = State0, {y_reg, Y}, Dest) ->
     Temp = first_avail(Avail),
     TempBit = reg_bit(Temp),
     I1 = jit_x86_64_asm:movq(?Y_REGS, Temp),
     I2 = jit_x86_64_asm:movq({Y * 8, Temp}, Temp),
     Stream1 = (State0#state.stream_module):append(State0#state.stream, <<I1/binary, I2/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     State1 = move_to_vm_register_emit(
-        State0#state{stream = Stream1, available_regs = Avail band (bnot TempBit)}, Temp, Dest
+        State0#state{stream = Stream1, available_regs = Avail band (bnot TempBit), regs = Regs1},
+        Temp,
+        Dest
     ),
     State1#state{available_regs = Avail};
 % term_to_float
 move_to_vm_register_emit(
-    #state{stream_module = StreamModule, available_regs = Avail, stream = Stream0} = State0,
+    #state{stream_module = StreamModule, available_regs = Avail, stream = Stream0, regs = Regs0} =
+        State0,
     {free, {ptr, Reg, 1}},
     {fp_reg, F}
 ) when is_atom(Reg) ->
@@ -1525,7 +1631,8 @@ move_to_vm_register_emit(
     I3 = jit_x86_64_asm:movq(Reg, {?FP_REG_OFFSET(State0, F), Temp}),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State1 = free_native_register(State0, Reg),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State1 = free_native_register(State0#state{regs = Regs1}, Reg),
     State1#state{stream = Stream1}.
 
 %%-----------------------------------------------------------------------------
@@ -1544,7 +1651,8 @@ move_to_vm_register_emit(
     Dest :: vm_register() | x86_64_register()
 ) -> state().
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Reg,
     Index,
     {x_reg, X}
@@ -1553,9 +1661,12 @@ move_array_element(
     I1 = jit_x86_64_asm:movq({Index * 8, Reg}, Temp),
     I2 = jit_x86_64_asm:movq(Temp, ?X_REG(X)),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
+    State#state{stream = Stream1, regs = Regs2};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Reg,
     Index,
     {ptr, Dest}
@@ -1564,9 +1675,10 @@ move_array_element(
     I1 = jit_x86_64_asm:movq({Index * 8, Reg}, Temp),
     I2 = jit_x86_64_asm:movq(Temp, {0, Dest}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} =
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
         State,
     Reg,
     Index,
@@ -1579,19 +1691,24 @@ move_array_element(
     I3 = jit_x86_64_asm:movq(Temp2, {Y * 8, Temp1}),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp1),
+    Regs3 = jit_regs:invalidate_reg(Regs2, Temp2),
+    State#state{stream = Stream1, regs = Regs3};
 move_array_element(
-    #state{stream_module = StreamModule, stream = Stream0} = State, Reg, Index, Dest
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Index, Dest
 ) when is_atom(Dest) andalso is_integer(Index) ->
     I1 = jit_x86_64_asm:movq({Index * 8, Reg}, Dest),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Dest),
+    State#state{stream = Stream1, regs = Regs1};
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -1603,17 +1720,21 @@ move_array_element(
     I4 = jit_x86_64_asm:movq(IndexReg, ?X_REG(X)),
     IndexBit = reg_bit(IndexReg),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>),
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {x_reg, X}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, IndexReg),
     State#state{
         available_regs = AvailableRegs0 bor IndexBit,
         used_regs = UsedRegs0 band (bnot IndexBit),
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs2
     };
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -1625,17 +1746,20 @@ move_array_element(
     I4 = jit_x86_64_asm:movq(IndexReg, {0, PtrReg}),
     IndexBit = reg_bit(IndexReg),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, IndexReg),
     State#state{
         available_regs = AvailableRegs0 bor IndexBit,
         used_regs = UsedRegs0 band (bnot IndexBit),
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs1
     };
 move_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = AvailableRegs0,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     {free, IndexReg},
@@ -1651,10 +1775,14 @@ move_array_element(
     Stream1 = StreamModule:append(
         Stream0, <<I1/binary, I2/binary, I3/binary, I4/binary, I5/binary>>
     ),
+    Regs1 = jit_regs:invalidate_vm_loc(Regs0, {y_reg, Y}),
+    Regs2 = jit_regs:invalidate_reg(Regs1, Temp),
+    Regs3 = jit_regs:invalidate_reg(Regs2, IndexReg),
     State#state{
         available_regs = AvailableRegs0 bor IndexBit,
         used_regs = UsedRegs0 band (bnot IndexBit),
-        stream = Stream1
+        stream = Stream1,
+        regs = Regs3
     }.
 
 %%-----------------------------------------------------------------------------
@@ -1674,20 +1802,23 @@ move_array_element(
 get_array_element(
     #state{
         stream_module = StreamModule,
-        stream = Stream0
+        stream = Stream0,
+        regs = Regs0
     } = State,
     {free, Reg},
     Index
 ) ->
     I1 = jit_x86_64_asm:movq({Index * 8, Reg}, Reg),
     Stream1 = StreamModule:append(Stream0, <<I1/binary>>),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 get_array_element(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State,
     Reg,
     Index
@@ -1696,9 +1827,13 @@ get_array_element(
     Bit = reg_bit(ElemReg),
     I1 = jit_x86_64_asm:movq({Index * 8, Reg}, ElemReg),
     Stream1 = StreamModule:append(Stream0, <<I1/binary>>),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ElemReg),
     {
         State#state{
-            stream = Stream1, available_regs = Avail band (bnot Bit), used_regs = UsedRegs0 bor Bit
+            stream = Stream1,
+            available_regs = Avail band (bnot Bit),
+            used_regs = UsedRegs0 bor Bit,
+            regs = Regs1
         },
         ElemReg
     }.
@@ -1720,7 +1855,8 @@ get_array_element(
     Index :: non_neg_integer()
 ) -> state().
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     {x_reg, X},
     Reg,
     Index
@@ -1729,9 +1865,11 @@ move_to_array_element(
     I1 = jit_x86_64_asm:movq(?X_REG(X), Temp),
     I2 = jit_x86_64_asm:movq(Temp, {Index * 8, Reg}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     {ptr, Source},
     Reg,
     Index
@@ -1740,9 +1878,10 @@ move_to_array_element(
     I1 = jit_x86_64_asm:movq({0, Source}, Temp),
     I2 = jit_x86_64_asm:movq(Temp, {Index * 8, Reg}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} =
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
         State,
     {y_reg, Y},
     Reg,
@@ -1754,7 +1893,8 @@ move_to_array_element(
     I3 = jit_x86_64_asm:movq(Temp, {Index * 8, Reg}),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
     #state{stream_module = StreamModule, stream = Stream0} = State, Source, Reg, Index
 ) when ?IS_GPR(Source) andalso ?IS_GPR(Reg) andalso is_integer(Index) ->
@@ -1768,7 +1908,8 @@ move_to_array_element(
     Stream1 = StreamModule:append(Stream0, I1),
     State#state{stream = Stream1};
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Source,
     Reg,
     Index
@@ -1777,7 +1918,8 @@ move_to_array_element(
     I1 = jit_x86_64_asm:movabsq(Source, Temp),
     I2 = jit_x86_64_asm:movq(Temp, {Index * 8, Reg}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a move of a value (integer, vm register or native register) to an
@@ -1799,7 +1941,8 @@ move_to_array_element(
 ) when is_integer(Index) andalso is_integer(Offset) ->
     move_to_array_element(State, Source, BaseReg, Index + Offset);
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     {x_reg, X},
     BaseReg,
     IndexReg,
@@ -1809,9 +1952,11 @@ move_to_array_element(
     I1 = jit_x86_64_asm:movq(?X_REG(X), Temp),
     I2 = jit_x86_64_asm:movq(Temp, {Offset * ?WORD_SIZE, BaseReg, IndexReg, 8}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     {y_reg, Y},
     BaseReg,
     IndexReg,
@@ -1822,7 +1967,8 @@ move_to_array_element(
     I2 = jit_x86_64_asm:movq({Y * 8, Temp}, Temp),
     I3 = jit_x86_64_asm:movq(Temp, {Offset * ?WORD_SIZE, BaseReg, IndexReg, 8}),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
-    State#state{stream = Stream1};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    State#state{stream = Stream1, regs = Regs1};
 move_to_array_element(
     #state{stream_module = StreamModule, stream = Stream0} = State,
     Source,
@@ -1852,57 +1998,96 @@ move_to_array_element(
 -spec move_to_native_register(state(), value() | cp) -> {state(), x86_64_register()}.
 move_to_native_register(State, Reg) when ?IS_GPR(Reg) ->
     {State, Reg};
-move_to_native_register(State, Value) ->
-    move_to_native_register_emit(State, Value).
+move_to_native_register(#state{regs = Regs} = State, Value) ->
+    Contents = jit_regs:value_to_contents(Value, ?MAX_REG),
+    case Contents =/= unknown andalso jit_regs:find_reg_with_contents(Regs, Contents) of
+        {ok, CachedReg} ->
+            Bit = reg_bit(CachedReg),
+            case State#state.used_regs band Bit of
+                0 ->
+                    case State#state.available_regs band Bit of
+                        0 ->
+                            move_to_native_register_emit(State, Value, Contents);
+                        _ ->
+                            {
+                                State#state{
+                                    used_regs = State#state.used_regs bor Bit,
+                                    available_regs = State#state.available_regs band (bnot Bit)
+                                },
+                                CachedReg
+                            }
+                    end;
+                _ ->
+                    {State, CachedReg}
+            end;
+        _ ->
+            move_to_native_register_emit(State, Value, Contents)
+    end.
 
 move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    cp
+    cp,
+    Contents
 ) ->
     Reg = first_avail(Avail),
     Bit = reg_bit(Reg),
     I1 = jit_x86_64_asm:movq(?CP, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             used_regs = Used bor Bit,
-            available_regs = Avail band (bnot Bit)
+            available_regs = Avail band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
 move_to_native_register_emit(
-    #state{stream_module = StreamModule, stream = Stream0} = State,
-    {ptr, Reg}
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State,
+    {ptr, Reg},
+    _Contents
 ) when is_atom(Reg) ->
     I1 = jit_x86_64_asm:movq({0, Reg}, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
-    {State#state{stream = Stream1}, Reg};
+    %% After dereferencing a pointer, contents tracking for this reg is invalidated
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 move_to_native_register_emit(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    Imm
+    Imm,
+    Contents
 ) when
     is_integer(Imm)
 ->
     Reg = first_avail(Avail),
     Bit = reg_bit(Reg),
-    I1 = jit_x86_64_asm:movq(Imm, Reg),
+    I1 =
+        if
+            ?IS_SINT32_T(Imm) -> jit_x86_64_asm:movq(Imm, Reg);
+            Imm >= 0, Imm =< 16#FFFFFFFF -> jit_x86_64_asm:movl(Imm, Reg);
+            true -> jit_x86_64_asm:movabsq(Imm, Reg)
+        end,
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             used_regs = Used bor Bit,
-            available_regs = Avail band (bnot Bit)
+            available_regs = Avail band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
@@ -1911,19 +2096,23 @@ move_to_native_register_emit(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {x_reg, extra}
+    {x_reg, extra},
+    Contents
 ) ->
     Reg = first_avail(Avail),
     Bit = reg_bit(Reg),
     I1 = jit_x86_64_asm:movq(?X_REG(?MAX_REG), Reg),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             used_regs = Used bor Bit,
-            available_regs = Avail band (bnot Bit)
+            available_regs = Avail band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
@@ -1932,9 +2121,11 @@ move_to_native_register_emit(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {x_reg, X}
+    {x_reg, X},
+    Contents
 ) when
     X < ?MAX_REG
 ->
@@ -1942,11 +2133,13 @@ move_to_native_register_emit(
     Bit = reg_bit(Reg),
     I1 = jit_x86_64_asm:movq(?X_REG(X), Reg),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             used_regs = Used bor Bit,
-            available_regs = Avail band (bnot Bit)
+            available_regs = Avail band (bnot Bit),
+            regs = Regs1
         },
         Reg
     };
@@ -1955,9 +2148,11 @@ move_to_native_register_emit(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
-    {y_reg, Y}
+    {y_reg, Y},
+    Contents
 ) ->
     Reg = first_avail(Avail),
     Bit = reg_bit(Reg),
@@ -1965,22 +2160,39 @@ move_to_native_register_emit(
     I2 = jit_x86_64_asm:movq({Y * 8, Reg}, Reg),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, Contents),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot Bit),
-            used_regs = Used bor Bit
+            used_regs = Used bor Bit,
+            regs = Regs1
         },
         Reg
     }.
 
 -spec move_to_native_register(state(), integer() | x86_64_register(), x86_64_register()) -> state().
 move_to_native_register(
-    #state{stream_module = StreamModule, stream = Stream0} = State, RegSrc, RegDst
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, RegSrc, RegDst
 ) when is_atom(RegSrc) orelse is_integer(RegSrc) ->
-    I = jit_x86_64_asm:movq(RegSrc, RegDst),
+    I =
+        if
+            is_atom(RegSrc) -> jit_x86_64_asm:movq(RegSrc, RegDst);
+            ?IS_SINT32_T(RegSrc) -> jit_x86_64_asm:movq(RegSrc, RegDst);
+            RegSrc >= 0, RegSrc =< 16#FFFFFFFF -> jit_x86_64_asm:movl(RegSrc, RegDst);
+            true -> jit_x86_64_asm:movabsq(RegSrc, RegDst)
+        end,
     Stream1 = StreamModule:append(Stream0, I),
-    State#state{stream = Stream1}.
+    %% Copy the source's tracking to the destination, or set imm if integer
+    Regs1 =
+        case is_atom(RegSrc) of
+            true ->
+                SrcContents = jit_regs:get_contents(Regs0, RegSrc),
+                jit_regs:set_contents(Regs0, RegDst, SrcContents);
+            false when is_integer(RegSrc) ->
+                jit_regs:set_contents(Regs0, RegDst, {imm, RegSrc})
+        end,
+    State#state{stream = Stream1, regs = Regs1}.
 
 -spec copy_to_native_register(state(), value()) -> {state(), x86_64_register()}.
 copy_to_native_register(
@@ -1988,7 +2200,8 @@ copy_to_native_register(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     Reg
 ) when is_atom(Reg) ->
@@ -1996,11 +2209,14 @@ copy_to_native_register(
     Bit = reg_bit(SaveReg),
     I1 = jit_x86_64_asm:movq(Reg, SaveReg),
     Stream1 = StreamModule:append(Stream0, I1),
+    SrcContents = jit_regs:get_contents(Regs0, Reg),
+    Regs1 = jit_regs:set_contents(Regs0, SaveReg, SrcContents),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot Bit),
-            used_regs = Used bor Bit
+            used_regs = Used bor Bit,
+            regs = Regs1
         },
         SaveReg
     };
@@ -2009,7 +2225,8 @@ copy_to_native_register(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = Used
+        used_regs = Used,
+        regs = Regs0
     } = State,
     {ptr, Reg}
 ) when is_atom(Reg) ->
@@ -2017,11 +2234,13 @@ copy_to_native_register(
     Bit = reg_bit(SaveReg),
     I1 = jit_x86_64_asm:movq({0, Reg}, SaveReg),
     Stream1 = StreamModule:append(Stream0, I1),
+    Regs1 = jit_regs:invalidate_reg(Regs0, SaveReg),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot Bit),
-            used_regs = Used bor Bit
+            used_regs = Used bor Bit,
+            regs = Regs1
         },
         SaveReg
     };
@@ -2029,7 +2248,8 @@ copy_to_native_register(State, Reg) ->
     move_to_native_register(State, Reg).
 
 move_to_cp(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     {y_reg, Y}
 ) ->
     Reg = first_avail(Avail),
@@ -2038,10 +2258,12 @@ move_to_cp(
     I3 = jit_x86_64_asm:movq(Reg, ?CP),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 increment_sp(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State,
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State,
     Offset
 ) ->
     Reg = first_avail(Avail),
@@ -2050,7 +2272,8 @@ increment_sp(
     I3 = jit_x86_64_asm:movq(Reg, ?Y_REGS),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 set_continuation_to_label(
     #state{
@@ -2058,12 +2281,14 @@ set_continuation_to_label(
         stream = Stream0,
         available_regs = Avail,
         branches = Branches,
-        labels = Labels
+        labels = Labels,
+        regs = Regs0
     } = State,
     Label
 ) ->
     Temp = first_avail(Avail),
     Offset = StreamModule:offset(Stream0),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     case lists:keyfind(Label, 1, Labels) of
         {Label, LabelOffset} ->
             % Label is already known, emit direct leaq without relocation
@@ -2073,7 +2298,7 @@ set_continuation_to_label(
             I2 = jit_x86_64_asm:movq(Temp, ?JITSTATE_CONTINUATION),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1};
+            State#state{stream = Stream1, regs = Regs1};
         false ->
             % Label not yet known, emit placeholder and add relocation
             {RewriteLEAOffset, I1} = jit_x86_64_asm:leaq_rel32({-4, rip}, Temp),
@@ -2081,7 +2306,7 @@ set_continuation_to_label(
             I2 = jit_x86_64_asm:movq(Temp, ?JITSTATE_CONTINUATION),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1, branches = [Reloc | Branches]}
+            State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}
     end.
 
 set_continuation_to_offset(
@@ -2089,7 +2314,8 @@ set_continuation_to_offset(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        branches = Branches
+        branches = Branches,
+        regs = Regs0
     } = State
 ) ->
     Temp = first_avail(Avail),
@@ -2100,7 +2326,8 @@ set_continuation_to_offset(
     I2 = jit_x86_64_asm:movq(Temp, ?JITSTATE_CONTINUATION),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    {State#state{stream = Stream1, branches = [Reloc | Branches]}, OffsetRef}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
+    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
 
 %% @doc Implement a continuation entry point. On x86-64 this is a nop
 %% as we don't need to save any register.
@@ -2113,7 +2340,8 @@ get_module_index(
         stream_module = StreamModule,
         stream = Stream0,
         available_regs = Avail,
-        used_regs = UsedRegs0
+        used_regs = UsedRegs0,
+        regs = Regs0
     } = State
 ) ->
     Reg = first_avail(Avail),
@@ -2122,17 +2350,19 @@ get_module_index(
     I2 = jit_x86_64_asm:movl(?MODULE_INDEX(Reg), Reg),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
+    Regs1 = jit_regs:set_contents(Regs0, Reg, module_index),
     {
         State#state{
             stream = Stream1,
             available_regs = Avail band (bnot Bit),
-            used_regs = UsedRegs0 bor Bit
+            used_regs = UsedRegs0 bor Bit,
+            regs = Regs1
         },
         Reg
     }.
 
 and_(
-    #state{stream_module = StreamModule, stream = Stream0} = State,
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State,
     {free, Reg},
     SrcReg
 ) when
@@ -2140,9 +2370,10 @@ and_(
 ->
     I1 = jit_x86_64_asm:andq(SrcReg, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
-    {State#state{stream = Stream1}, Reg};
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 and_(
-    #state{stream_module = StreamModule, stream = Stream0} = State, {free, Reg}, Val
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, {free, Reg}, Val
 ) when
     ?IS_GPR(Reg)
 ->
@@ -2153,13 +2384,16 @@ and_(
             true -> jit_x86_64_asm:andq(Val, Reg)
         end,
     Stream1 = StreamModule:append(Stream0, I1),
-    {State#state{stream = Stream1}, Reg};
+    %% AND modifies the register, invalidate its contents tracking
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 and_(
     #state{
         stream_module = StreamModule,
         available_regs = Avail,
         used_regs = UR,
-        stream = Stream0
+        stream = Stream0,
+        regs = Regs0
     } = State,
     Reg,
     Val
@@ -2176,31 +2410,36 @@ and_(
         end,
     Stream1 = StreamModule:append(Stream0, I1),
     Stream2 = StreamModule:append(Stream1, I2),
+    Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State#state{
             stream = Stream2,
             available_regs = Avail band (bnot Bit),
-            used_regs = UR bor Bit
+            used_regs = UR bor Bit,
+            regs = Regs1
         },
         ResultReg
     }.
 
-or_(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, SrcReg) when
+or_(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, SrcReg) when
     is_atom(SrcReg)
 ->
     I1 = jit_x86_64_asm:orq(SrcReg, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1};
-or_(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) ->
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1};
+or_(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) ->
     I1 = jit_x86_64_asm:orq(Val, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 add(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
-        available_regs = Avail
+        available_regs = Avail,
+        regs = Regs0
     } = State,
     Reg,
     Val
@@ -2210,17 +2449,20 @@ add(
     I2 = jit_x86_64_asm:addq(TempReg, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
     Stream2 = StreamModule:append(Stream1, I2),
-    State#state{stream = Stream2};
-add(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) ->
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempReg), Reg),
+    State#state{stream = Stream2, regs = Regs1};
+add(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) ->
     I1 = jit_x86_64_asm:addq(Val, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 sub(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
-        available_regs = Avail
+        available_regs = Avail,
+        regs = Regs0
     } = State,
     Reg,
     Val
@@ -2230,11 +2472,13 @@ sub(
     I2 = jit_x86_64_asm:subq(TempReg, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
     Stream2 = StreamModule:append(Stream1, I2),
-    State#state{stream = Stream2};
-sub(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) ->
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempReg), Reg),
+    State#state{stream = Stream2, regs = Regs1};
+sub(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) ->
     I1 = jit_x86_64_asm:subq(Val, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 mul(State, _Reg, 1) ->
     State;
@@ -2250,16 +2494,36 @@ mul(State, Reg, 32) ->
     shift_left(State, Reg, 5);
 mul(State, Reg, 64) ->
     shift_left(State, Reg, 6);
-mul(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) ->
+mul(
+    #state{
+        stream_module = StreamModule, stream = Stream0, regs = Regs0, available_regs = Avail
+    } = State,
+    Reg,
+    Val
+) when Val < -16#80000000 orelse Val > 16#7FFFFFFF ->
+    TempReg = first_avail(Avail),
+    I1 = jit_x86_64_asm:movabsq(Val, TempReg),
+    I2 = jit_x86_64_asm:imulq(TempReg, Reg),
+    Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
+    Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempReg), Reg),
+    State#state{stream = Stream1, regs = Regs1};
+mul(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) ->
     I1 = jit_x86_64_asm:imulq(Val, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
-    State#state{stream = Stream1}.
+    Regs1 = jit_regs:invalidate_reg(Regs0, Reg),
+    State#state{stream = Stream1, regs = Regs1}.
+
+%% Signed integer division: quotient = DividendReg / DivisorReg
+%% Uses idivq which divides rdx:rax by operand, quotient in rax.
+%% rdx is the native interface pointer and must be saved/restored.
 
 -spec decrement_reductions_and_maybe_schedule_next(state()) -> state().
 decrement_reductions_and_maybe_schedule_next(
-    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail} = State0
+    #state{stream_module = StreamModule, stream = Stream0, available_regs = Avail, regs = Regs0} =
+        State0
 ) ->
     Temp = first_avail(Avail),
+    Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     Offset = StreamModule:offset(Stream0),
     I1 = jit_x86_64_asm:decl(?JITSTATE_REMAINING_REDUCTIONS),
     {RewriteJNZOffset, I2} = jit_x86_64_asm:jnz_rel8(0),
@@ -2267,7 +2531,7 @@ decrement_reductions_and_maybe_schedule_next(
     I4 = jit_x86_64_asm:movq(Temp, ?JITSTATE_CONTINUATION),
     Code = <<I1/binary, I2/binary, I3/binary, I4/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
-    State1 = State0#state{stream = Stream1},
+    State1 = State0#state{stream = Stream1, regs = Regs1},
     State2 = call_primitive_last(State1, ?PRIM_SCHEDULE_NEXT_CP, [ctx, jit_state]),
     % Rewrite jumps
     #state{stream = Stream2} = State2,
@@ -2280,7 +2544,10 @@ decrement_reductions_and_maybe_schedule_next(
             (NewOffset - Offset - byte_size(I1) - byte_size(I2) - byte_size(I3)):32/little
         >>
     ),
-    merge_used_regs(State2#state{stream = Stream4}, State1#state.used_regs).
+    State3 = merge_used_regs(State2#state{stream = Stream4}, State1#state.used_regs),
+    %% The schedule_next path is a tail call (dead end), so the register tracking
+    %% from the non-taken path (State1) is what matters at the continuation.
+    State3#state{regs = State1#state.regs}.
 
 -spec call_or_schedule_next(state(), non_neg_integer()) -> state().
 call_or_schedule_next(State0, Label) ->
@@ -2410,10 +2677,6 @@ reg_bit(r9) -> ?REG_BIT_R9;
 reg_bit(r10) -> ?REG_BIT_R10;
 reg_bit(r11) -> ?REG_BIT_R11.
 
-regs_to_mask([]) -> 0;
-regs_to_mask([imm | T]) -> regs_to_mask(T);
-regs_to_mask([Reg | T]) -> reg_bit(Reg) bor regs_to_mask(T).
-
 first_avail(Mask) when Mask band ?REG_BIT_RAX =/= 0 -> rax;
 first_avail(Mask) when Mask band ?REG_BIT_R11 =/= 0 -> r11;
 first_avail(Mask) when Mask band ?REG_BIT_R10 =/= 0 -> r10;
@@ -2475,9 +2738,10 @@ args_regs(Args) ->
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec add_label(state(), integer() | reference()) -> state().
-add_label(#state{stream_module = StreamModule, stream = Stream} = State, Label) ->
+add_label(#state{stream_module = StreamModule, stream = Stream, regs = Regs0} = State, Label) ->
     Offset = StreamModule:offset(Stream),
-    add_label(State, Label, Offset).
+    Regs1 = jit_regs:invalidate_all(Regs0),
+    add_label(State#state{regs = Regs1}, Label, Offset).
 
 -spec add_label(state(), integer() | reference(), integer()) -> state().
 add_label(
@@ -2510,7 +2774,8 @@ add_label(
     State#state{
         stream = Stream2,
         branches = RemainingBranches,
-        labels = [{Label, LabelOffset} | Labels]
+        labels = [{Label, LabelOffset} | Labels],
+        regs = jit_regs:invalidate_all(State#state.regs)
     };
-add_label(#state{labels = Labels} = State, Label, Offset) ->
-    State#state{labels = [{Label, Offset} | Labels]}.
+add_label(#state{labels = Labels, regs = Regs0} = State, Label, Offset) ->
+    State#state{labels = [{Label, Offset} | Labels], regs = jit_regs:invalidate_all(Regs0)}.

--- a/tests/libs/jit/CMakeLists.txt
+++ b/tests/libs/jit/CMakeLists.txt
@@ -26,6 +26,7 @@ set(ERLANG_MODULES
     tests
     jit_tests
     jit_tests_common
+    jit_regs_tests
     jit_aarch64_tests
     jit_aarch64_asm_tests
     jit_armv6m_tests

--- a/tests/libs/jit/jit_aarch64_tests.erl
+++ b/tests/libs/jit/jit_aarch64_tests.erl
@@ -20,9 +20,7 @@
 
 -module(jit_aarch64_tests).
 
--ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--endif.
 
 -include("jit/include/jit.hrl").
 -include("jit/src/term.hrl").
@@ -245,7 +243,7 @@ call_ext_only_test() ->
         "  1c:	d61f00e0 	br	x7\n"
         "  20:	f9401047 	ldr	x7, [x2, #32]\n"
         "  24:	d2800042 	mov	x2, #0x2                   	// #2\n"
-        "  28:	d2800043 	mov	x3, #0x2                   	// #2\n"
+        "  28:	aa0203e3 	mov	x3, x2\n"
         "  2c:	92800004 	mov	x4, #0xffffffffffffffff    	// #-1\n"
         "  30:	d61f00e0 	br	x7"
     >>,
@@ -284,7 +282,7 @@ call_ext_last_test() ->
         "  1c:	d61f00e0 	br	x7\n"
         "  20:	f9401047 	ldr	x7, [x2, #32]\n"
         "  24:	d2800042 	mov	x2, #0x2                   	// #2\n"
-        "  28:	d2800043 	mov	x3, #0x2                   	// #2\n"
+        "  28:	aa0203e3 	mov	x3, x2\n"
         "  2c:	d2800144 	mov	x4, #0xa                   	// #10\n"
         "  30:	d61f00e0 	br	x7"
     >>,
@@ -2238,5 +2236,18 @@ jump_to_continuation_test() ->
             "   0:	10000007 	adr	x7, 0x0\n"
             "   4:	8b0000e7 	add	x7, x7, x0\n"
             "   8:	d61f00e0 	br	x7"
+        >>,
+    jit_tests_common:assert_stream(aarch64, Dump, Stream).
+
+%% After freeing a register, cache is preserved so reload is elided
+cached_load_after_free_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    State2 = ?BACKEND:free_native_registers(State1, [r7]),
+    {State3, r7} = ?BACKEND:move_to_native_register(State2, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State3),
+    Dump =
+        <<
+            "   0:	f9401807 	ldr	x7, [x0, #48]"
         >>,
     jit_tests_common:assert_stream(aarch64, Dump, Stream).

--- a/tests/libs/jit/jit_armv6m_tests.erl
+++ b/tests/libs/jit/jit_armv6m_tests.erl
@@ -20,9 +20,7 @@
 
 -module(jit_armv6m_tests).
 
--ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--endif.
 
 -include("jit/include/jit.hrl").
 -include("jit/src/term.hrl").
@@ -1378,19 +1376,19 @@ call_only_or_schedule_next_and_label_relocation_test() ->
             "   2:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "   4:	449f      	add	pc, r3\n"
             "   6:	46c0      	nop			; (mov r8, r8)\n"
-            "   8:	0054      	lsls	r4, r2, #1\n"
+            "   8:	0055      	lsls	r5, r2, #1\n"
             "   a:	0000      	movs	r0, r0\n"
             "   c:	4b01      	ldr	r3, [pc, #4]	; (0x14)\n"
             "   e:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "  10:	449f      	add	pc, r3\n"
             "  12:	46c0      	nop			; (mov r8, r8)\n"
-            "  14:	0010      	movs	r0, r2\n"
+            "  14:	0011      	movs	r1, r2\n"
             "  16:	0000      	movs	r0, r0\n"
             "  18:	4b01      	ldr	r3, [pc, #4]	; (0x20)\n"
             "  1a:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "  1c:	449f      	add	pc, r3\n"
             "  1e:	46c0      	nop			; (mov r8, r8)\n"
-            "  20:	0030      	movs	r0, r6\n"
+            "  20:	0031      	movs	r1, r6\n"
             "  22:	0000      	movs	r0, r0\n"
             "  24:	9e00      	ldr	r6, [sp, #0]\n"
             "  26:	68b7      	ldr	r7, [r6, #8]\n"
@@ -1450,19 +1448,19 @@ call_only_or_schedule_next_and_label_relocation_unaligned_test() ->
             "   4:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "   6:	449f      	add	pc, r3\n"
             "   8:	46c0      	nop			; (mov r8, r8)\n"
-            "   a:	0056      	lsls	r6, r2, #1\n"
+            "   a:	0057      	lsls	r7, r2, #1\n"
             "   c:	0000      	movs	r0, r0\n"
             "   e:	4b01      	ldr	r3, [pc, #4]	; (0x14)\n"
             "  10:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "  12:	449f      	add	pc, r3\n"
             "  14:	46c0      	nop			; (mov r8, r8)\n"
-            "  16:	0012      	movs	r2, r2\n"
+            "  16:	0013      	movs	r3, r2\n"
             "  18:	0000      	movs	r0, r0\n"
             "  1a:	4b01      	ldr	r3, [pc, #4]	; (0x20)\n"
             "  1c:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "  1e:	449f      	add	pc, r3\n"
             "  20:	46c0      	nop			; (mov r8, r8)\n"
-            "  22:	0032      	movs	r2, r6\n"
+            "  22:	0033      	movs	r3, r6\n"
             "  24:	0000      	movs	r0, r0\n"
             "  26:	46c0      	nop			; (mov r8, r8)\n"
             "  28:	9e00      	ldr	r6, [sp, #0]\n"
@@ -1853,7 +1851,7 @@ is_boolean_test() ->
         "   e:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  10:	449f      	add	pc, r3\n"
         "  12:	46c0      	nop\n"
-        "  14:	00ec      	lsls	r4, r5, #3\n"
+        "  14:	00ed      	lsls	r5, r5, #3\n"
         "  16:	0000      	movs	r0, r0\n"
         "  18:	6987      	ldr	r7, [r0, #24]\n"
         "  1a:	2f4b      	cmp	r7, #75\n"
@@ -1894,7 +1892,7 @@ is_boolean_far_test() ->
         "   e:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  10:	449f      	add	pc, r3\n"
         "  12:	46c0      	nop\n"
-        "  14:	0fec      	lsrs	r4, r5, #31\n"
+        "  14:	0fed      	lsrs	r5, r5, #31\n"
         "  16:	0000      	movs	r0, r0\n"
         "  18:	6987      	ldr	r7, [r0, #24]\n"
         "  1a:	2f4b      	cmp	r7, #75\n"
@@ -1971,7 +1969,7 @@ is_boolean_far_known_test() ->
         "   e:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  10:	449f      	add	pc, r3\n"
         "  12:	46c0      	nop\n"
-        "  14:	0fec      	lsrs	r4, r5, #31\n"
+        "  14:	0fed      	lsrs	r5, r5, #31\n"
         "  16:	0000      	movs	r0, r0\n"
         "  18:	6987      	ldr	r7, [r0, #24]\n"
         "  1a:	2f4b      	cmp	r7, #75\n"
@@ -2019,7 +2017,7 @@ is_boolean_far_known_unaligned_test() ->
         "  10:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  12:	449f      	add	pc, r3\n"
         "  14:	46c0      	nop\n"
-        "  16:	0fea      	lsrs	r2, r5, #31\n"
+        "  16:	0feb      	lsrs	r3, r5, #31\n"
         "  18:	0000      	movs	r0, r0\n"
         "  1a:	6987      	ldr	r7, [r0, #24]\n"
         "  1c:	2f4b      	cmp	r7, #75\n"
@@ -2124,19 +2122,19 @@ wait_test() ->
         "   2:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "   4:	449f      	add	pc, r3\n"
         "   6:	46c0      	nop			; (mov r8, r8)\n"
-        "   8:	0034      	movs	r4, r6\n"
+        "   8:	0035      	movs	r5, r6\n"
         "   a:	0000      	movs	r0, r0\n"
         "   c:	4b01      	ldr	r3, [pc, #4]	; (0x14)\n"
         "   e:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  10:	449f      	add	pc, r3\n"
         "  12:	46c0      	nop			; (mov r8, r8)\n"
-        "  14:	0010      	movs	r0, r2\n"
+        "  14:	0011      	movs	r1, r2\n"
         "  16:	0000      	movs	r0, r0\n"
         "  18:	4b01      	ldr	r3, [pc, #4]	; (0x20)\n"
         "  1a:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  1c:	449f      	add	pc, r3\n"
         "  1e:	46c0      	nop			; (mov r8, r8)\n"
-        "  20:	001c      	movs	r4, r3\n"
+        "  20:	001d      	movs	r5, r3\n"
         "  22:	0000      	movs	r0, r0\n"
         "  24:	a700      	add	r7, pc, #0	; (adr r7, 0x28)\n"
         "  26:	260f      	movs	r6, #15\n"
@@ -2185,13 +2183,13 @@ return_labels_and_lines_test() ->
         "   e:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  10:	449f      	add	pc, r3\n"
         "  12:	46c0      	nop\n"
-        "  14:	fffc      	.short	0xfffc\n"
+        "  14:	fffd      	.short	0xfffd\n"
         "  16:	ffff      	.short	0xffff\n"
         "  18:	4b01      	ldr	r3, [pc, #4]\n"
         "  1a:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  1c:	449f      	add	pc, r3\n"
         "  1e:	46c0      	nop\n"
-        "  20:	0000      	movs	r0, r0\n"
+        "  20:	0001      	movs	r1, r0\n"
         "  22:	0000      	movs	r0, r0\n"
         "  24:	a000      	add	r0, pc, #0\n"
         "  26:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}\n"
@@ -2244,13 +2242,13 @@ return_labels_and_lines_unaligned_test() ->
         "  10:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  12:	449f      	add	pc, r3\n"
         "  14:	46c0      	nop\n"
-        "  16:	fffa      	.short	0xfffa\n"
+        "  16:	fffb      	.short	0xfffb\n"
         "  18:	ffff      	.short	0xffff\n"
         "  1a:	4b01      	ldr	r3, [pc, #4]\n"
         "  1c:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
         "  1e:	449f      	add	pc, r3\n"
         "  20:	46c0      	nop\n"
-        "  22:	fffe      	.short	0xfffe\n"
+        "  22:	ffff      	.short	0xffff\n"
         "  24:	ffff      	.short	0xffff\n"
         "  26:	a001      	add	r0, pc, #4\n"
         "  28:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}\n"
@@ -3935,25 +3933,25 @@ add_beam_test() ->
             "   2:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "   4:	449f      	add	pc, r3\n"
             "   6:	46c0      	nop			; (mov r8, r8)\n"
-            "   8:	00d8      	lsls	r0, r3, #3\n"
+            "   8:	00d9      	lsls	r1, r3, #3\n"
             "   a:	0000      	movs	r0, r0\n"
             "   c:	4b01      	ldr	r3, [pc, #4]	; (0x14)\n"
             "   e:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "  10:	449f      	add	pc, r3\n"
             "  12:	46c0      	nop			; (mov r8, r8)\n"
-            "  14:	001c      	movs	r4, r3\n"
+            "  14:	001d      	movs	r5, r3\n"
             "  16:	0000      	movs	r0, r0\n"
             "  18:	4b01      	ldr	r3, [pc, #4]	; (0x20)\n"
             "  1a:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "  1c:	449f      	add	pc, r3\n"
             "  1e:	46c0      	nop			; (mov r8, r8)\n"
-            "  20:	0044      	lsls	r4, r0, #1\n"
+            "  20:	0045      	lsls	r5, r0, #1\n"
             "  22:	0000      	movs	r0, r0\n"
             "  24:	4b01      	ldr	r3, [pc, #4]	; (0x2c)\n"
             "  26:	b5f2      	push	{r1, r4, r5, r6, r7, lr}\n"
             "  28:	449f      	add	pc, r3\n"
             "  2a:	46c0      	nop			; (mov r8, r8)\n"
-            "  2c:	00a8      	lsls	r0, r5, #2\n"
+            "  2c:	00a9      	lsls	r1, r5, #2\n"
             "  2e:	0000      	movs	r0, r0\n"
             % label 1
             % {move,{integer,9},{x,1}}.
@@ -4061,5 +4059,176 @@ add_beam_test() ->
             "  e4:	9705      	str	r7, [sp, #20]\n"
             "  e6:	46b6      	mov	lr, r6\n"
             "  e8:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}\n"
+        >>,
+    jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% After freeing a register, cache is preserved so reload is elided
+cached_load_after_free_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    State2 = ?BACKEND:free_native_registers(State1, [r7]),
+    {State3, r7} = ?BACKEND:move_to_native_register(State2, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State3),
+    Dump =
+        <<
+            "   0:	6987      	ldr	r7, [r0, #24]"
+        >>,
+    jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% Verify that and_ with a negative immediate invalidates the Temp register
+%% cache entry. Before the fix, the Temp register (used to hold the bics mask)
+%% kept a stale cache entry, causing a subsequent move_to_native_register for
+%% the same VM register to skip the load.
+and_negative_imm_invalidates_temp_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, r6} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    State3 = ?BACKEND:free_native_registers(State2, [r6]),
+    % and_ with -4 picks r6 as Temp (first available), loads 3 into it, bics
+    {State4, r7} = ?BACKEND:and_(State3, {free, r7}, -4),
+    % This must emit a ldr to reload x_reg 1, not use stale cache
+    {State5, r6} = ?BACKEND:move_to_native_register(State4, {x_reg, 1}),
+    Stream = ?BACKEND:stream(State5),
+    Dump =
+        <<
+            "   0:	6987      	ldr	r7, [r0, #24]\n"
+            "   2:	69c6      	ldr	r6, [r0, #28]\n"
+            "   4:	2603      	movs	r6, #3\n"
+            "   6:	43b7      	bics	r7, r6\n"
+            "   8:	69c6      	ldr	r6, [r0, #28]"
+        >>,
+    jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% Same test but with a positive immediate, exercising the ands path.
+and_positive_imm_invalidates_temp_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, r6} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    State3 = ?BACKEND:free_native_registers(State2, [r6]),
+    {State4, r7} = ?BACKEND:and_(State3, {free, r7}, 16#3F),
+    {State5, r6} = ?BACKEND:move_to_native_register(State4, {x_reg, 1}),
+    Stream = ?BACKEND:stream(State5),
+    Dump =
+        <<
+            "   0:	6987      	ldr	r7, [r0, #24]\n"
+            "   2:	69c6      	ldr	r6, [r0, #28]\n"
+            "   4:	263f      	movs	r6, #63	; 0x3f\n"
+            "   6:	4037      	ands	r7, r6\n"
+            "   8:	69c6      	ldr	r6, [r0, #28]"
+        >>,
+    jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% Verify if_block_cond invalidates register cache for destructive {free, Reg}
+%% operations. The {{free, Reg}, '&', 0xF, '!=', 0xF} condition uses mvns+lsls
+%% which clobbers Reg, but before the fix the cache was not invalidated.
+if_block_cond_free_reg_invalidates_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, r6} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    State3 = ?BACKEND:if_block(
+        State2,
+        {{free, r7}, '&', 16#F, '!=', 16#F},
+        fun(BSt0) -> ?BACKEND:add(BSt0, r6, 2) end
+    ),
+    {State4, r7} = ?BACKEND:move_to_native_register(State3, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State4),
+    Dump =
+        <<
+            "   0:	6987      	ldr	r7, [r0, #24]\n"
+            "   2:	69c6      	ldr	r6, [r0, #28]\n"
+            "   4:	43ff      	mvns	r7, r7\n"
+            "   6:	073f      	lsls	r7, r7, #28\n"
+            "   8:	d000      	beq.n	0xc\n"
+            "   a:	3602      	adds	r6, #2\n"
+            "   c:	6987      	ldr	r7, [r0, #24]"
+        >>,
+    jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% Verify jump_to_label invalidates all register caching. After an unconditional
+%% jump, register contents are unknown. Before the fix, stale cache entries
+%% survived and caused skipped loads via jit_regs:merge in if_block.
+jump_to_label_invalidates_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    State2 = ?BACKEND:free_native_registers(State1, [r7]),
+    State3 = ?BACKEND:jump_to_label(State2, 42),
+    {State4, r7} = ?BACKEND:move_to_native_register(State3, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State4),
+    Dump =
+        <<
+            "   0:	6987      	ldr	r7, [r0, #24]\n"
+            "   2:	ffff ffff 			; <UNDEFINED> instruction: 0xffffffff\n"
+            "   6:	ffff ffff 			; <UNDEFINED> instruction: 0xffffffff\n"
+            "   a:	ffff 6987 	vtbl.8	d22, {d31-<overflow reg d32}, d7"
+        >>,
+    jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% Verify move_array_element to {x_reg, X} invalidates the vm_loc cache entry.
+%% Before the fix, a register caching {x_reg, X} would still be considered
+%% valid after move_array_element overwrote {x_reg, X} in memory.
+move_array_element_x_reg_invalidates_vm_loc_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 5}),
+    {State2, r6} = ?BACKEND:move_to_native_register(State1, {x_reg, 0}),
+    S3 = ?BACKEND:move_array_element(State2, r6, 0, {x_reg, 5}),
+    {S4, _} = ?BACKEND:move_to_native_register(S3, {x_reg, 5}),
+    Stream = ?BACKEND:stream(S4),
+    Dump =
+        <<
+            "   0:	6ac7      	ldr	r7, [r0, #44]	; 0x2c\n"
+            "   2:	6986      	ldr	r6, [r0, #24]\n"
+            "   4:	6835      	ldr	r5, [r6, #0]\n"
+            "   6:	62c5      	str	r5, [r0, #44]	; 0x2c\n"
+            "   8:	6ac5      	ldr	r5, [r0, #44]	; 0x2c"
+        >>,
+    jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% Verify ldr_y_reg invalidates its hidden temp register's cache entry.
+%% ldr_y_reg uses first_avail(AvailT) as a scratch register to load the
+%% Y_REGS pointer, but before the fix this temp was not invalidated.
+ldr_y_reg_invalidates_hidden_temp_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, r6} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    {State3, r5} = ?BACKEND:move_to_native_register(State2, {x_reg, 2}),
+    State4 = ?BACKEND:free_native_registers(State3, [r6, r5]),
+    % y_reg load: Reg=r6 (first avail), hidden temp=r5 (first avail of remaining)
+    {State5, r6} = ?BACKEND:move_to_native_register(State4, {y_reg, 0}),
+    % r5 was hidden temp - if not invalidated, cache still says r5={x_reg,2}
+    {State6, r5} = ?BACKEND:move_to_native_register(State5, {x_reg, 2}),
+    Stream = ?BACKEND:stream(State6),
+    Dump =
+        <<
+            "   0:	6987      	ldr	r7, [r0, #24]\n"
+            "   2:	69c6      	ldr	r6, [r0, #28]\n"
+            "   4:	6a05      	ldr	r5, [r0, #32]\n"
+            "   6:	6945      	ldr	r5, [r0, #20]\n"
+            "   8:	682e      	ldr	r6, [r5, #0]\n"
+            "   a:	6a05      	ldr	r5, [r0, #32]"
+        >>,
+    jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% Verify move_to_native_register for y_reg does not crash with function_clause
+%% when all other registers are exhausted (AvailT=0). Before the fix,
+%% first_avail(0) was called in the invalidation code.
+y_reg_load_last_available_register_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, r7} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, r6} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    {State3, r5} = ?BACKEND:move_to_native_register(State2, {x_reg, 2}),
+    {State4, r4} = ?BACKEND:move_to_native_register(State3, {x_reg, 3}),
+    {State5, r3} = ?BACKEND:move_to_native_register(State4, {x_reg, 4}),
+    % r1 is the last available register
+    {State6, r1} = ?BACKEND:move_to_native_register(State5, {y_reg, 0}),
+    Stream = ?BACKEND:stream(State6),
+    Dump =
+        <<
+            "   0:	6987      	ldr	r7, [r0, #24]\n"
+            "   2:	69c6      	ldr	r6, [r0, #28]\n"
+            "   4:	6a05      	ldr	r5, [r0, #32]\n"
+            "   6:	6a44      	ldr	r4, [r0, #36]	; 0x24\n"
+            "   8:	6a83      	ldr	r3, [r0, #40]	; 0x28\n"
+            "   a:	6941      	ldr	r1, [r0, #20]\n"
+            "   c:	6809      	ldr	r1, [r1, #0]"
         >>,
     jit_tests_common:assert_stream(arm, Dump, Stream).

--- a/tests/libs/jit/jit_regs_tests.erl
+++ b/tests/libs/jit/jit_regs_tests.erl
@@ -1,0 +1,138 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(jit_regs_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+new_test() ->
+    Regs = jit_regs:new(),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs, rax)),
+    ?assertEqual(none, jit_regs:find_reg_with_contents(Regs, {x_reg, 0})),
+    ?assertEqual([], jit_regs:stack_contents(Regs)).
+
+set_and_get_contents_test() ->
+    Regs0 = jit_regs:new(),
+    Regs1 = jit_regs:set_contents(Regs0, rax, {x_reg, 0}),
+    ?assertEqual({x_reg, 0}, jit_regs:get_contents(Regs1, rax)),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs1, r11)),
+    Regs2 = jit_regs:set_contents(Regs1, r11, {imm, 42}),
+    ?assertEqual({x_reg, 0}, jit_regs:get_contents(Regs2, rax)),
+    ?assertEqual({imm, 42}, jit_regs:get_contents(Regs2, r11)).
+
+find_reg_with_contents_test() ->
+    Regs0 = jit_regs:new(),
+    Regs1 = jit_regs:set_contents(Regs0, rax, {x_reg, 0}),
+    Regs2 = jit_regs:set_contents(Regs1, r11, {y_reg, 1}),
+    ?assertEqual({ok, rax}, jit_regs:find_reg_with_contents(Regs2, {x_reg, 0})),
+    ?assertEqual({ok, r11}, jit_regs:find_reg_with_contents(Regs2, {y_reg, 1})),
+    ?assertEqual(none, jit_regs:find_reg_with_contents(Regs2, {x_reg, 5})).
+
+invalidate_reg_test() ->
+    Regs0 = jit_regs:new(),
+    Regs1 = jit_regs:set_contents(Regs0, rax, {x_reg, 0}),
+    Regs2 = jit_regs:set_contents(Regs1, r11, {y_reg, 1}),
+    Regs3 = jit_regs:invalidate_reg(Regs2, rax),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs3, rax)),
+    ?assertEqual({y_reg, 1}, jit_regs:get_contents(Regs3, r11)),
+    ?assertEqual(none, jit_regs:find_reg_with_contents(Regs3, {x_reg, 0})).
+
+invalidate_all_test() ->
+    Regs0 = jit_regs:new(),
+    Regs1 = jit_regs:set_contents(Regs0, rax, {x_reg, 0}),
+    Regs2 = jit_regs:set_contents(Regs1, r11, {y_reg, 1}),
+    Regs3 = jit_regs:invalidate_all(Regs2),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs3, rax)),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs3, r11)).
+
+invalidate_vm_loc_test() ->
+    Regs0 = jit_regs:new(),
+    Regs1 = jit_regs:set_contents(Regs0, rax, {x_reg, 0}),
+    Regs2 = jit_regs:set_contents(Regs1, r11, {x_reg, 0}),
+    Regs3 = jit_regs:set_contents(Regs2, r10, {y_reg, 1}),
+    %% Invalidate all registers tracking x_reg 0
+    Regs4 = jit_regs:invalidate_vm_loc(Regs3, {x_reg, 0}),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs4, rax)),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs4, r11)),
+    %% y_reg 1 should be unaffected
+    ?assertEqual({y_reg, 1}, jit_regs:get_contents(Regs4, r10)).
+
+merge_test() ->
+    Regs0 = jit_regs:new(),
+    %% Path A: rax = x_reg 0, r11 = x_reg 1
+    RegsA = jit_regs:set_contents(
+        jit_regs:set_contents(Regs0, rax, {x_reg, 0}),
+        r11,
+        {x_reg, 1}
+    ),
+    %% Path B: rax = x_reg 0, r11 = x_reg 2
+    RegsB = jit_regs:set_contents(
+        jit_regs:set_contents(Regs0, rax, {x_reg, 0}),
+        r11,
+        {x_reg, 2}
+    ),
+    Merged = jit_regs:merge(RegsA, RegsB),
+    %% rax = x_reg 0 in both paths: kept
+    ?assertEqual({x_reg, 0}, jit_regs:get_contents(Merged, rax)),
+    %% r11 differs: invalidated
+    ?assertEqual(unknown, jit_regs:get_contents(Merged, r11)).
+
+stack_test() ->
+    Regs0 = jit_regs:new(),
+    Regs1 = jit_regs:stack_push(Regs0, rdi),
+    Regs2 = jit_regs:stack_push(Regs1, rsi),
+    ?assertEqual([rsi, rdi], jit_regs:stack_contents(Regs2)),
+    {rsi, Regs3} = jit_regs:stack_pop(Regs2),
+    {rdi, Regs4} = jit_regs:stack_pop(Regs3),
+    ?assertEqual([], jit_regs:stack_contents(Regs4)),
+    Regs5 = jit_regs:stack_clear(Regs2),
+    ?assertEqual([], jit_regs:stack_contents(Regs5)).
+
+invalidate_volatile_test() ->
+    Regs0 = jit_regs:new(),
+    Regs1 = jit_regs:set_contents(Regs0, rax, {x_reg, 0}),
+    Regs2 = jit_regs:set_contents(Regs1, rdi, cp),
+    Regs3 = jit_regs:set_contents(Regs2, r11, {imm, 42}),
+    %% Only rdi is preserved
+    Regs4 = jit_regs:invalidate_volatile(Regs3, [rdi]),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs4, rax)),
+    ?assertEqual(cp, jit_regs:get_contents(Regs4, rdi)),
+    ?assertEqual(unknown, jit_regs:get_contents(Regs4, r11)).
+
+value_to_contents_test() ->
+    MaxReg = 16,
+    ?assertEqual(cp, jit_regs:value_to_contents(cp, MaxReg)),
+    ?assertEqual({x_reg, 0}, jit_regs:value_to_contents({x_reg, 0}, MaxReg)),
+    ?assertEqual({x_reg, 5}, jit_regs:value_to_contents({x_reg, 5}, MaxReg)),
+    ?assertEqual({x_reg, MaxReg}, jit_regs:value_to_contents({x_reg, extra}, MaxReg)),
+    ?assertEqual({y_reg, 3}, jit_regs:value_to_contents({y_reg, 3}, MaxReg)),
+    ?assertEqual({imm, 42}, jit_regs:value_to_contents(42, MaxReg)),
+    ?assertEqual({imm, 0}, jit_regs:value_to_contents(0, MaxReg)),
+    ?assertEqual(unknown, jit_regs:value_to_contents({ptr, rax}, MaxReg)),
+    ?assertEqual(unknown, jit_regs:value_to_contents({fp_reg, 0}, MaxReg)).
+
+vm_dest_to_contents_test() ->
+    MaxReg = 16,
+    ?assertEqual({x_reg, 0}, jit_regs:vm_dest_to_contents({x_reg, 0}, MaxReg)),
+    ?assertEqual({x_reg, 15}, jit_regs:vm_dest_to_contents({x_reg, 15}, MaxReg)),
+    ?assertEqual({x_reg, MaxReg}, jit_regs:vm_dest_to_contents({x_reg, extra}, MaxReg)),
+    ?assertEqual({y_reg, 5}, jit_regs:vm_dest_to_contents({y_reg, 5}, MaxReg)),
+    ?assertEqual(unknown, jit_regs:vm_dest_to_contents({fp_reg, 0}, MaxReg)),
+    ?assertEqual(unknown, jit_regs:vm_dest_to_contents({ptr, rax}, MaxReg)).

--- a/tests/libs/jit/jit_riscv32_tests.erl
+++ b/tests/libs/jit/jit_riscv32_tests.erl
@@ -20,9 +20,7 @@
 
 -module(jit_riscv32_tests).
 
--ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--endif.
 
 -include("jit/include/jit.hrl").
 -include("jit/src/term.hrl").
@@ -134,30 +132,28 @@ call_primitive_6_args_test() ->
     Stream = ?BACKEND:stream(State4),
     Dump =
         <<
-            "   0:  01852f83            lw  t6,24(a0)\n"
-            "   4:  4f0d                li  t5,3\n"
-            "   6:  ffff4f13            not t5,t5\n"
-            "   a:  01efffb3            and t6,t6,t5\n"
-            "   e:  01c52f03            lw  t5,28(a0)\n"
-            "  12:  0b800e93            li  t4,184\n"
-            "  16:  9eb2                add t4,t4,a2\n"
-            "  18:  000eae83            lw  t4,0(t4)\n"
-            "  1c:  1141                addi    sp,sp,-16\n"
-            "  1e:  c006                sw  ra,0(sp)\n"
-            "  20:  c22a                sw  a0,4(sp)\n"
-            "  22:  c42e                sw  a1,8(sp)\n"
-            "  24:  c632                sw  a2,12(sp)\n"
-            "  26:  867e                mv  a2,t6\n"
-            "  28:  04000693            li  a3,64\n"
-            "  2c:  4721                li  a4,8\n"
-            "  2e:  87fa                mv  a5,t5\n"
-            "  30:  9e82                jalr    t4\n"
-            "  32:  8eaa                mv  t4,a0\n"
-            "  34:  4082                lw  ra,0(sp)\n"
-            "  36:  4512                lw  a0,4(sp)\n"
-            "  38:  45a2                lw  a1,8(sp)\n"
-            "  3a:  4632                lw  a2,12(sp)\n"
-            "  3c:  0141                addi    sp,sp,16"
+            "   0:	01852f83          	lw	t6,24(a0)\n"
+            "   4:  ffcfff93            andi    t6,t6,-4\n"
+            "   8:  01c52f03          	lw	t5,28(a0)\n"
+            "   c:  0b800e93            li  t4,184\n"
+            "  10:  9eb2                add t4,t4,a2\n"
+            "  12:  000eae83            lw  t4,0(t4)\n"
+            "  16:  1141                addi    sp,sp,-16\n"
+            "  18:  c006                sw  ra,0(sp)\n"
+            "  1a:  c22a                sw  a0,4(sp)\n"
+            "  1c:  c42e                sw  a1,8(sp)\n"
+            "  1e:  c632                sw  a2,12(sp)\n"
+            "  20:  867e                mv  a2,t6\n"
+            "  22:  04000693            li  a3,64\n"
+            "  26:  4721                li  a4,8\n"
+            "  28:  87fa                mv  a5,t5\n"
+            "  2a:  9e82                jalr    t4\n"
+            "  2c:  8eaa                mv  t4,a0\n"
+            "  2e:  4082                lw  ra,0(sp)\n"
+            "  30:  4512                lw  a0,4(sp)\n"
+            "  32:  45a2                lw  a1,8(sp)\n"
+            "  34:  4632                lw  a2,12(sp)\n"
+            "  36:  0141                addi    sp,sp,16"
         >>,
     jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
@@ -1003,11 +999,10 @@ if_block_test_() ->
                         "   0:  01852f83            lw  t6,24(a0)\n"
                         "   4:  01c52f03            lw  t5,28(a0)\n"
                         "   8:  8efe                    mv  t4,t6\n"
-                        "   a:  03f00e13            li  t3,63\n"
-                        "   e:  01cefeb3            and t4,t4,t3\n"
-                        "  12:  4e21                    li  t3,8\n"
-                        "  14:  01ce8363            beq t4,t3,0x1a\n"
-                        "  18:  0f09                    addi    t5,t5,2"
+                        "   a:  03fefe93            andi    t4,t4,63\n"
+                        "   e:  4e21                    li  t3,8\n"
+                        "  10:  01ce8363            beq t4,t3,0x16\n"
+                        "  14:  0f09                    addi    t5,t5,2"
                     >>,
                     jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegA, RegB], ?BACKEND:used_regs(State1))
@@ -1047,12 +1042,11 @@ if_block_test_() ->
                     Stream = ?BACKEND:stream(State1),
                     Dump = <<
                         "      0:   01852f83            lw  t6,24(a0)\n"
-                        "      4:   01c52f03            lw  t5,28(a0)\n"
-                        "      8:   03f00e93            li  t4,63\n"
-                        "      c:   01dfffb3            and t6,t6,t4\n"
-                        "      10:  4ea1                    li  t4,8\n"
-                        "      12:  01df8363            beq t6,t4,0x18\n"
-                        "      16:  0f09                    addi    t5,t5,2"
+                        "      4:   01c52f03          	lw	t5,28(a0)\n"
+                        "      8:   03ffff93            andi    t6,t6,63\n"
+                        "      c:   4ea1                    li  t4,8\n"
+                        "      e:   01df8363            beq t6,t4,0x14\n"
+                        "      12:  0f09                    addi    t5,t5,2"
                     >>,
                     jit_tests_common:assert_stream(riscv32, Dump, Stream),
                     ?assertEqual([RegB], ?BACKEND:used_regs(State1))
@@ -1430,16 +1424,14 @@ get_list_test() ->
     Stream = ?BACKEND:stream(State5),
     Dump =
         <<
-            "0: 01852f83            lw  t6,24(a0)\n"
-            "4: 4f0d                    li  t5,3\n"
-            "6: ffff4f13            not t5,t5\n"
-            "a: 01efffb3            and t6,t6,t5\n"
-            "e: 004fae83            lw  t4,4(t6)\n"
-            "12:    01452f03            lw  t5,20(a0)\n"
-            "16:    01df2223            sw  t4,4(t5)\n"
-            "1a:    000fae83            lw  t4,0(t6)\n"
-            "1e:    01452f03            lw  t5,20(a0)\n"
-            "22:    01df2023            sw  t4,0(t5)"
+            "0:	01852f83          	lw	t6,24(a0)\n"
+            "4: ffcfff93            andi    t6,t6,-4\n"
+            "8: 004fae83            lw  t4,4(t6)\n"
+            "c:	01452f03          	lw	t5,20(a0)\n"
+            "10:    01df2223            sw  t4,4(t5)\n"
+            "14:    000fae83            lw  t4,0(t6)\n"
+            "18:	01452f03          	lw	t5,20(a0)\n"
+            "1c:    01df2023            sw  t4,0(t5)"
         >>,
     jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
@@ -1483,26 +1475,22 @@ is_integer_test() ->
             "  10:  01852f83            lw  t6,24(a0)\n"
             "  14:  ffffcf13            not t5,t6\n"
             "  18:  0f72                slli    t5,t5,0x1c\n"
-            "  1a:  020f0f63            beqz    t5,0x58\n"
+            "  1a:  020f0963            beqz    t5,0x4c\n"
             "  1e:  8f7e                mv  t5,t6\n"
-            "  20:  4e8d                li  t4,3\n"
-            "  22:  01df7f33            and t5,t5,t4\n"
-            "  26:  4e89                li  t4,2\n"
-            "  28:  01df0663            beq t5,t4,0x34\n"
-            "  2c:  a8d1                j   0x100\n"
-            "  2e:  0001                nop\n"
-            "  30:  00000013            nop\n"
-            "  34:  4f0d                li  t5,3\n"
-            "  36:  ffff4f13            not t5,t5\n"
-            "  3a:  01efffb3            and t6,t6,t5\n"
-            "  3e:  000faf83            lw  t6,0(t6)\n"
-            "  42:  03f00f13            li  t5,63\n"
-            "  46:  01efffb3            and t6,t6,t5\n"
-            "  4a:  4f21                li  t5,8\n"
-            "  4c:  01ef8663            beq t6,t5,0x58\n"
-            "  50:  a845                j   0x100\n"
-            "  52:  0001                nop\n"
-            "  54:  00000013            nop"
+            "  20:  003f7f13            andi    t5,t5,3\n"
+            "  24:  4e89                li  t4,2\n"
+            "  26:  01df0663            beq t5,t4,0x32\n"
+            "  2a:  a8d9                j   0x100\n"
+            "  2c:  0001                nop\n"
+            "  2e:  00000013            nop\n"
+            "  32:  ffcfff93            andi    t6,t6,-4\n"
+            "  36:  000faf83            lw  t6,0(t6)\n"
+            "  3a:  03ffff93            andi    t6,t6,63\n"
+            "  3e:  4f21                li  t5,8\n"
+            "  40:  01ef8663            beq t6,t5,0x4c\n"
+            "  44:  a875                j   0x100\n"
+            "  46:  0001                nop\n"
+            "  48:  00000013            nop"
         >>,
     jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
@@ -1552,31 +1540,26 @@ is_number_test() ->
             "  10:  01852f83            lw  t6,24(a0)\n"
             "  14:  ffffcf13            not t5,t6\n"
             "  18:  0f72                slli    t5,t5,0x1c\n"
-            "  1a:  040f0763            beqz    t5,0x68\n"
+            "  1a:  020f0f63            beqz    t5,0x58\n"
             "  1e:  8f7e                mv  t5,t6\n"
-            "  20:  4e8d                li  t4,3\n"
-            "  22:  01df7f33            and t5,t5,t4\n"
-            "  26:  4e89                li  t4,2\n"
-            "  28:  01df0663            beq t5,t4,0x34\n"
-            "  2c:  a8d1                j   0x100\n"
-            "  2e:  0001                nop\n"
-            "  30:  00000013            nop\n"
-            "  34:  4f0d                li  t5,3\n"
-            "  36:  ffff4f13            not t5,t5\n"
-            "  3a:  01efffb3            and t6,t6,t5\n"
-            "  3e:  000faf83            lw  t6,0(t6)\n"
-            "  42:  8f7e                mv  t5,t6\n"
-            "  44:  03f00e93            li  t4,63\n"
-            "  48:  01df7f33            and t5,t5,t4\n"
-            "  4c:  4ea1                li  t4,8\n"
-            "  4e:  01df0d63            beq t5,t4,0x68\n"
-            "  52:  03f00f13            li  t5,63\n"
-            "  56:  01efffb3            and t6,t6,t5\n"
-            "  5a:  4f61                li  t5,24\n"
-            "  5c:  01ef8663            beq t6,t5,0x68\n"
-            "  60:  a045                j   0x100\n"
-            "  62:  0001                nop\n"
-            "  64:  00000013            nop"
+            "  20:  003f7f13            andi    t5,t5,3\n"
+            "  24:  4e89                li  t4,2\n"
+            "  26:  01df0663            beq t5,t4,0x32\n"
+            "  2a:  a8d9                j   0x100\n"
+            "  2c:  0001                nop\n"
+            "  2e:  00000013            nop\n"
+            "  32:  ffcfff93            andi    t6,t6,-4\n"
+            "  36:  000faf83            lw  t6,0(t6)\n"
+            "  3a:  8f7e                mv  t5,t6\n"
+            "  3c:  03ff7f13            andi    t5,t5,63\n"
+            "  40:  4ea1                li  t4,8\n"
+            "  42:  01df0b63            beq t5,t4,0x58\n"
+            "  46:  03ffff93            andi    t6,t6,63\n"
+            "  4a:  4f61                li  t5,24\n"
+            "  4c:  01ef8663            beq t6,t5,0x58\n"
+            "  50:  a845                j   0x100\n"
+            "  52:  0001                nop\n"
+            "  54:  00000013            nop"
         >>,
     jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
@@ -2047,42 +2030,38 @@ call_fun_test() ->
             "  20:  01852f83            lw  t6,24(a0)\n"
             "  24:  8f7e                    mv  t5,t6\n"
             "  26:  8efa                    mv  t4,t5\n"
-            "  28:  4e0d                    li  t3,3\n"
-            "  2a:  01cefeb3            and t4,t4,t3\n"
-            "  2e:  4e09                    li  t3,2\n"
-            "  30:  01ce8a63            beq t4,t3,0x44\n"
-            "  34:  04c62f83            lw  t6,76(a2)\n"
-            "  38:  03800613            li  a2,56\n"
-            "  3c:  18b00693            li  a3,395\n"
-            "  40:  877a                    mv  a4,t5\n"
-            "  42:  8f82                    jr  t6\n"
-            "  44:  4e8d                    li  t4,3\n"
-            "  46:  fffece93            not t4,t4\n"
-            "  4a:  01df7f33            and t5,t5,t4\n"
-            "  4e:  000f2f03            lw  t5,0(t5)\n"
-            "  52:  8efa                    mv  t4,t5\n"
-            "  54:  03f00e13            li  t3,63\n"
-            "  58:  01cefeb3            and t4,t4,t3\n"
-            "  5c:  4e51                    li  t3,20\n"
-            "  5e:  01ce8a63            beq t4,t3,0x72\n"
-            "  62:  04c62f83            lw  t6,76(a2)\n"
-            "  66:  06600613            li  a2,102\n"
-            "  6a:  18b00693            li  a3,395\n"
-            "  6e:  877a                    mv  a4,t5\n"
-            "  70:  8f82                    jr  t6\n"
-            "  72:  0005ae83            lw  t4,0(a1)\n"
-            "  76:  000eae83            lw  t4,0(t4)\n"
-            "  7a:  0ee2                    slli    t4,t4,0x18\n"
-            "  7c:  27000f13            li  t5,624\n"
-            "  80:  00000013            nop\n"
-            "  84:  01eeeeb3            or  t4,t4,t5\n"
-            "  88:  05d52e23            sw  t4,92(a0)\n"
-            "  8c:  08000f13            li  t5,128\n"
-            "  90:  9f32                    add t5,t5,a2\n"
-            "  92:  000f2f03            lw  t5,0(t5)\n"
-            "  96:  867e                    mv  a2,t6\n"
-            "  98:  4681                    li  a3,0\n"
-            "  9a:  8f02                    jr  t5"
+            "  28:  003efe93            andi    t4,t4,3\n"
+            "  2c:  4e09                    li  t3,2\n"
+            "  2e:  01ce8a63            beq t4,t3,0x42\n"
+            "  32:  04c62f83            lw  t6,76(a2)\n"
+            "  36:  03600613            li  a2,54\n"
+            "  3a:  18b00693            li  a3,395\n"
+            "  3e:  877a                    mv  a4,t5\n"
+            "  40:  8f82                    jr  t6\n"
+            "  42:  ffcf7f13            andi    t5,t5,-4\n"
+            "  46:  000f2f03            lw  t5,0(t5)\n"
+            "  4a:  8efa                    mv  t4,t5\n"
+            "  4c:  03fefe93            andi    t4,t4,63\n"
+            "  50:  4e51                    li  t3,20\n"
+            "  52:  01ce8a63            beq t4,t3,0x66\n"
+            "  56:  04c62f83            lw  t6,76(a2)\n"
+            "  5a:  05a00613            li  a2,90\n"
+            "  5e:  18b00693            li  a3,395\n"
+            "  62:  877a                    mv  a4,t5\n"
+            "  64:  8f82                    jr  t6\n"
+            "  66:  0005ae83            lw  t4,0(a1)\n"
+            "  6a:  000eae83            lw  t4,0(t4)\n"
+            "  6e:  0ee2                    slli    t4,t4,0x18\n"
+            "  70:  24000f13            li  t5,576\n"
+            "  74:  00000013            nop\n"
+            "  78:  01eeeeb3            or  t4,t4,t5\n"
+            "  7c:	05d52e23          	sw	t4,92(a0)\n"
+            "  80:  08000f13            li  t5,128\n"
+            "  84:  9f32                    add t5,t5,a2\n"
+            "  86:  000f2f03            lw  t5,0(t5)\n"
+            "  8a:  867e                    mv  a2,t6\n"
+            "  8c:  4681                    li  a3,0\n"
+            "  8e:  8f02                    jr  t5"
         >>,
     jit_tests_common:assert_stream(riscv32, Dump, Stream).
 
@@ -2644,7 +2623,7 @@ move_to_native_register_test_() ->
                     Stream = ?BACKEND:stream(State1),
                     ?assertEqual(t6, Reg),
                     Dump = <<
-                        "   0:  02c52f83            lw  t6,44(a0)"
+                        "   0:	02c52f83          	lw	t6,44(a0)"
                     >>,
                     jit_tests_common:assert_stream(riscv32, Dump, Stream)
                 end),
@@ -3024,19 +3003,17 @@ and_register_exhaustion_negative_test() ->
     {State4, t3} = ?BACKEND:move_to_native_register(State3, {x_reg, 3}),
     {State5, t2} = ?BACKEND:move_to_native_register(State4, {x_reg, 4}),
     {StateNoRegs, t1} = ?BACKEND:move_to_native_register(State5, {x_reg, 5}),
-    % Test negative immediate (-4) which should use NOT+AND with t0 as temp
+    % Test negative immediate (-4) which now uses ANDI directly (no temp needed)
     {StateResult, t6} = ?BACKEND:and_(StateNoRegs, {free, t6}, -4),
     Stream = ?BACKEND:stream(StateResult),
     ExpectedDump = <<
-        "      0:   01852f83            lw  t6,24(a0)\n"
-        "      4:   01c52f03            lw  t5,28(a0)\n"
-        "      8:   02052e83            lw  t4,32(a0)\n"
-        "      c:   02452e03            lw  t3,36(a0)\n"
-        "     10:   02852383            lw  t2,40(a0)\n"
-        "     14:   02c52303            lw  t1,44(a0)\n"
-        "     18:   428d                    li  t0,3\n"
-        "     1a:   fff2c293            not t0,t0\n"
-        "     1e:   005fffb3            and t6,t6,t0"
+        "      0:	01852f83          	lw	t6,24(a0)\n"
+        "      4:   01c52f03          	lw	t5,28(a0)\n"
+        "      8:	02052e83          	lw	t4,32(a0)\n"
+        "      c:	02452e03          	lw	t3,36(a0)\n"
+        "     10:	02852383          	lw	t2,40(a0)\n"
+        "     14:	02c52303          	lw	t1,44(a0)\n"
+        "     18:   ffcfff93            andi    t6,t6,-4"
     >>,
     jit_tests_common:assert_stream(riscv32, ExpectedDump, Stream).
 
@@ -3049,18 +3026,17 @@ and_register_exhaustion_positive_test() ->
     {State4, t3} = ?BACKEND:move_to_native_register(State3, {x_reg, 3}),
     {State5, t2} = ?BACKEND:move_to_native_register(State4, {x_reg, 4}),
     {StateNoRegs, t1} = ?BACKEND:move_to_native_register(State5, {x_reg, 5}),
-    % Test positive immediate (0x3F) which should use AND with t0 as temp
+    % Test positive immediate (0x3F) which now uses ANDI directly (no temp needed)
     {StateResult, t6} = ?BACKEND:and_(StateNoRegs, {free, t6}, 16#3F),
     Stream = ?BACKEND:stream(StateResult),
     ExpectedDump = <<
-        "   0:  01852f83            lw  t6,24(a0)\n"
-        "   4:  01c52f03            lw  t5,28(a0)\n"
-        "   8:  02052e83            lw  t4,32(a0)\n"
-        "   c:  02452e03            lw  t3,36(a0)\n"
-        "  10:  02852383            lw  t2,40(a0)\n"
-        "  14:  02c52303            lw  t1,44(a0)\n"
-        "  18:  03f00293            li  t0,63\n"
-        "  1c:  005fffb3            and t6,t6,t0"
+        "   0:	01852f83          	lw	t6,24(a0)\n"
+        "   4:	01c52f03          	lw	t5,28(a0)\n"
+        "   8:	02052e83          	lw	t4,32(a0)\n"
+        "   c:	02452e03          	lw	t3,36(a0)\n"
+        "  10:	02852383          	lw	t2,40(a0)\n"
+        "  14:	02c52303          	lw	t1,44(a0)\n"
+        "  18:  03ffff93            andi    t6,t6,63"
     >>,
     jit_tests_common:assert_stream(riscv32, ExpectedDump, Stream).
 
@@ -3569,5 +3545,127 @@ add_beam_test() ->
             % label 0
             "  e0:  00462f83            lw  t6,4(a2)\n"
             "  e4:  8f82                jr  t6"
+        >>,
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
+
+%% After freeing a register, cache is preserved so reload is elided
+cached_load_after_free_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, t6} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    State2 = ?BACKEND:free_native_registers(State1, [t6]),
+    {State3, t6} = ?BACKEND:move_to_native_register(State2, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State3),
+    Dump =
+        <<
+            "   0:  01852f83          	lw	t6,24(a0)"
+        >>,
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
+
+%% Verify that and_ with a large positive immediate invalidates the Temp
+%% register cache entry. Before the fix, the Temp register (used to hold the
+%% and mask) kept a stale cache entry, causing a subsequent
+%% move_to_native_register for the same VM register to skip the load.
+and_positive_imm_invalidates_temp_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, t6} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, t5} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    State3 = ?BACKEND:free_native_registers(State2, [t5]),
+    % and_ with 0x3F00 (> 2047) picks t5 as Temp, loads mask into it
+    {State4, t6} = ?BACKEND:and_(State3, {free, t6}, 16#3F00),
+    % This must emit a lw to reload x_reg 1, not use stale cache
+    {State5, t5} = ?BACKEND:move_to_native_register(State4, {x_reg, 1}),
+    Stream = ?BACKEND:stream(State5),
+    Dump =
+        <<
+            "   0:  01852f83          	lw	t6,24(a0)\n"
+            "   4:	01c52f03          	lw	t5,28(a0)\n"
+            "   8:  6f11                lui t5,0x4\n"
+            "   a:  f00f0f13            addi    t5,t5,-256\n"
+            "   e:  01efffb3            and t6,t6,t5\n"
+            "  12:  01c52f03          	lw	t5,28(a0)"
+        >>,
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
+
+if_block_cond_free_reg_invalidates_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, t6} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, t5} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    State3 = ?BACKEND:if_block(
+        State2,
+        {{free, t6}, '&', 16#F, '!=', 16#F},
+        fun(BSt0) -> ?BACKEND:add(BSt0, t5, 2) end
+    ),
+    {State4, t6} = ?BACKEND:move_to_native_register(State3, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State4),
+    Dump =
+        <<
+            "   0:  01852f83          	lw	t6,24(a0)\n"
+            "   4:	01c52f03          	lw	t5,28(a0)\n"
+            "   8:  ffffcf93            not t6,t6\n"
+            "   c:  0ff2                slli    t6,t6,0x1c\n"
+            "   e:  000f8363            beqz    t6,0x14\n"
+            "  12:  0f09                addi    t5,t5,2\n"
+            "  14:  01852f83          	lw	t6,24(a0)"
+        >>,
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
+
+jump_to_label_invalidates_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, t6} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    State2 = ?BACKEND:free_native_registers(State1, [t6]),
+    State3 = ?BACKEND:jump_to_label(State2, 42),
+    {State4, t6} = ?BACKEND:move_to_native_register(State3, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State4),
+    Dump =
+        <<
+            "   0:	01852f83          	lw	t6,24(a0)\n"
+            "   4:  ffff                .insn   2, 0xffff\n"
+            "   6:  ffff                .insn   2, 0xffff\n"
+            "   8:  ffff                .insn   2, 0xffff\n"
+            "   a:  ffff                .insn   2, 0xffff\n"
+            "   c:	01852f83          	lw	t6,24(a0)"
+        >>,
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
+
+ldr_y_reg_invalidates_hidden_temp_cache_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, t6} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, t5} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    {State3, t4} = ?BACKEND:move_to_native_register(State2, {x_reg, 2}),
+    State4 = ?BACKEND:free_native_registers(State3, [t5, t4]),
+    {State5, t5} = ?BACKEND:move_to_native_register(State4, {y_reg, 0}),
+    {State6, t4} = ?BACKEND:move_to_native_register(State5, {x_reg, 2}),
+    Stream = ?BACKEND:stream(State6),
+    Dump =
+        <<
+            "   0:	01852f83          	lw	t6,24(a0)\n"
+            "   4:	01c52f03          	lw	t5,28(a0)\n"
+            "   8:	02052e83          	lw	t4,32(a0)\n"
+            "   c:	01452e83          	lw	t4,20(a0)\n"
+            "  10:  000eaf03            lw  t5,0(t4)\n"
+            "  14:	02052e83          	lw	t4,32(a0)"
+        >>,
+    jit_tests_common:assert_stream(riscv32, Dump, Stream).
+
+y_reg_load_last_available_register_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, t6} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, t5} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    {State3, t4} = ?BACKEND:move_to_native_register(State2, {x_reg, 2}),
+    {State4, t3} = ?BACKEND:move_to_native_register(State3, {x_reg, 3}),
+    {State5, t2} = ?BACKEND:move_to_native_register(State4, {x_reg, 4}),
+    {State6, t1} = ?BACKEND:move_to_native_register(State5, {x_reg, 5}),
+    {State7, t0} = ?BACKEND:move_to_native_register(State6, {y_reg, 0}),
+    Stream = ?BACKEND:stream(State7),
+    Dump =
+        <<
+            "    0:	01852f83          	lw	t6,24(a0)\n"
+            "    4:	01c52f03          	lw	t5,28(a0)\n"
+            "    8:	02052e83          	lw	t4,32(a0)\n"
+            "    c:	02452e03          	lw	t3,36(a0)\n"
+            "   10:	02852383          	lw	t2,40(a0)\n"
+            "   14:	02c52303          	lw	t1,44(a0)\n"
+            "   18:	01452283          	lw	t0,20(a0)\n"
+            "  1c:  0002a283            lw  t0,0(t0)"
         >>,
     jit_tests_common:assert_stream(riscv32, Dump, Stream).

--- a/tests/libs/jit/jit_tests.erl
+++ b/tests/libs/jit/jit_tests.erl
@@ -191,41 +191,40 @@ term_to_int_verify_is_match_state_typed_optimization_x86_64_test() ->
     ),
 
     % Check call to bs_start_match3 is followed by a skip of verify_is_boxed
-    %  100:	48 8b 77 30          	mov    0x30(%rdi),%rsi
-    %  104:	48 c7 c2 00 00 00 00 	mov    $0x0,%rdx
-    %  10b:	ff d0                	callq  *%rax
-    %  10d:	5a                   	pop    %rdx
-    %  10e:	5e                   	pop    %rsi
-    %  10f:	5f                   	pop    %rdi
-    %  110:	48 89 47 40          	mov    %rax,0x40(%rdi)
-    %  114:	48 8b 47 40          	mov    0x40(%rdi),%rax
-    %  118:	48 83 e0 fc          	and    $0xfffffffffffffffc,%rax
+    % The register value cache eliminates the redundant load after the store,
+    % since %rax already holds the value.
+    %   48 8b 77 30          	mov    0x30(%rdi),%rsi
+    %   48 c7 c2 00 00 00 00 	mov    $0x0,%rdx
+    %   ff d0                	callq  *%rax
+    %   5a                   	pop    %rdx
+    %   5e                   	pop    %rsi
+    %   5f                   	pop    %rdi
+    %   48 89 47 40          	mov    %rax,0x40(%rdi)
+    %   48 83 e0 fc          	and    $0xfffffffffffffffc,%rax
 
-    % As opposed to:
-    %  100:	48 8b 77 30          	mov    0x30(%rdi),%rsi
-    %  104:	48 c7 c2 00 00 00 00 	mov    $0x0,%rdx
-    %  10b:	ff d0                	callq  *%rax
-    %  10d:	5a                   	pop    %rdx
-    %  10e:	5e                   	pop    %rsi
-    %  10f:	5f                   	pop    %rdi
-    %  110:	48 89 47 40          	mov    %rax,0x40(%rdi)
-    %  114:	48 8b 47 40          	mov    0x40(%rdi),%rax
-    %  118:	49 89 c3             	mov    %rax,%r11
-    %  11b:	41 80 e3 03          	and    $0x3,%r11b
-    %  11f:	41 80 fb 02          	cmp    $0x2,%r11b
-    %  123:	74 13                	je     0x138
-    %  125:	48 8b 02             	mov    (%rdx),%rax
-    %  128:	48 c7 c2 28 01 00 00 	mov    $0x128,%rdx
-    %  12f:	48 c7 c1 0b 01 00 00 	mov    $0x10b,%rcx
-    %  136:	ff e0                	jmpq   *%rax
-    %  138:	48 83 e0 fc          	and    $0xfffffffffffffffc,%rax
+    % As opposed to (without typed optimization, verify_is_boxed would be emitted):
+    %   48 8b 77 30          	mov    0x30(%rdi),%rsi
+    %   48 c7 c2 00 00 00 00 	mov    $0x0,%rdx
+    %   ff d0                	callq  *%rax
+    %   5a                   	pop    %rdx
+    %   5e                   	pop    %rsi
+    %   5f                   	pop    %rdi
+    %   48 89 47 40          	mov    %rax,0x40(%rdi)
+    %   49 89 c3             	mov    %rax,%r11
+    %   41 80 e3 03          	and    $0x3,%r11b
+    %   41 80 fb 02          	cmp    $0x2,%r11b
+    %   74 0f                	je     <skip>
+    %   48 8b 02             	mov    (%rdx),%rax
+    %   ba xx xx 00 00       	mov    $0x...,%edx
+    %   b9 xx xx 00 00       	mov    $0x...,%ecx
+    %   ff e0                	jmpq   *%rax
+    %   48 83 e0 fc          	and    $0xfffffffffffffffc,%rax
     ?assertMatch(
-        {_, 28},
+        {_, 24},
         binary:match(
             CompiledCode,
             <<16#48, 16#8b, 16#77, 16#30, 16#48, 16#c7, 16#c2, 16#00, 16#00, 16#00, 16#00, 16#ff,
-                16#d0, 16#5a, 16#5e, 16#5f, 16#48, 16#89, 16#47, 16#40, 16#48, 16#8b, 16#47, 16#40,
-                16#48, 16#83, 16#e0, 16#fc>>
+                16#d0, 16#5a, 16#5e, 16#5f, 16#48, 16#89, 16#47, 16#40, 16#48, 16#83, 16#e0, 16#fc>>
         )
     ),
 

--- a/tests/libs/jit/jit_tests_common.erl
+++ b/tests/libs/jit/jit_tests_common.erl
@@ -75,6 +75,14 @@ asm(Arch, Bin, Str) ->
 %% Helper function to find available binutils for a given architecture
 -spec find_binutils(atom()) -> {ok, string(), string()} | false.
 find_binutils(Arch) ->
+    case erlang:system_info(machine) of
+        "ATOM" ->
+            false;
+        _ ->
+            find_binutils_beam(Arch)
+    end.
+
+find_binutils_beam(Arch) ->
     Prefixes0 = toolchain_prefixes(Arch),
     Prefixes =
         case Arch of

--- a/tests/libs/jit/jit_x86_64_tests.erl
+++ b/tests/libs/jit/jit_x86_64_tests.erl
@@ -20,9 +20,7 @@
 
 -module(jit_x86_64_tests).
 
--ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--endif.
 
 -include("jit/include/jit.hrl").
 -include("jit/src/term.hrl").
@@ -232,9 +230,9 @@ call_ext_only_test() ->
             "  14:	ff e0                	jmpq   *%rax\n"
             "  16:	48 8b 42 20          	mov    0x20(%rdx),%rax\n"
             "  1a:	48 c7 c2 02 00 00 00 	mov    $0x2,%rdx\n"
-            "  21:	48 c7 c1 02 00 00 00 	mov    $0x2,%rcx\n"
-            "  28:	49 c7 c0 ff ff ff ff 	mov    $0xffffffffffffffff,%r8\n"
-            "  2f:	ff e0                	jmpq   *%rax\n"
+            "  21:	48 89 d1             	mov    %rdx,%rcx\n"
+            "  24:	49 c7 c0 ff ff ff ff 	mov    $0xffffffffffffffff,%r8\n"
+            "  2b:	ff e0                	jmpq   *%rax\n"
         >>,
     jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
@@ -253,9 +251,9 @@ call_ext_last_test() ->
             "  14:	ff e0                	jmpq   *%rax\n"
             "  16:	48 8b 42 20          	mov    0x20(%rdx),%rax\n"
             "  1a:	48 c7 c2 02 00 00 00 	mov    $0x2,%rdx\n"
-            "  21:	48 c7 c1 02 00 00 00 	mov    $0x2,%rcx\n"
-            "  28:	49 c7 c0 0a 00 00 00 	mov    $0xa,%r8\n"
-            "  2f:	ff e0                	jmpq   *%rax\n"
+            "  21:	48 89 d1             	mov    %rdx,%rcx\n"
+            "  24:	49 c7 c0 0a 00 00 00 	mov    $0xa,%r8\n"
+            "  2b:	ff e0                	jmpq   *%rax\n"
         >>,
     jit_tests_common:assert_stream(x86_64, Dump, Stream).
 
@@ -1851,5 +1849,56 @@ wait_known_test() ->
             "  25:	48 89 46 08          	mov    %rax,0x8(%rsi)\n"
             "  29:	48 8b 82 e8 00 00 00 	mov    0xe8(%rdx),%rax\n"
             "  30:	ff e0                	jmpq   *%rax"
+        >>,
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
+
+%% Loading the same x_reg twice should skip the second load
+cached_load_same_xreg_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, rax} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, rax} = ?BACKEND:move_to_native_register(State1, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State2),
+    Dump =
+        <<
+            "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax"
+        >>,
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
+
+%% Loading a different x_reg should emit a load, loading same again should skip
+cached_load_different_xreg_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, rax} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    {State2, r11} = ?BACKEND:move_to_native_register(State1, {x_reg, 1}),
+    {State3, r11} = ?BACKEND:move_to_native_register(State2, {x_reg, 1}),
+    Stream = ?BACKEND:stream(State3),
+    Dump =
+        <<
+            "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax\n"
+            "   4:	4c 8b 5f 38          	mov    0x38(%rdi),%r11"
+        >>,
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
+
+%% Loading cp twice should skip the second load
+cached_load_cp_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, rax} = ?BACKEND:move_to_native_register(State0, cp),
+    {State2, rax} = ?BACKEND:move_to_native_register(State1, cp),
+    Stream = ?BACKEND:stream(State2),
+    Dump =
+        <<
+            "   0:	48 8b 87 b8 00 00 00 	mov    0xb8(%rdi),%rax"
+        >>,
+    jit_tests_common:assert_stream(x86_64, Dump, Stream).
+
+%% After freeing a register, cache is preserved so reload is elided
+cached_load_after_free_test() ->
+    State0 = ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0)),
+    {State1, rax} = ?BACKEND:move_to_native_register(State0, {x_reg, 0}),
+    State2 = ?BACKEND:free_native_registers(State1, [rax]),
+    {State3, rax} = ?BACKEND:move_to_native_register(State2, {x_reg, 0}),
+    Stream = ?BACKEND:stream(State3),
+    Dump =
+        <<
+            "   0:	48 8b 47 30          	mov    0x30(%rdi),%rax"
         >>,
     jit_tests_common:assert_stream(x86_64, Dump, Stream).


### PR DESCRIPTION
Add register value tracking (jit_regs) to all JIT backends (x86-64, aarch64, armv6m, riscv32). This enables optimization of redundant loads when a register already contains the needed value.

Factor out shared value_to_contents and vm_dest_to_contents helpers into jit_regs module. Add regs_to_mask/2 to replace per-backend duplicated regs_to_mask/1 functions. Add invalidate_volatile/2 for correct cache management after function calls.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
