### PR TITLE
CI: rename pico combined for release/tag sorting

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -240,7 +240,7 @@ jobs:
       if: matrix.platform == '' && matrix.jit == ''
       shell: bash
       run: |
-        ATOMVM_COMBINED_FILE=AtomVM-combined-${{ matrix.board }}-${{env.AVM_REF_NAME}}.uf2
+        ATOMVM_COMBINED_FILE=AtomVM-${{ matrix.board }}-combined-${{env.AVM_REF_NAME}}.uf2
         ./uf2tool join -o "${ATOMVM_COMBINED_FILE}" src/platforms/rp2/build/src/AtomVM-${{ matrix.board }}-${{env.AVM_REF_NAME}}.uf2 build/libs/atomvmlib-rp2-${{ matrix.board }}-${{env.AVM_REF_NAME}}.uf2
         sha256sum "${ATOMVM_COMBINED_FILE}" > "${ATOMVM_COMBINED_FILE}.sha256"
         echo "ATOMVM_COMBINED_FILE=${ATOMVM_COMBINED_FILE}" >> $GITHUB_ENV


### PR DESCRIPTION
In a release/tag the combined artifacts would be at the top away from the other pico artifacts: 
AtomVM-combined-pico2_w-main-latest.uf2
...
AtomVM-pico2_w-main-latest.uf2

due to alphabetical sorting - renaming fixes that.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
