### PR TITLE
STM32 CI: use tag release for renode

### DIFF
--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -192,7 +192,7 @@ jobs:
       run: |
         set -euo pipefail
         mkdir -p renode-portable
-        wget -qO- https://builds.renode.io/renode-latest.linux-portable.tar.gz \
+        wget -qO- https://github.com/renode/renode/releases/download/v1.16.1/renode-1.16.1.linux-portable.tar.gz \
           | tar -xzf - -C renode-portable --strip-components=1
         echo "$PWD/renode-portable" >> $GITHUB_PATH
         pip install -r renode-portable/tests/requirements.txt


### PR DESCRIPTION
Fix CI failure with stm32l562qei6 caused by upstream update of latest binary. Stick to latest release (1.16.1)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
