### PR TITLE
CI: Use setup-beam in macOS CI

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-14", "macos-15", "macos-15-intel", "macos-26"]
-        otp: ["24", "25", "26", "27", "28"]
+        otp: ["25", "26", "27", "28"]
         mbedtls: ["mbedtls@3"]
         cmake_opts_other: [""]
 
@@ -66,22 +66,27 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: "Install deps"
-      if: matrix.otp != '24' && matrix.otp != '25'
-      run: brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam ${{ matrix.mbedtls }} rebar3
+    - name: "Normalize ImageOS for setup-beam"
+      if: matrix.os == 'macos-26'
+      run: echo "ImageOS=macos15" >> "$GITHUB_ENV"
+
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp }}
+        rebar3-version: ${{ fromJSON('{"25":"3.24.0","26":"3.25.1","27":"3.25.1","28":"3.26"}')[matrix.otp] || '3' }}
+        hexpm-mirrors: |
+          https://builds.hex.pm
+          https://repo.hex.pm
+          https://cdn.jsdelivr.net/hex
 
     - name: "Install deps"
-      if: matrix.otp == '24' || matrix.otp == '25'
+      run: brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen ${{ matrix.mbedtls }}
+
+    - name: "Install Gleam"
       run: |
-        brew update
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam ${{ matrix.mbedtls }}
-        wget https://github.com/erlang/rebar3/releases/download/3.23.0/rebar3
-        chmod +x rebar3
-        for bin_dir in {/usr/local,/opt/homebrew}/opt/erlang@{24,25}/bin/ ; do
-            if [ -e ${bin_dir} ]; then
-                sudo cp rebar3 ${bin_dir}
-            fi
-        done
+        # Reuse the OTP/rebar3 installed by setup-beam instead of Homebrew dependencies.
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --ignore-dependencies gleam
+        gleam --version
 
     - name: "Workaround for nxdomain random issues"
       run: |
@@ -126,20 +131,15 @@ jobs:
     - name: "Build: run cmake"
       working-directory: build
       run: |
-        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
         cmake -DAVM_WARNINGS_ARE_ERRORS=ON ${MBEDTLS_PREFIX:+-DCMAKE_PREFIX_PATH="$MBEDTLS_PREFIX"} ${{ matrix.cmake_opts_other }} -G Ninja ..
 
     - name: "Build: run ninja"
       working-directory: build
-      run: |
-        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
-        ninja
+      run: ninja
 
     - name: "Build: run dialyzer"
       working-directory: build
-      run: |
-        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
-        ninja dialyzer
+      run: ninja dialyzer
 
     # Test
     - name: "Test: test-erlang"
@@ -202,7 +202,6 @@ jobs:
     - name: "Install and smoke test"
       working-directory: build
       run: |
-        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
         sudo ninja install
         atomvm examples/erlang/hello_world.avm
         atomvm -v

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -91,15 +91,12 @@ jobs:
         # This is ARM64
         - os: "macos-15"
           otp: "26"
-          path_prefix: "/opt/homebrew/opt/erlang@26/bin:"
 
         - os: "macos-15"
           otp: "27"
-          path_prefix: "/opt/homebrew/opt/erlang@27/bin:"
 
         - os: "macos-15"
           otp: "28"
-          path_prefix: "/opt/homebrew/opt/erlang@28/bin:"
     steps:
     # Setup
     - name: "Checkout repo"
@@ -122,9 +119,23 @@ jobs:
         apt update -y
         apt install -y cmake gperf zlib1g-dev ninja-build
 
+    - name: "Normalize ImageOS for setup-beam"
+      if: matrix.os == 'macos-26'
+      run: echo "ImageOS=macos15" >> "$GITHUB_ENV"
+
+    - uses: erlef/setup-beam@v1
+      if: runner.os == 'macOS'
+      with:
+        otp-version: ${{ matrix.otp }}
+        rebar3-version: ${{ fromJSON('{"26":"3.25.1","27":"3.25.1","28":"3.26"}')[matrix.otp] || '3' }}
+        hexpm-mirrors: |
+          https://builds.hex.pm
+          https://repo.hex.pm
+          https://cdn.jsdelivr.net/hex
+
     - name: "Install deps (macOS)"
       if: runner.os == 'macOS'
-      run: brew update && brew install gperf erlang@${{ matrix.otp }} mbedtls@3 rebar3
+      run: brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf mbedtls@3
 
     - name: "macOS setup mbedtls@3 environment"
       if: runner.os == 'macOS'
@@ -156,7 +167,6 @@ jobs:
     - name: "Build: run cmake"
       working-directory: build
       run: |
-        export PATH="${{ matrix.path_prefix }}$PATH"
         cmake -G Ninja ${MBEDTLS_PREFIX:+-DCMAKE_PREFIX_PATH="$MBEDTLS_PREFIX"} ${{ matrix.cmake_opts }} ..
 
     - name: "Touch files to benefit from cache"
@@ -169,7 +179,6 @@ jobs:
     - name: "Build: run ninja"
       working-directory: build
       run: |
-        export PATH="${{ matrix.path_prefix }}$PATH"
         ninja
 
     # Test
@@ -177,7 +186,6 @@ jobs:
       timeout-minutes: 10
       working-directory: build
       run: |
-        export PATH="${{ matrix.path_prefix }}$PATH"
         ./tests/test-erlang -b ${{ matrix.test_erlang_opts }}
 
     # Test
@@ -185,7 +193,6 @@ jobs:
       timeout-minutes: 10
       working-directory: build
       run: |
-        export PATH="${{ matrix.path_prefix }}$PATH"
         erl -pa tests/libs/estdlib/ -pa tests/libs/estdlib/beams/ -pa libs/etest/src/beams -pa libs/eavmlib/src/beams -pa libs/avm_network/src/beams -s tests -s init stop -noshell
 
     # Test
@@ -193,7 +200,6 @@ jobs:
       timeout-minutes: 10
       working-directory: build
       run: |
-        export PATH="${{ matrix.path_prefix }}$PATH"
         erl -pa tests/libs/etest/beams -s test_eunit test -s init stop -noshell
 
     # Test
@@ -202,5 +208,4 @@ jobs:
       working-directory: build
       if: matrix.otp != '21' && matrix.otp != '22'
       run: |
-        export PATH="${{ matrix.path_prefix }}$PATH"
         erl -pa tests/libs/jit/beams/ libs/jit/src/beams/ libs/etest/src/beams -noshell -s tests -s init stop -noshell


### PR DESCRIPTION
Fixes currently broken CIs for macos

Switch the macOS workflows from Homebrew-managed Erlang/Elixir tooling to erlef/setup-beam, add the macOS 26 ImageOS workaround, and simplify dependency and PATH handling.

Note:
OTP24 is not supported setup-beam - thus removed
Gleam fails installing using setup-beam - thus brew install gleam
macos-26 is not supported setup-beam - thus hackish workaround
rebar3 needs to be specifically set in setup-beam - thus weird conditional
(it can't resolve "3" to a given otp compatible version)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
