### PR TITLE
JIT armv6m: fix BCC overflow from literal pool flush

### DIFF
--- a/libs/jit/src/jit_armv6m.erl
+++ b/libs/jit/src/jit_armv6m.erl
@@ -139,7 +139,8 @@
     used_regs :: non_neg_integer(),
     labels :: [{integer() | reference(), integer()}],
     variant :: non_neg_integer(),
-    literal_pool :: [{non_neg_integer(), armv6m_register(), non_neg_integer()}]
+    literal_pool :: [{non_neg_integer(), armv6m_register(), non_neg_integer()}],
+    literal_pool_max_offset :: unbound | disabled | non_neg_integer()
 }).
 
 -type state() :: #state{}.
@@ -278,7 +279,8 @@ new(Variant, StreamModule, Stream) ->
         used_regs = 0,
         labels = [],
         variant = Variant,
-        literal_pool = []
+        literal_pool = [],
+        literal_pool_max_offset = unbound
     }.
 
 %%-----------------------------------------------------------------------------
@@ -1009,7 +1011,7 @@ branch_to_label_code(#state{available_regs = 0}, _Offset, _Label, _LabelLookup) 
 %%-----------------------------------------------------------------------------
 -spec if_block(state(), condition() | {'and', [condition()]}, fun((state()) -> state())) -> state().
 if_block(
-    #state{stream_module = StreamModule} = State0,
+    #state{stream_module = StreamModule, literal_pool_max_offset = PrevMaxOffset} = State0,
     {'and', CondList},
     BlockFn
 ) ->
@@ -1022,7 +1024,10 @@ if_block(
         {[], State0},
         CondList
     ),
-    State2 = BlockFn(State1),
+    %% The first BCC (last in reversed Replacements) has the tightest constraint
+    {FirstBccOffset, _} = lists:last(Replacements),
+    NewMaxOffset = if_block_max_offset(PrevMaxOffset, FirstBccOffset),
+    State2 = BlockFn(State1#state{literal_pool_max_offset = NewMaxOffset}),
     Stream2 = State2#state.stream,
     OffsetAfter = StreamModule:offset(Stream2),
     Stream3 = lists:foldl(
@@ -1034,22 +1039,40 @@ if_block(
         Stream2,
         Replacements
     ),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs);
+    State3 = merge_used_regs(
+        State2#state{stream = Stream3, literal_pool_max_offset = PrevMaxOffset},
+        State1#state.used_regs
+    ),
+    maybe_flush_literal_pool(State3);
 if_block(
-    #state{stream_module = StreamModule, stream = Stream0} = State0,
+    #state{stream_module = StreamModule, literal_pool_max_offset = PrevMaxOffset} = State0,
     Cond,
     BlockFn
 ) ->
-    Offset = StreamModule:offset(Stream0),
+    Offset = StreamModule:offset(State0#state.stream),
     {State1, CC, BranchInstrOffset} = if_block_cond(State0, Cond),
-    State2 = BlockFn(State1),
+    BccOffset = Offset + BranchInstrOffset,
+    NewMaxOffset = if_block_max_offset(PrevMaxOffset, BccOffset),
+    State2 = BlockFn(State1#state{literal_pool_max_offset = NewMaxOffset}),
     Stream2 = State2#state.stream,
     OffsetAfter = StreamModule:offset(Stream2),
     %% Patch the conditional branch instruction to jump to the end of the block
-    BranchOffset = OffsetAfter - (Offset + BranchInstrOffset),
+    BranchOffset = OffsetAfter - BccOffset,
     NewBranchInstr = jit_armv6m_asm:bcc(CC, BranchOffset),
-    Stream3 = StreamModule:replace(Stream2, Offset + BranchInstrOffset, NewBranchInstr),
-    merge_used_regs(State2#state{stream = Stream3}, State1#state.used_regs).
+    Stream3 = StreamModule:replace(Stream2, BccOffset, NewBranchInstr),
+    State3 = merge_used_regs(
+        State2#state{stream = Stream3, literal_pool_max_offset = PrevMaxOffset},
+        State1#state.used_regs
+    ),
+    maybe_flush_literal_pool(State3).
+
+%% When entering an if_block, compute the literal_pool_max_offset for BlockFn.
+%% If we're already inside a conditional (not unbound), disable flushing entirely
+%% so only the outermost if_block controls the literal pool.
+if_block_max_offset(unbound, BccOffset) ->
+    BccOffset + 258;
+if_block_max_offset(_AlreadySet, _BccOffset) ->
+    disabled.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit an if else block, i.e. emit a test of a condition and
@@ -1064,31 +1087,36 @@ if_block(
 -spec if_else_block(state(), condition(), fun((state()) -> state()), fun((state()) -> state())) ->
     state().
 if_else_block(
-    #state{stream_module = StreamModule, stream = Stream0} = State0,
+    #state{stream_module = StreamModule, literal_pool_max_offset = PrevMaxOffset} = State0,
     Cond,
     BlockTrueFn,
     BlockFalseFn
 ) ->
-    Offset = StreamModule:offset(Stream0),
+    Offset = StreamModule:offset(State0#state.stream),
     {State1, CC, BranchInstrOffset} = if_block_cond(State0, Cond),
-    State2 = BlockTrueFn(State1),
+    BccOffset = Offset + BranchInstrOffset,
+    NewMaxOffset = if_block_max_offset(PrevMaxOffset, BccOffset),
+    State2 = BlockTrueFn(State1#state{literal_pool_max_offset = NewMaxOffset}),
     Stream2 = State2#state.stream,
     %% Emit unconditional branch to skip the else block (will be replaced)
     ElseJumpOffset = StreamModule:offset(Stream2),
     ?ASSERT(byte_size(jit_armv6m_asm:b(0)) =:= 2),
     ElseJumpInstr = <<16#FFFF:16>>,
     Stream3 = StreamModule:append(Stream2, ElseJumpInstr),
-    %% Else block starts here.
-    OffsetAfter = StreamModule:offset(Stream3),
-    %% Patch the conditional branch to jump to the else block
-    ElseBranchOffset = OffsetAfter - (Offset + BranchInstrOffset),
+    %% Flush literal pool in dead space between B and else block
+    State2a = flush_literal_pool(State2#state{stream = Stream3}),
+    Stream3a = State2a#state.stream,
+    %% Else block starts here — patch the conditional branch
+    OffsetAfter = StreamModule:offset(Stream3a),
+    ElseBranchOffset = OffsetAfter - BccOffset,
     NewBranchInstr = jit_armv6m_asm:bcc(CC, ElseBranchOffset),
-    Stream4 = StreamModule:replace(Stream3, Offset + BranchInstrOffset, NewBranchInstr),
-    %% Build the else block
-    StateElse = State2#state{
+    Stream4 = StreamModule:replace(Stream3a, BccOffset, NewBranchInstr),
+    %% Build the else block (restore previous max_offset)
+    StateElse = State2a#state{
         stream = Stream4,
         used_regs = State1#state.used_regs,
-        available_regs = State1#state.available_regs
+        available_regs = State1#state.available_regs,
+        literal_pool_max_offset = PrevMaxOffset
     },
     State3 = BlockFalseFn(StateElse),
     Stream5 = State3#state.stream,
@@ -1097,7 +1125,8 @@ if_else_block(
     FinalJumpOffset = OffsetFinal - ElseJumpOffset,
     NewElseJumpInstr = jit_armv6m_asm:b(FinalJumpOffset),
     Stream6 = StreamModule:replace(Stream5, ElseJumpOffset, NewElseJumpInstr),
-    merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs).
+    State4 = merge_used_regs(State3#state{stream = Stream6}, State2#state.used_regs),
+    maybe_flush_literal_pool(State4).
 
 -spec if_block_cond(state(), condition()) ->
     {
@@ -3201,35 +3230,107 @@ maybe_flush_literal_pool(
     % bigint.beam currently requires 663 or lower to compile.
     if
         Offset - Addr > 512 ->
-            NbLiterals = length(LP),
-            Continuation = NbLiterals * 4 + 4 - (Offset rem 4),
-            Stream1 = StreamModule:append(Stream0, jit_armv6m_asm:b(Continuation)),
-            Stream2 =
-                if
-                    Offset rem 4 =:= 0 ->
-                        StreamModule:append(Stream1, <<16#FFFF:16>>);
-                    true ->
-                        Stream1
-                end,
-            flush_literal_pool(State#state{stream = Stream2});
+            flush_literal_pool_with_branch_over(State);
         true ->
             State
     end.
 
+-spec flush_literal_pool_with_branch_over(state()) -> state().
+flush_literal_pool_with_branch_over(#state{literal_pool = []} = State) ->
+    State;
+flush_literal_pool_with_branch_over(#state{literal_pool_max_offset = disabled} = State) ->
+    State;
+flush_literal_pool_with_branch_over(
+    #state{
+        stream_module = StreamModule,
+        stream = Stream0,
+        literal_pool = LP,
+        literal_pool_max_offset = MaxOffset
+    } = State
+) ->
+    Offset = StreamModule:offset(Stream0),
+    AlignPadding =
+        if
+            Offset rem 4 =:= 0 -> 2;
+            true -> 0
+        end,
+    PoolStart = Offset + 2 + AlignPadding,
+    NbToFlush =
+        case MaxOffset of
+            unbound ->
+                length(LP);
+            MaxOff when is_integer(MaxOff) ->
+                NbCanFlush = (MaxOff - PoolStart) div 4,
+                if
+                    NbCanFlush =< 0 -> 0;
+                    true -> min(NbCanFlush, length(LP))
+                end
+        end,
+    case NbToFlush of
+        0 ->
+            State;
+        _ ->
+            BranchAddr = Offset,
+            Stream1 = StreamModule:append(Stream0, <<16#FFFF:16>>),
+            Stream2 =
+                if
+                    AlignPadding > 0 ->
+                        StreamModule:append(Stream1, <<16#FFFF:16>>);
+                    true ->
+                        Stream1
+                end,
+            State1 = flush_literal_pool(State#state{stream = Stream2}),
+            Stream3 = State1#state.stream,
+            OffsetAfter = StreamModule:offset(Stream3),
+            BranchOffset = OffsetAfter - BranchAddr,
+            BranchInstr = jit_armv6m_asm:b(BranchOffset),
+            Stream4 = StreamModule:replace(Stream3, BranchAddr, BranchInstr),
+            State1#state{stream = Stream4}
+    end.
+
 flush_literal_pool(#state{literal_pool = []} = State) ->
     State;
+flush_literal_pool(#state{literal_pool_max_offset = disabled} = State) ->
+    State;
 flush_literal_pool(
-    #state{stream_module = StreamModule, stream = Stream0, literal_pool = LP} = State
+    #state{
+        stream_module = StreamModule,
+        stream = Stream0,
+        literal_pool = LP,
+        literal_pool_max_offset = MaxOffset
+    } = State
 ) ->
-    % Align
     Offset = StreamModule:offset(Stream0),
-    Stream1 =
-        if
-            Offset rem 4 =:= 0 -> Stream0;
-            true -> StreamModule:append(Stream0, <<0:16>>)
-        end,
-    % Lay all values and update ldr instructions
-    Stream2 = lists:foldl(
+    case MaxOffset of
+        unbound ->
+            Stream1 = align_stream_for_literal_pool(StreamModule, Stream0, Offset),
+            Stream2 = flush_literal_entries(StreamModule, Stream1, lists:reverse(LP)),
+            State#state{stream = Stream2, literal_pool = []};
+        MaxOff when is_integer(MaxOff) ->
+            AlignPadding = (Offset rem 4),
+            NbCanFlush = (MaxOff - Offset - AlignPadding) div 4,
+            if
+                NbCanFlush =< 0 ->
+                    State;
+                true ->
+                    ReversedLP = lists:reverse(LP),
+                    {ToFlush, ToKeep} = lists:split(
+                        min(NbCanFlush, length(ReversedLP)), ReversedLP
+                    ),
+                    Stream1 = align_stream_for_literal_pool(StreamModule, Stream0, Offset),
+                    Stream2 = flush_literal_entries(StreamModule, Stream1, ToFlush),
+                    State#state{stream = Stream2, literal_pool = lists:reverse(ToKeep)}
+            end
+    end.
+
+align_stream_for_literal_pool(StreamModule, Stream, Offset) ->
+    if
+        Offset rem 4 =:= 0 -> Stream;
+        true -> StreamModule:append(Stream, <<16#FFFF:16>>)
+    end.
+
+flush_literal_entries(StreamModule, Stream, Entries) ->
+    lists:foldl(
         fun({LdrInstructionAddr, Reg, Val}, AccStream) ->
             LiteralPosition = StreamModule:offset(AccStream),
             LdrPC = (LdrInstructionAddr band (bnot 3)) + 4,
@@ -3240,10 +3341,9 @@ flush_literal_pool(
                 AccStream1, LdrInstructionAddr, LdrInstruction
             )
         end,
-        Stream1,
-        lists:reverse(LP)
-    ),
-    State#state{stream = Stream2, literal_pool = []}.
+        Stream,
+        Entries
+    ).
 
 sub(#state{stream_module = StreamModule, stream = Stream0} = State, Reg, Val) when
     (Val >= 0 andalso Val =< 255) orelse is_atom(Val)
@@ -3348,7 +3448,10 @@ mul(
 -spec decrement_reductions_and_maybe_schedule_next(state()) -> state().
 decrement_reductions_and_maybe_schedule_next(
     #state{
-        stream_module = StreamModule, stream = Stream0, available_regs = Avail
+        stream_module = StreamModule,
+        stream = Stream0,
+        available_regs = Avail,
+        literal_pool_max_offset = PrevMaxOffset
     } = State0
 ) ->
     Temp = first_avail(Avail),
@@ -3361,6 +3464,7 @@ decrement_reductions_and_maybe_schedule_next(
     I2 = jit_armv6m_asm:subs(Temp, Temp, 1),
     % Store back the decremented value
     I3 = jit_armv6m_asm:str(Temp, ?JITSTATE_REDUCTIONCOUNT(TempJitState)),
+    Stream0 = State0#state.stream,
     Stream1 = StreamModule:append(Stream0, <<I0/binary, I1/binary, I2/binary, I3/binary>>),
     BNEOffset = StreamModule:offset(Stream1),
     % Branch if reduction count is not zero
@@ -3374,7 +3478,8 @@ decrement_reductions_and_maybe_schedule_next(
     I7 = jit_armv6m_asm:str(Temp, ?JITSTATE_CONTINUATION(TempJitState)),
     % Append the instructions to the stream
     Stream2 = StreamModule:append(Stream1, <<I4/binary, I5/binary, I6/binary, I7/binary>>),
-    State1 = State0#state{stream = Stream2},
+    NewMaxOffset = if_block_max_offset(PrevMaxOffset, BNEOffset),
+    State1 = State0#state{stream = Stream2, literal_pool_max_offset = NewMaxOffset},
     State2 = call_primitive_last(State1, ?PRIM_SCHEDULE_NEXT_CP, [ctx, jit_state]),
     % Add the prolog at the continuation point (where scheduled execution resumes)
     #state{stream = Stream3} = State2,
@@ -3406,7 +3511,11 @@ decrement_reductions_and_maybe_schedule_next(
     Stream5 = StreamModule:replace(
         Stream4, BNEOffset, <<NewI4/binary, NewI5/binary>>
     ),
-    merge_used_regs(State2#state{stream = Stream5}, State1#state.used_regs).
+    State3 = merge_used_regs(
+        State2#state{stream = Stream5, literal_pool_max_offset = PrevMaxOffset},
+        State1#state.used_regs
+    ),
+    maybe_flush_literal_pool(State3).
 
 -spec call_or_schedule_next(state(), non_neg_integer()) -> state().
 call_or_schedule_next(State0, Label) ->

--- a/tests/libs/jit/jit_armv6m_tests.erl
+++ b/tests/libs/jit/jit_armv6m_tests.erl
@@ -723,7 +723,7 @@ if_block_test_() ->
                         "   8:	d000      	beq.n	0xc\n"
                         "   a:	3601      	adds	r6, #1\n"
                         "   c:	e078      	b.n	0x100\n"
-                        "   e:	0000      	movs	r0, r0\n"
+                        "   e:	ffff      	.short	0xffff\n"
                         "  10:	07cb      	lsls	r3, r1, #31\n"
                         "  12:	0000      	movs	r0, r0"
                     >>,
@@ -1168,7 +1168,7 @@ if_block_test_() ->
                         "   8:	dd00      	ble.n	0xc\n"
                         "   a:	3602      	adds	r6, #2\n"
                         "   c:	e078      	b.n	0x100\n"
-                        "   e:	0000      	movs	r0, r0\n"
+                        "   e:	ffff      	.short	0xffff\n"
                         "  10:	03ff      	lsls	r7, r7, #15\n"
                         "  12:	0000      	movs	r0, r0"
                     >>,
@@ -1193,7 +1193,7 @@ if_block_test_() ->
                         "   8:	dd00      	ble.n	0xc\n"
                         "   a:	3602      	adds	r6, #2\n"
                         "   c:	e078      	b.n	0x100\n"
-                        "   e:	0000      	movs	r0, r0\n"
+                        "   e:	ffff      	.short	0xffff\n"
                         "  10:	03ff      	lsls	r7, r7, #15\n"
                         "  12:	0000      	movs	r0, r0"
                     >>,
@@ -1671,7 +1671,7 @@ call_bif_with_large_literal_integer_test() ->
             "  38:	9705      	str	r7, [sp, #20]\n"
             "  3a:	46b6      	mov	lr, r6\n"
             "  3c:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}\n"
-            "  3e:	0000      	movs	r0, r0\n"
+            "  3e:	ffff      	.short	0xffff\n"
             "  40:	e895 3b7f 	ldmia.w	r5, {r0, r1, r2, r3, r4, r5, r6, r8, r9, fp, ip, sp}\n"
             "  44:	6187      	str	r7, [r0, #24]"
         >>,
@@ -2653,7 +2653,7 @@ move_to_vm_register_test_() ->
                         "   0:	4f01      	ldr	r7, [pc, #4]	; (0x8)\n"
                         "   2:	6187      	str	r7, [r0, #24]\n"
                         "   4:	e07c      	b.n	0x100\n"
-                        "   6:	0000      	movs	r0, r0\n"
+                        "   6:	ffff      	.short	0xffff\n"
                         "   8:	5678      	ldrsb	r0, [r7, r1]\n"
                         "   a:	1234      	asrs	r4, r6, #8"
                     >>)
@@ -2681,7 +2681,7 @@ move_to_vm_register_test_() ->
                         "   0:	4f01      	ldr	r7, [pc, #4]	; (0x8)\n"
                         "   2:	6587      	str	r7, [r0, #88]	; 0x58\n"
                         "   4:	e07c      	b.n	0x100\n"
-                        "   6:	0000      	movs	r0, r0\n"
+                        "   6:	ffff      	.short	0xffff\n"
                         "   8:	5678      	ldrsb	r0, [r7, r1]\n"
                         "   a:	1234      	asrs	r4, r6, #8"
                     >>)
@@ -2712,7 +2712,7 @@ move_to_vm_register_test_() ->
                         "   0:	4f01      	ldr	r7, [pc, #4]	; (0x8)\n"
                         "   2:	601f      	str	r7, [r3, #0]\n"
                         "   4:	e07c      	b.n	0x100\n"
-                        "   6:	0000      	movs	r0, r0\n"
+                        "   6:	ffff      	.short	0xffff\n"
                         "   8:	5678      	ldrsb	r0, [r7, r1]\n"
                         "   a:	1234      	asrs	r4, r6, #8"
                     >>)
@@ -3304,7 +3304,7 @@ add_test_() ->
                         "   0:	4f01      	ldr	r7, [pc, #4]	; (0x8)\n"
                         "   2:	19d2      	adds	r2, r2, r7\n"
                         "   4:	e07c      	b.n	0x100\n"
-                        "   6:	0000      	movs	r0, r0\n"
+                        "   6:	ffff      	.short	0xffff\n"
                         "   8:	2345      	movs	r3, #69	; 0x45\n"
                         "   a:	0001      	movs	r1, r0"
                     >>)
@@ -3361,7 +3361,7 @@ sub_test_() ->
                         "   0:	4f01      	ldr	r7, [pc, #4]	; (0x8)\n"
                         "   2:	1bd2      	subs	r2, r2, r7\n"
                         "   4:	e07c      	b.n	0x100\n"
-                        "   6:	0000      	movs	r0, r0\n"
+                        "   6:	ffff      	.short	0xffff\n"
                         "   8:	bcde      	pop	{r1, r2, r3, r4, r6, r7, pc}\n"
                         "   a:	000a      	movs	r2, r1"
                     >>)
@@ -4063,3 +4063,148 @@ add_beam_test() ->
             "  e8:	bdf2      	pop	{r1, r4, r5, r6, r7, pc}\n"
         >>,
     jit_tests_common:assert_stream(arm, Dump, Stream).
+
+%% Test that literal pool entries accumulated before an if_block are flushed
+%% in the dead space after terminal instructions, constrained by BCC range.
+if_block_literal_pool_flush_test_() ->
+    {setup,
+        fun() ->
+            ?BACKEND:new(?JIT_VARIANT_PIC, jit_stream_binary, jit_stream_binary:new(0))
+        end,
+        fun(State0) ->
+            [
+                ?_test(begin
+                    State1 = ?BACKEND:move_to_native_register(State0, 16#12345678, r5),
+                    State2 = ?BACKEND:move_to_native_register(State1, 16#ABCD1234, r5),
+                    State3 = ?BACKEND:if_block(
+                        State2,
+                        {r5, '==', 0},
+                        fun(BSt0) ->
+                            ?BACKEND:jump_to_offset(BSt0, 16#100)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State3),
+                    Dump = <<
+                        "   0:	4d02      	ldr	r5, [pc, #8]	; (0xc)\n"
+                        "   2:	4d03      	ldr	r5, [pc, #12]	; (0x10)\n"
+                        "   4:	2d00      	cmp	r5, #0\n"
+                        "   6:	d105      	bne.n	0x14\n"
+                        "   8:	e07a      	b.n	0x100\n"
+                        "   a:	ffff      	.short	0xffff\n"
+                        "   c:	5678      	ldrsb	r0, [r7, r1]\n"
+                        "   e:	1234      	asrs	r4, r6, #8\n"
+                        "  10:	1234      	asrs	r4, r6, #8\n"
+                        "  12:	abcd      	add	r3, sp, #820	; 0x334"
+                    >>,
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
+                end),
+                ?_test(begin
+                    % Stress test: accumulate 70 literal pool entries, then
+                    % if_block with terminal. This exercises partial flushing
+                    % since 70 entries (280 bytes) exceed BCC range (~254 bytes
+                    % available after block code).
+                    State1 = lists:foldl(
+                        fun(I, AccState) ->
+                            ?BACKEND:move_to_native_register(
+                                AccState, 16#10000000 + I, r5
+                            )
+                        end,
+                        State0,
+                        lists:seq(1, 70)
+                    ),
+                    State2 = ?BACKEND:if_block(
+                        State1,
+                        {r5, '==', 0},
+                        fun(BSt0) ->
+                            ?BACKEND:jump_to_offset(BSt0, 16#400)
+                        end
+                    ),
+                    % Flush remaining entries
+                    State3 = ?BACKEND:flush(State2),
+                    Stream = ?BACKEND:stream(State3),
+                    % 70 LDR placeholders (140) + CMP+BCC (4) + B (2) +
+                    % alignment (2) + 70 literals (280) = 428
+                    ?assertEqual(428, byte_size(Stream)),
+                    % BCC at offset 142, patched to offset 400 (distance 258,
+                    % exactly the max BCC forward range)
+                    <<_:142/binary, BccInstr:16/little, _/binary>> = Stream,
+                    % bne with offset 258: adjusted = 258-4 = 254, /2 = 127
+                    ?assertEqual(16#D100 bor (1 bsl 8) bor 127, BccInstr)
+                end),
+                ?_test(begin
+                    % Nested if_blocks: inner gets disabled, outer controls flush.
+                    State1 = ?BACKEND:move_to_native_register(State0, 16#12345678, r5),
+                    State2 = ?BACKEND:move_to_native_register(State1, 16#ABCD1234, r5),
+                    State3 = ?BACKEND:if_block(
+                        State2,
+                        {r5, '==', 0},
+                        fun(BSt0) ->
+                            BSt1 = ?BACKEND:if_block(
+                                BSt0,
+                                {r5, '!=', 42},
+                                fun(BSt2) ->
+                                    ?BACKEND:jump_to_offset(BSt2, 16#200)
+                                end
+                            ),
+                            ?BACKEND:jump_to_offset(BSt1, 16#300)
+                        end
+                    ),
+                    Stream = ?BACKEND:stream(State3),
+                    Dump = <<
+                        "   0:	4d03      	ldr	r5, [pc, #12]	; (0x10)\n"
+                        "   2:	4d04      	ldr	r5, [pc, #16]	; (0x14)\n"
+                        "   4:	2d00      	cmp	r5, #0\n"
+                        "   6:	d107      	bne.n	0x18\n"
+                        "   8:	2d2a      	cmp	r5, #42	; 0x2a\n"
+                        "   a:	d000      	beq.n	0xe\n"
+                        "   c:	e0f8      	b.n	0x200\n"
+                        "   e:	e177      	b.n	0x300\n"
+                        "  10:	5678      	ldrsb	r0, [r7, r1]\n"
+                        "  12:	1234      	asrs	r4, r6, #8\n"
+                        "  14:	1234      	asrs	r4, r6, #8\n"
+                        "  16:	abcd      	add	r3, sp, #820	; 0x334"
+                    >>,
+                    jit_tests_common:assert_stream(arm, Dump, Stream)
+                end),
+                ?_test(begin
+                    % Regression: literal pool entries accumulated inside nested
+                    % if_blocks (where flushing is disabled) could drift beyond
+                    % the 1020-byte LDR range. After exiting, maybe_flush_literal_pool
+                    % must flush them.
+                    State1 = lists:foldl(
+                        fun(I, AccState) ->
+                            ?BACKEND:move_to_native_register(
+                                AccState, 16#10000000 + I, r5
+                            )
+                        end,
+                        State0,
+                        lists:seq(1, 60)
+                    ),
+                    State2 = ?BACKEND:if_block(
+                        State1,
+                        {r5, '==', 0},
+                        fun(BSt0) ->
+                            BSt1 = ?BACKEND:if_block(
+                                BSt0,
+                                {r5, '!=', 42},
+                                fun(BSt2) ->
+                                    lists:foldl(
+                                        fun(I, AccState) ->
+                                            ?BACKEND:move_to_native_register(
+                                                AccState, 16#20000000 + I, r5
+                                            )
+                                        end,
+                                        BSt2,
+                                        lists:seq(1, 10)
+                                    )
+                                end
+                            ),
+                            BSt1
+                        end
+                    ),
+                    State3 = ?BACKEND:flush(State2),
+                    Stream = ?BACKEND:stream(State3),
+                    ?assert(byte_size(Stream) > 0)
+                end)
+            ]
+        end}.


### PR DESCRIPTION
Fix a bug where blocks in if_block or if_else_block could inflate by flushing too many literals beyond the bcc range. The actual budget is set during these calls and literals can be partially flushed. Also add another flush opportunity in if_else_blocks and decrement_reductions_and_maybe_schedule_next

Fixes: https://github.com/atomvm/AtomVM/issues/2180

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
