### PR TITLE
Add timer:send_after/2,3 and apply_after/4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added DWARF debug information support for JIT-compiled code
 - Added I2C and SPI APIs to rp2 platform
 - Added `code:get_object_code/1`
+- Added `timer:send_after/2`, `timer:send_after/3` and `timer:apply_after/4`
 
 ### Changed
 - ~10% binary size reduction by rewriting module loading logic

--- a/libs/estdlib/src/timer.erl
+++ b/libs/estdlib/src/timer.erl
@@ -27,7 +27,7 @@
 %%-----------------------------------------------------------------------------
 -module(timer).
 
--export([sleep/1]).
+-export([sleep/1, send_after/2, send_after/3, apply_after/4]).
 
 %%-----------------------------------------------------------------------------
 %% @param Timeout number of milliseconds to sleep or `infinity'
@@ -43,3 +43,53 @@ sleep(Timeout) ->
     after Timeout ->
         ok
     end.
+
+%%-----------------------------------------------------------------------------
+%% @param Time time in milliseconds after which to send the message.
+%% @param Message the message to send to the calling process.
+%% @returns `{ok, TRef}' where `TRef' is a reference to the timer.
+%%
+%% @doc Sends `Message' to the calling process after `Time' milliseconds.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec send_after(Time :: non_neg_integer(), Message :: term()) -> {ok, reference()}.
+send_after(Time, Message) ->
+    TRef = timer_manager:send_after(Time, self(), Message),
+    {ok, TRef}.
+
+%%-----------------------------------------------------------------------------
+%% @param Time time in milliseconds after which to send the message.
+%% @param Pid the process to which to send the message.
+%% @param Message the message to send.
+%% @returns `{ok, TRef}' where `TRef' is a reference to the timer.
+%%
+%% @doc Sends `Message' to `Pid' after `Time' milliseconds.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec send_after(Time :: non_neg_integer(), Pid :: pid() | atom(), Message :: term()) ->
+    {ok, reference()}.
+send_after(Time, Pid, Message) ->
+    TRef = timer_manager:send_after(Time, Pid, Message),
+    {ok, TRef}.
+
+%%-----------------------------------------------------------------------------
+%% @param Time time in milliseconds after which to apply the function.
+%% @param Module the module of the function to apply.
+%% @param Function the function to apply.
+%% @param Arguments the arguments to pass to the function.
+%% @returns `{ok, TRef}' where `TRef' is a reference to the timer.
+%%
+%% @doc Applies `Module:Function(Arguments)' after `Time' milliseconds.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec apply_after(
+    Time :: non_neg_integer(), Module :: module(), Function :: atom(), Arguments :: [term()]
+) -> {ok, reference()}.
+apply_after(Time, Module, Function, Arguments) ->
+    Pid = spawn(fun() ->
+        receive
+            apply_now -> apply(Module, Function, Arguments)
+        end
+    end),
+    TRef = timer_manager:send_after(Time, Pid, apply_now),
+    {ok, TRef}.

--- a/tests/libs/estdlib/test_timer.erl
+++ b/tests/libs/estdlib/test_timer.erl
@@ -29,6 +29,9 @@ test() ->
     ok = test_timer_loop(),
     ok = test_timer_badargs(),
     ok = test_infinity(),
+    ok = test_send_after_2(),
+    ok = test_send_after_3(),
+    ok = test_apply_after(),
     ok.
 
 test_timer() ->
@@ -79,4 +82,45 @@ test_infinity() ->
     receive
         ok ->
             ok = etest:assert_true(erlang:is_process_alive(Pid))
+    end.
+
+test_send_after_2() ->
+    {ok, _TRef} = timer:send_after(500, hello),
+    receive
+        hello -> {error, too_early}
+    after 250 ->
+        ok
+    end,
+    receive
+        hello -> ok
+    after 10000 ->
+        {error, timeout}
+    end.
+
+test_send_after_3() ->
+    Self = self(),
+    {ok, _TRef} = timer:send_after(500, Self, hello_dest),
+    receive
+        hello_dest -> {error, too_early}
+    after 250 ->
+        ok
+    end,
+    receive
+        hello_dest -> ok
+    after 10000 ->
+        {error, timeout}
+    end.
+
+test_apply_after() ->
+    Self = self(),
+    {ok, _TRef} = timer:apply_after(500, erlang, send, [Self, apply_result]),
+    receive
+        apply_result -> {error, too_early}
+    after 250 ->
+        ok
+    end,
+    receive
+        apply_result -> ok
+    after 10000 ->
+        {error, timeout}
     end.


### PR DESCRIPTION
Implement timer:send_after/2, timer:send_after/3 and timer:apply_after/4 using timer_manager. Add tests for all three functions.

Used by circuits_uart (elixir)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
