### PR TITLE
Prepare v0.7.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0-alpha.1] - Unreleased
+## [0.7.0-alpha.1] - 2026-04-06
 
 ### Added
 - Added `json` module to estdlib, compatible with Erlang/OTP `json` API
@@ -44,6 +44,7 @@ of raising `badarg`
 exception passes through a non-matching catch clause
 
 ### Removed
+- Removed support for OTP versions < 26
 - Removed old `json_encoder` module (now standard Erlang/OTP `json` module is available)
 
 ## [0.7.0-alpha.0] - 2026-03-20
@@ -177,10 +178,6 @@ table.
 - ESP32 ports now flash a complete working image using the `idf.py flash` task.
 - ESP32 platform now uses reproducible builds.
 - C API: `externalterm` module was renamed to `external_term` and it has a completely new API
-
-### Removed
-
-- Removed support for OTP versions < 26
 
 ### Fixed
 

--- a/version.cmake
+++ b/version.cmake
@@ -19,5 +19,5 @@
 #
 
 # Please, keep also in sync src/libAtomVM/atomvm_version.h
-set(ATOMVM_BASE_VERSION "0.7.0-alpha.0")
+set(ATOMVM_BASE_VERSION "0.7.0-alpha.1")
 set(ATOMVM_DEV TRUE)


### PR DESCRIPTION
Update CHANGELOG.md and bump version number.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
