### PR TITLE
Fix warning with `os:system_time/1`

### DIFF
--- a/libs/estdlib/src/os.erl
+++ b/libs/estdlib/src/os.erl
@@ -46,5 +46,5 @@ system_time() ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec system_time(TimeUnit :: erlang:time_unit()) -> integer().
-system_time(TimeUnit) ->
+system_time(_TimeUnit) ->
     erlang:nif_error(undefined).


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
