### PR TITLE
Prepare next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0-beta.0] - Unreleased
+
 ## [0.7.0-alpha.1] - 2026-04-06
 
 ### Added

--- a/version.cmake
+++ b/version.cmake
@@ -19,5 +19,5 @@
 #
 
 # Please, keep also in sync src/libAtomVM/atomvm_version.h
-set(ATOMVM_BASE_VERSION "0.7.0-alpha.1")
+set(ATOMVM_BASE_VERSION "0.7.0-beta.0")
 set(ATOMVM_DEV TRUE)


### PR DESCRIPTION
Update CHANGELOG.md, bump version number in version.cmake.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
