### PR TITLE
ahttp_client.erl: Add chunked transfer encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added named variable debugging support in DWARF when modules are compiled with `beam_debug_info`
 - Added more reset reasons and ensured `esp:reset_reason/0` doesn't return `undefined`
 - Added I2C and SPI APIs to stm32 platform
+- Added `Transfer-Encoding: chunked` response support to `ahttp_client`, including HTTP trailers
 
 ### Changed
 - Updated network type db() to dbm() to reflect the actual representation of the type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use ES6 modules for emscripten port, using .mjs suffix
 - `ahttp_client` now returns `{error, {parser, incomplete_response}}` when a socket closes mid-response
   (previously silently reported `closed`); `ssl_closed` messages are also handled
+- `ahttp_client` now returns `{error, {parser, {conflicting_content_length, V}}}` when a response
+  carries differing `Content-Length` values (previously silently accepted the last one),
+  per RFC 9112 §6.3
 
 ### Fixed
 - Stop using deprecated `term_from_int32` on STM32 platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed improper cast of ESP32 `event_data` for `WIFI_EVENT_AP_STA(DIS)CONNECTED` events
 - `erlang:system_info(system_architecture)` now reports normalized `arch-vendor-os` strings
 - Fixed `ahttp_client` crash on non-numeric or negative `Content-Length` values
+- Fixed `ahttp_client` crash on headers with empty or all-whitespace values
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ahttp_client` now emits a `done` event for responses with `Content-Length: 0` (previously
   the parser stayed in `body` state forever, hanging passive callers and misflagging legitimate
   close as `incomplete_response`)
+- `ahttp_client` now discards bytes past `Content-Length` and transitions to `done` (previously
+  emitted the excess as body data and stalled the parser when the socket delivered more than
+  the promised byte count)
 
 ### Fixed
 - Stop using deprecated `term_from_int32` on STM32 platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ahttp_client` now discards bytes past `Content-Length` and transitions to `done` (previously
   emitted the excess as body data and stalled the parser when the socket delivered more than
   the promised byte count)
+- `ahttp_client` now caps parsed status, header and chunk-size lines at 16 KiB (`?MAX_LINE_SIZE`);
+  longer lines return `{error, {parser, {line_too_long, Prefix}}}` with the first 128 bytes of
+  the offending line. Callers whose upstream servers emit unusually large headers must account
+  for this limit
 
 ### Removed
 - Removed `ahttp_client` support for obsolete line folding (RFC 9112 §5.2); folded header and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated network type db() to dbm() to reflect the actual representation of the type
 - Use ES6 modules for emscripten port, using .mjs suffix
+- `ahttp_client` now returns `{error, {parser, incomplete_response}}` when a socket closes mid-response
+  (previously silently reported `closed`); `ssl_closed` messages are also handled
 
 ### Fixed
 - Stop using deprecated `term_from_int32` on STM32 platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emitted the excess as body data and stalled the parser when the socket delivered more than
   the promised byte count)
 
+### Removed
+- Removed `ahttp_client` support for obsolete line folding (RFC 9112 §5.2); folded header and
+  trailer lines now return `{error, {parser, deprecated_obs_fold}}`, and the
+  `header_continuation` / `trailer_header_continuation` response events are no longer emitted
+
 ### Fixed
 - Stop using deprecated `term_from_int32` on STM32 platform
 - Stop using deprecated `term_from_int32` on RP2 platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop using deprecated `term_from_int32` on ESP32 platform
 - Fixed improper cast of ESP32 `event_data` for `WIFI_EVENT_AP_STA(DIS)CONNECTED` events
 - `erlang:system_info(system_architecture)` now reports normalized `arch-vendor-os` strings
+- Fixed `ahttp_client` crash on non-numeric or negative `Content-Length` values
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ahttp_client` now returns `{error, {parser, {conflicting_content_length, V}}}` when a response
   carries differing `Content-Length` values (previously silently accepted the last one),
   per RFC 9112 §6.3
+- `ahttp_client` now emits a `done` event for responses with `Content-Length: 0` (previously
+  the parser stayed in `body` state forever, hanging passive callers and misflagging legitimate
+  close as `incomplete_response`)
 
 ### Fixed
 - Stop using deprecated `term_from_int32` on STM32 platform

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -311,6 +311,12 @@ feed_parser(Parser, Chunk) ->
 
 consume_bytes(#parser_state{acc = undefined} = Parser, ParsedAcc) ->
     {ok, Parser, ParsedAcc};
+consume_bytes(
+    #parser_state{acc = Chunk, remaining_body_bytes = N} = Parser, ParsedAcc
+) when is_binary(Chunk) andalso is_integer(N) andalso N > 0 andalso byte_size(Chunk) >= N ->
+    <<Data:N/binary, _Rest/binary>> = Chunk,
+    UpdatedParser = Parser#parser_state{state = done, acc = undefined, remaining_body_bytes = 0},
+    {ok, UpdatedParser, [done, {data, Data} | ParsedAcc]};
 consume_bytes(#parser_state{acc = Chunk} = Parser, ParsedAcc) when is_binary(Chunk) ->
     ReplacedAccParser = replace_chunk(Parser, undefined),
     NewRemBodyBytes = maybe_decrement(

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -23,16 +23,26 @@
 
 -export_type([connection/0, error_tuple/0, backend/0]).
 
--define(DEFAULT_WANTED_HEADERS, [<<"Content-Length">>]).
+-define(DEFAULT_WANTED_HEADERS, [<<"Content-Length">>, <<"Transfer-Encoding">>]).
 
 -type maybe_binary() :: binary() | undefined.
 -type maybe_integer() :: integer() | undefined.
 -type maybe_ref() :: reference() | undefined.
--type maybe_parsing_state() :: headers | body | done | undefined.
+-type maybe_parsing_state() ::
+    headers
+    | body
+    | chunked_size
+    | chunked_body
+    | chunked_crlf
+    | chunked_trailers
+    | done
+    | undefined.
+-type body_encoding() :: chunked | undefined.
 
 -record(parser_state, {
     state :: maybe_parsing_state(),
     acc :: maybe_binary(),
+    body_encoding :: body_encoding(),
     remaining_body_bytes :: maybe_integer(),
     last_header :: maybe_binary() | ignore,
     wanted_headers :: [binary()]
@@ -65,6 +75,9 @@
 -type status_response() :: {status, reference(), 0..999}.
 -type header_response() :: {header, reference(), {binary(), binary()}}.
 -type header_continuation_response() :: {header_continuation, reference(), {binary(), binary()}}.
+-type trailer_header_response() :: {trailer_header, reference(), {binary(), binary()}}.
+-type trailer_header_continuation_response() ::
+    {trailer_header_continuation, reference(), {binary(), binary()}}.
 -type data_response() :: {data, reference(), binary()}.
 -type done_response() :: {done, reference()}.
 
@@ -72,10 +85,12 @@
     status_response()
     | header_response()
     | header_continuation_response()
+    | trailer_header_response()
+    | trailer_header_continuation_response()
     | data_response()
     | done_response().
 
--type error_tuple() :: {error, {backend(), term()}}.
+-type error_tuple() :: {error, {backend(), term()}} | {error, {parser, term()}}.
 
 %%-----------------------------------------------------------------------------
 %% @param   Protocol the protocol, either http or https
@@ -246,22 +261,25 @@ transform_headers([{Name, Value} | Tail]) ->
     {ok, connection(), [response()]} | {ok, connection(), closed} | unknown | error_tuple().
 
 stream(#http_client{socket = {gen_tcp, TSocket}, parser = Parser} = Conn, {tcp, TSocket, Chunk}) ->
-    {ok, UpdatedParser, Parsed} = feed_parser(Parser, Chunk),
-    Responses = make_responses(Parsed, Conn#http_client.ref, []),
-    {ok, Conn#http_client{parser = UpdatedParser}, Responses};
+    dispatch_feed(Conn, Parser, Chunk);
 stream(#http_client{socket = {gen_tcp, TSocket}} = Conn, {tcp_closed, TSocket}) ->
     {ok, Conn, closed};
 stream(#http_client{socket = {ssl, SSLSocket}, parser = Parser} = Conn, {ssl, SSLSocket, Chunk}) ->
-    {ok, UpdatedParser, Parsed} = feed_parser(Parser, Chunk),
-    Responses = make_responses(Parsed, Conn#http_client.ref, []),
-    {ok, Conn#http_client{parser = UpdatedParser}, Responses};
+    dispatch_feed(Conn, Parser, Chunk);
 stream(_Conn, _Other) ->
     unknown.
 
 stream_data(#http_client{parser = Parser} = Conn, Chunk) ->
-    {ok, UpdatedParser, Parsed} = feed_parser(Parser, Chunk),
-    Responses = make_responses(Parsed, Conn#http_client.ref, []),
-    {ok, Conn#http_client{parser = UpdatedParser}, Responses}.
+    dispatch_feed(Conn, Parser, Chunk).
+
+dispatch_feed(Conn, Parser, Chunk) ->
+    case feed_parser(Parser, Chunk) of
+        {ok, UpdatedParser, Parsed} ->
+            Responses = make_responses(Parsed, Conn#http_client.ref, []),
+            {ok, Conn#http_client{parser = UpdatedParser}, Responses};
+        {error, _} = Error ->
+            Error
+    end.
 
 make_responses([], _Ref, Acc) ->
     Acc;
@@ -272,6 +290,8 @@ make_responses([{Tag, Value} | Tail], Ref, Acc) ->
 
 feed_parser(#parser_state{state = body} = Parser, Chunk) ->
     consume_bytes(append_chunk(Parser, Chunk), []);
+feed_parser(#parser_state{state = chunked_body} = Parser, Chunk) ->
+    consume_chunk_data(append_chunk(Parser, Chunk), []);
 feed_parser(Parser, Chunk) ->
     consume_lines(append_chunk(Parser, Chunk), []).
 
@@ -289,6 +309,38 @@ consume_bytes(#parser_state{acc = Chunk} = Parser, ParsedAcc) when is_binary(Chu
     ),
     {ok, UpdatedParser, Parsed}.
 
+consume_chunk_data(#parser_state{acc = undefined} = Parser, ParsedAcc) ->
+    {ok, Parser, ParsedAcc};
+consume_chunk_data(
+    #parser_state{acc = Chunk, remaining_body_bytes = N} = Parser, ParsedAcc
+) when is_binary(Chunk) andalso byte_size(Chunk) < N ->
+    NewN = N - byte_size(Chunk),
+    UpdatedParser = Parser#parser_state{acc = undefined, remaining_body_bytes = NewN},
+    {ok, UpdatedParser, [{data, Chunk} | ParsedAcc]};
+consume_chunk_data(
+    #parser_state{acc = Chunk, remaining_body_bytes = N} = Parser, ParsedAcc
+) when is_binary(Chunk) ->
+    <<Data:N/binary, Rest/binary>> = Chunk,
+    Transitioned = Parser#parser_state{state = chunked_crlf, remaining_body_bytes = 0},
+    Replaced = replace_chunk(Transitioned, Rest),
+    consume_lines(Replaced, [{data, Data} | ParsedAcc]).
+
+parse_chunk_size(Line) ->
+    [HexBin | _Ext] = binary:split(Line, <<";">>),
+    LTrim = trim_left_spaces(HexBin, 0),
+    case LTrim of
+        <<>> ->
+            error;
+        _ ->
+            Trimmed = trim_right_spaces(LTrim, byte_size(LTrim)),
+            try binary_to_integer(Trimmed, 16) of
+                N when N >= 0 -> {ok, N};
+                _ -> error
+            catch
+                error:_ -> error
+            end
+    end.
+
 consume_lines(#parser_state{acc = undefined} = Parser, ParsedAcc) ->
     {ok, Parser, ParsedAcc};
 consume_lines(Parser, ParsedAcc) ->
@@ -300,12 +352,14 @@ consume_lines(Parser, ParsedAcc) ->
             case parse_line(ReplacedAccParser, Line) of
                 {consume_bytes, UpdatedParser} ->
                     consume_bytes(UpdatedParser, ParsedAcc);
+                {consume_chunk_data, UpdatedParser} ->
+                    consume_chunk_data(UpdatedParser, ParsedAcc);
                 {ok, UpdatedParser} ->
                     consume_lines(UpdatedParser, ParsedAcc);
                 {ok, UpdatedParser, Found} ->
                     consume_lines(UpdatedParser, [Found | ParsedAcc]);
-                {error, UpdatedParser, NotParsed} ->
-                    {error, UpdatedParser, ParsedAcc, NotParsed}
+                {error, _UpdatedParser, Reason} ->
+                    {error, {parser, Reason}}
             end
     end.
 
@@ -329,6 +383,13 @@ parse_line(
 ) ->
     StatusCode = binary_to_integer(C),
     {ok, Parser#parser_state{state = headers}, {status, StatusCode}};
+parse_line(
+    #parser_state{state = headers, body_encoding = chunked, remaining_body_bytes = N} = Parser,
+    <<>>
+) when is_integer(N) ->
+    {error, Parser, {content_length_with_transfer_encoding, N}};
+parse_line(#parser_state{state = headers, body_encoding = chunked} = Parser, <<>>) ->
+    {ok, Parser#parser_state{state = chunked_size, last_header = undefined}};
 parse_line(#parser_state{state = headers} = Parser, <<>>) ->
     {consume_bytes, Parser#parser_state{state = body}};
 parse_line(
@@ -346,23 +407,88 @@ parse_line(#parser_state{state = headers, wanted_headers = WantedHeaders} = Pars
         {ok, Name, Value} ->
             LTrimmedValue = trim_left_spaces(Value, 0),
             TrimmedValue = trim_right_spaces(LTrimmedValue, byte_size(LTrimmedValue)),
-            UpdatedParser =
-                case Name of
-                    % this is safe since match_header uses same casing as in WantedHeaders
-                    <<"Content-Length">> ->
-                        RemainingLen = binary_to_integer(TrimmedValue),
-                        Parser#parser_state{remaining_body_bytes = RemainingLen};
-                    _ ->
-                        Parser
-                end,
-            {ok, UpdatedParser#parser_state{last_header = Name}, {header, {Name, TrimmedValue}}};
+            % this is safe since match_header uses same casing as in WantedHeaders
+            case apply_header_semantics(Name, TrimmedValue, Parser) of
+                {ok, UpdatedParser} ->
+                    {ok, UpdatedParser#parser_state{last_header = Name},
+                        {header, {Name, TrimmedValue}}};
+                {error, Reason} ->
+                    {error, Parser, Reason}
+            end;
         ignore ->
-            {ok, Parser#parser_state{last_header = ignore}};
+            {ok, Parser#parser_state{last_header = ignore}}
+    end;
+parse_line(#parser_state{state = chunked_size} = Parser, Line) ->
+    case parse_chunk_size(Line) of
+        {ok, 0} ->
+            {ok, Parser#parser_state{state = chunked_trailers, last_header = undefined}};
+        {ok, N} ->
+            {consume_chunk_data, Parser#parser_state{
+                state = chunked_body, remaining_body_bytes = N
+            }};
         error ->
-            {error, Parser, HeaderLine}
+            {error, Parser, {invalid_chunk_size, Line}}
+    end;
+parse_line(#parser_state{state = chunked_crlf} = Parser, <<>>) ->
+    {ok, Parser#parser_state{state = chunked_size}};
+parse_line(#parser_state{state = chunked_crlf} = Parser, Line) ->
+    {error, Parser, {expected_chunk_crlf, Line}};
+parse_line(#parser_state{state = chunked_trailers} = Parser, <<>>) ->
+    {ok, Parser#parser_state{state = done}, done};
+parse_line(
+    #parser_state{state = chunked_trailers, last_header = ignore} = Parser,
+    <<C, _MultiLine/binary>>
+) when C == $\s orelse C == $\t ->
+    {ok, Parser};
+parse_line(
+    #parser_state{state = chunked_trailers, last_header = LastH} = Parser,
+    <<C, MultiLine/binary>>
+) when is_binary(LastH) andalso (C == $\s orelse C == $\t) ->
+    LTrimmedValue = trim_left_spaces(MultiLine, 0),
+    TrimmedValue = trim_right_spaces(LTrimmedValue, byte_size(LTrimmedValue)),
+    {ok, Parser, {trailer_header_continuation, {LastH, TrimmedValue}}};
+parse_line(
+    #parser_state{state = chunked_trailers, wanted_headers = WantedHeaders} = Parser, HeaderLine
+) ->
+    case match_header(WantedHeaders, HeaderLine) of
+        {ok, Name, Value} ->
+            case is_forbidden_trailer_field(Name) of
+                true ->
+                    {ok, Parser#parser_state{last_header = ignore}};
+                false ->
+                    LTrimmedValue = trim_left_spaces(Value, 0),
+                    TrimmedValue = trim_right_spaces(LTrimmedValue, byte_size(LTrimmedValue)),
+                    {ok, Parser#parser_state{last_header = Name},
+                        {trailer_header, {Name, TrimmedValue}}}
+            end;
+        ignore ->
+            {ok, Parser#parser_state{last_header = ignore}}
     end;
 parse_line(Parser, Any) ->
-    {error, Parser, Any}.
+    {error, Parser, {invalid_line, Any}}.
+
+apply_header_semantics(<<"Content-Length">>, Value, Parser) ->
+    {ok, Parser#parser_state{remaining_body_bytes = binary_to_integer(Value)}};
+apply_header_semantics(<<"Transfer-Encoding">>, Value, Parser) ->
+    case te_is_chunked(Value) of
+        true -> {ok, Parser#parser_state{body_encoding = chunked}};
+        false -> {error, {unsupported_transfer_encoding, Value}}
+    end;
+apply_header_semantics(_Name, _Value, Parser) ->
+    {ok, Parser}.
+
+%% Only bare "chunked" is accepted; stacked codings like "gzip, chunked" (valid per RFC 9112 §6.1)
+%% would deliver undecoded bytes since this client has no gzip/compress/deflate decoder.
+te_is_chunked(Value) ->
+    case byte_size(Value) =:= byte_size(<<"chunked">>) of
+        true -> icmp(Value, <<"chunked">>);
+        false -> false
+    end.
+
+%% Framing-affecting fields filtered from trailers (subset of RFC 9110 §6.5.1).
+is_forbidden_trailer_field(<<"Content-Length">>) -> true;
+is_forbidden_trailer_field(<<"Transfer-Encoding">>) -> true;
+is_forbidden_trailer_field(_) -> false.
 
 trim_left_spaces(Bin, Count) ->
     case Bin of

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -74,19 +74,14 @@
 
 -type status_response() :: {status, reference(), 0..999}.
 -type header_response() :: {header, reference(), {binary(), binary()}}.
--type header_continuation_response() :: {header_continuation, reference(), {binary(), binary()}}.
 -type trailer_header_response() :: {trailer_header, reference(), {binary(), binary()}}.
--type trailer_header_continuation_response() ::
-    {trailer_header_continuation, reference(), {binary(), binary()}}.
 -type data_response() :: {data, reference(), binary()}.
 -type done_response() :: {done, reference()}.
 
 -type response() ::
     status_response()
     | header_response()
-    | header_continuation_response()
     | trailer_header_response()
-    | trailer_header_continuation_response()
     | data_response()
     | done_response().
 
@@ -421,16 +416,10 @@ parse_line(#parser_state{state = headers, remaining_body_bytes = 0} = Parser, <<
     {ok, Parser#parser_state{state = done, last_header = undefined}, done};
 parse_line(#parser_state{state = headers} = Parser, <<>>) ->
     {consume_bytes, Parser#parser_state{state = body}};
-parse_line(
-    #parser_state{state = headers, last_header = ignore} = Parser, <<C, _MultiLine/binary>>
-) when C == $\s orelse C == $\t ->
-    {ok, Parser};
-parse_line(
-    #parser_state{state = headers, last_header = LastH} = Parser, <<C, MultiLine/binary>>
-) when is_binary(LastH) andalso (C == $\s orelse C == $\t) ->
-    LTrimmedValue = trim_left_spaces(MultiLine, 0),
-    TrimmedValue = trim_right_spaces(LTrimmedValue, byte_size(LTrimmedValue)),
-    {ok, Parser, {header_continuation, {LastH, TrimmedValue}}};
+parse_line(#parser_state{state = headers} = Parser, <<C, _Rest/binary>> = Line) when
+    C == $\s orelse C == $\t
+->
+    {error, Parser, {deprecated_obs_fold, Line}};
 parse_line(#parser_state{state = headers, wanted_headers = WantedHeaders} = Parser, HeaderLine) ->
     case match_header(WantedHeaders, HeaderLine) of
         {ok, Name, Value} ->
@@ -464,18 +453,10 @@ parse_line(#parser_state{state = chunked_crlf} = Parser, Line) ->
     {error, Parser, {expected_chunk_crlf, Line}};
 parse_line(#parser_state{state = chunked_trailers} = Parser, <<>>) ->
     {ok, Parser#parser_state{state = done}, done};
-parse_line(
-    #parser_state{state = chunked_trailers, last_header = ignore} = Parser,
-    <<C, _MultiLine/binary>>
-) when C == $\s orelse C == $\t ->
-    {ok, Parser};
-parse_line(
-    #parser_state{state = chunked_trailers, last_header = LastH} = Parser,
-    <<C, MultiLine/binary>>
-) when is_binary(LastH) andalso (C == $\s orelse C == $\t) ->
-    LTrimmedValue = trim_left_spaces(MultiLine, 0),
-    TrimmedValue = trim_right_spaces(LTrimmedValue, byte_size(LTrimmedValue)),
-    {ok, Parser, {trailer_header_continuation, {LastH, TrimmedValue}}};
+parse_line(#parser_state{state = chunked_trailers} = Parser, <<C, _Rest/binary>> = Line) when
+    C == $\s orelse C == $\t
+->
+    {error, Parser, {deprecated_obs_fold, Line}};
 parse_line(
     #parser_state{state = chunked_trailers, wanted_headers = WantedHeaders} = Parser, HeaderLine
 ) ->

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -505,6 +505,8 @@ trim_left_spaces(Bin, Count) ->
             NoLeftSpaces
     end.
 
+trim_right_spaces(_Bin, 0) ->
+    <<>>;
 trim_right_spaces(Bin, Count) ->
     Len = Count - 1,
     case Bin of

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -255,6 +255,13 @@ transform_headers([{Name, Value} | Tail]) ->
 %%
 %%          Since the response might span multiple socket messages, `stream/2' may be called
 %%          multiple times. Each time the latest `UpdatedConn' must be used.
+%%
+%%          Binaries in `{data, Ref, Binary}' responses are sub-binaries of the socket
+%%          receive buffer; the client never copies. This is the right default for the
+%%          common case of piping chunks straight into another parser (e.g. a JSON
+%%          decoder) that consumes and drops them before the next call. Callers who
+%%          retain a chunk beyond the current processing step should call
+%%          `binary:copy/1' on it first so the underlying receive buffer can be released.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec stream(Conn :: connection(), Msg :: socket_message()) ->

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -468,7 +468,14 @@ parse_line(Parser, Any) ->
     {error, Parser, {invalid_line, Any}}.
 
 apply_header_semantics(<<"Content-Length">>, Value, Parser) ->
-    {ok, Parser#parser_state{remaining_body_bytes = binary_to_integer(Value)}};
+    try binary_to_integer(Value) of
+        N when N >= 0 ->
+            {ok, Parser#parser_state{remaining_body_bytes = N}};
+        _ ->
+            {error, {invalid_content_length, Value}}
+    catch
+        error:badarg -> {error, {invalid_content_length, Value}}
+    end;
 apply_header_semantics(<<"Transfer-Encoding">>, Value, Parser) ->
     case te_is_chunked(Value) of
         true -> {ok, Parser#parser_state{body_encoding = chunked}};

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -24,6 +24,7 @@
 -export_type([connection/0, error_tuple/0, backend/0]).
 
 -define(DEFAULT_WANTED_HEADERS, [<<"Content-Length">>, <<"Transfer-Encoding">>]).
+-define(MAX_LINE_SIZE, 16384).
 
 -type maybe_binary() :: binary() | undefined.
 -type maybe_integer() :: integer() | undefined.
@@ -257,6 +258,11 @@ transform_headers([{Name, Value} | Tail]) ->
 %%          decoder) that consumes and drops them before the next call. Callers who
 %%          retain a chunk beyond the current processing step should call
 %%          `binary:copy/1' on it first so the underlying receive buffer can be released.
+%%
+%%          Individual response headers are limited to 16 KiB. A response whose
+%%          header exceeds this size returns `{error, {parser, line_too_long}}'.
+%%          The same size limit also applies to the HTTP status line and, for
+%%          chunked transfer-encoded responses, to each chunk-size line.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec stream(Conn :: connection(), Msg :: socket_message()) ->
@@ -363,12 +369,20 @@ parse_chunk_size(Line) ->
             end
     end.
 
+%% TODO: pair MAX_LINE_SIZE with a recv/stream timeout — slow-drip peers can
+%% still tie up a connection under the memory cap.
 consume_lines(#parser_state{acc = undefined} = Parser, ParsedAcc) ->
     {ok, Parser, ParsedAcc};
 consume_lines(Parser, ParsedAcc) ->
     case binary:split(Parser#parser_state.acc, <<"\r\n">>) of
+        [NotTerminatedLine] when byte_size(NotTerminatedLine) > ?MAX_LINE_SIZE ->
+            <<Prefix:128/binary, _/binary>> = NotTerminatedLine,
+            {error, {parser, {line_too_long, Prefix}}};
         [_NotTerminatedLine] ->
             {ok, Parser, ParsedAcc};
+        [Line, _Rest] when byte_size(Line) > ?MAX_LINE_SIZE ->
+            <<Prefix:128/binary, _/binary>> = Line,
+            {error, {parser, {line_too_long, Prefix}}};
         [Line, Rest] ->
             ReplacedAccParser = replace_chunk(Parser, Rest),
             case parse_line(ReplacedAccParser, Line) of

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -263,6 +263,15 @@ transform_headers([{Name, Value} | Tail]) ->
 %%          header exceeds this size returns `{error, {parser, line_too_long}}'.
 %%          The same size limit also applies to the HTTP status line and, for
 %%          chunked transfer-encoded responses, to each chunk-size line.
+%%
+%%          When the peer closes the connection after a complete response (or
+%%          before any request was sent), `stream/2' returns
+%%          `{ok, Conn, closed}' — a distinct ok marker that callers can use
+%%          to stop their receive loop. A close that arrives while the parser
+%%          is still mid-response returns `{error, {parser, incomplete_response}}'.
+%%          The passive-mode `recv/2' uses a different shape on close
+%%          (`{error, {SocketType, closed}}') because it inherits the native
+%%          `gen_tcp:recv/2' / `ssl:recv/2' contract; see `recv/2'.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec stream(Conn :: connection(), Msg :: socket_message()) ->
@@ -621,6 +630,15 @@ stream_request_body(#http_client{socket = Socket, ref = Ref} = Conn, Ref, BodyCh
 %%          `{active, false}'.
 %%
 %%          See also `stream/2' for more information about the responses list.
+%%
+%%          A peer close after a complete response returns
+%%          `{error, {SocketType, closed}}', matching the native
+%%          `gen_tcp:recv/2' / `ssl:recv/2' contract unchanged. A close
+%%          mid-response returns `{error, {parser, incomplete_response}}'. This
+%%          differs from active-mode `stream/2', which uses
+%%          `{ok, Conn, closed}' for a normal close — passive mode surfaces
+%%          close as an error so a straightforward `case recv/2' in the
+%%          caller stays a single match on `{ok, _, _}'.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec recv(Conn :: connection(), Len :: non_neg_integer()) ->

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -404,6 +404,8 @@ parse_line(
     {error, Parser, {content_length_with_transfer_encoding, N}};
 parse_line(#parser_state{state = headers, body_encoding = chunked} = Parser, <<>>) ->
     {ok, Parser#parser_state{state = chunked_size, last_header = undefined}};
+parse_line(#parser_state{state = headers, remaining_body_bytes = 0} = Parser, <<>>) ->
+    {ok, Parser#parser_state{state = done, last_header = undefined}, done};
 parse_line(#parser_state{state = headers} = Parser, <<>>) ->
     {consume_bytes, Parser#parser_state{state = body}};
 parse_line(

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -355,12 +355,12 @@ consume_chunk_data(
 
 parse_chunk_size(Line) ->
     [HexBin | _Ext] = binary:split(Line, <<";">>),
-    LTrim = trim_left_spaces(HexBin, 0),
+    LTrim = trim_ows_left(HexBin),
     case LTrim of
         <<>> ->
             error;
         _ ->
-            Trimmed = trim_right_spaces(LTrim, byte_size(LTrim)),
+            Trimmed = trim_ows_right(LTrim),
             try binary_to_integer(Trimmed, 16) of
                 N when N >= 0 -> {ok, N};
                 _ -> error
@@ -437,8 +437,8 @@ parse_line(#parser_state{state = headers} = Parser, <<C, _Rest/binary>> = Line) 
 parse_line(#parser_state{state = headers, wanted_headers = WantedHeaders} = Parser, HeaderLine) ->
     case match_header(WantedHeaders, HeaderLine) of
         {ok, Name, Value} ->
-            LTrimmedValue = trim_left_spaces(Value, 0),
-            TrimmedValue = trim_right_spaces(LTrimmedValue, byte_size(LTrimmedValue)),
+            LTrimmedValue = trim_ows_left(Value),
+            TrimmedValue = trim_ows_right(LTrimmedValue),
             % this is safe since match_header uses same casing as in WantedHeaders
             case apply_header_semantics(Name, TrimmedValue, Parser) of
                 {ok, UpdatedParser} ->
@@ -480,8 +480,8 @@ parse_line(
                 true ->
                     {ok, Parser#parser_state{last_header = ignore}};
                 false ->
-                    LTrimmedValue = trim_left_spaces(Value, 0),
-                    TrimmedValue = trim_right_spaces(LTrimmedValue, byte_size(LTrimmedValue)),
+                    LTrimmedValue = trim_ows_left(Value),
+                    TrimmedValue = trim_ows_right(LTrimmedValue),
                     {ok, Parser#parser_state{last_header = Name},
                         {trailer_header, {Name, TrimmedValue}}}
             end;
@@ -528,23 +528,21 @@ is_forbidden_trailer_field(<<"Content-Length">>) -> true;
 is_forbidden_trailer_field(<<"Transfer-Encoding">>) -> true;
 is_forbidden_trailer_field(_) -> false.
 
-trim_left_spaces(Bin, Count) ->
-    case Bin of
-        <<_Bin:Count/binary, C, _Rest/binary>> when C == $\s orelse C == $\t ->
-            trim_left_spaces(Bin, Count + 1);
-        <<_Bin:Count/binary, NoLeftSpaces/binary>> ->
-            NoLeftSpaces
-    end.
+%% Trim HTTP OWS (RFC 9110 §5.6.3: OWS = *( SP / HTAB )) from the left.
+trim_ows_left(<<$\s, Rest/binary>>) -> trim_ows_left(Rest);
+trim_ows_left(<<$\t, Rest/binary>>) -> trim_ows_left(Rest);
+trim_ows_left(Bin) -> Bin.
 
-trim_right_spaces(_Bin, 0) ->
+trim_ows_right(Bin) ->
+    trim_ows_right(Bin, byte_size(Bin)).
+trim_ows_right(_Bin, 0) ->
     <<>>;
-trim_right_spaces(Bin, Count) ->
-    Len = Count - 1,
-    case Bin of
-        <<_LBin:Len/binary, C, _TrimmedSpaces/binary>> when C == $\s orelse C == $\t ->
-            trim_right_spaces(Bin, Count - 1);
-        <<LBin:Count/binary, _TrimmedSpaces/binary>> ->
-            LBin
+trim_ows_right(Bin, Len) ->
+    case binary:at(Bin, Len - 1) of
+        C when C =:= $\s orelse C =:= $\t ->
+            trim_ows_right(Bin, Len - 1);
+        _ ->
+            binary:part(Bin, 0, Len)
     end.
 
 maybe_decrement(undefined, _B) ->

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -262,12 +262,26 @@ transform_headers([{Name, Value} | Tail]) ->
 
 stream(#http_client{socket = {gen_tcp, TSocket}, parser = Parser} = Conn, {tcp, TSocket, Chunk}) ->
     dispatch_feed(Conn, Parser, Chunk);
-stream(#http_client{socket = {gen_tcp, TSocket}} = Conn, {tcp_closed, TSocket}) ->
-    {ok, Conn, closed};
+stream(#http_client{socket = {gen_tcp, TSocket}, parser = Parser} = Conn, {tcp_closed, TSocket}) ->
+    case is_parser_truncated(Parser) of
+        false -> {ok, Conn, closed};
+        true -> {error, {parser, incomplete_response}}
+    end;
 stream(#http_client{socket = {ssl, SSLSocket}, parser = Parser} = Conn, {ssl, SSLSocket, Chunk}) ->
     dispatch_feed(Conn, Parser, Chunk);
+stream(#http_client{socket = {ssl, SSLSocket}, parser = Parser} = Conn, {ssl_closed, SSLSocket}) ->
+    case is_parser_truncated(Parser) of
+        false -> {ok, Conn, closed};
+        true -> {error, {parser, incomplete_response}}
+    end;
 stream(_Conn, _Other) ->
     unknown.
+
+is_parser_truncated(undefined) -> false;
+is_parser_truncated(#parser_state{state = done}) -> false;
+is_parser_truncated(#parser_state{state = undefined}) -> false;
+is_parser_truncated(#parser_state{state = body, remaining_body_bytes = undefined}) -> false;
+is_parser_truncated(_) -> true.
 
 stream_data(#http_client{parser = Parser} = Conn, Chunk) ->
     dispatch_feed(Conn, Parser, Chunk).
@@ -597,10 +611,17 @@ stream_request_body(#http_client{socket = Socket, ref = Ref} = Conn, Ref, BodyCh
 -spec recv(Conn :: connection(), Len :: non_neg_integer()) ->
     {ok, connection(), [response()]} | error_tuple().
 
-recv(#http_client{socket = {SocketType, _}} = Conn, Len) ->
+recv(#http_client{socket = {SocketType, _}, parser = Parser} = Conn, Len) ->
     case socket_recv(Conn, Len) of
-        {ok, Data} -> stream_data(Conn, Data);
-        {error, Reason} -> {error, {SocketType, Reason}}
+        {ok, Data} ->
+            stream_data(Conn, Data);
+        {error, closed} ->
+            case is_parser_truncated(Parser) of
+                false -> {error, {SocketType, closed}};
+                true -> {error, {parser, incomplete_response}}
+            end;
+        {error, Reason} ->
+            {error, {SocketType, Reason}}
     end.
 
 socket_recv(#http_client{socket = {gen_tcp, TCPSocket}}, Len) ->

--- a/libs/avm_network/src/ahttp_client.erl
+++ b/libs/avm_network/src/ahttp_client.erl
@@ -484,7 +484,14 @@ parse_line(Parser, Any) ->
 apply_header_semantics(<<"Content-Length">>, Value, Parser) ->
     try binary_to_integer(Value) of
         N when N >= 0 ->
-            {ok, Parser#parser_state{remaining_body_bytes = N}};
+            case Parser#parser_state.remaining_body_bytes of
+                undefined ->
+                    {ok, Parser#parser_state{remaining_body_bytes = N}};
+                N ->
+                    {ok, Parser};
+                _Other ->
+                    {error, {conflicting_content_length, Value}}
+            end;
         _ ->
             {error, {invalid_content_length, Value}}
     catch

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -37,6 +37,8 @@ test() ->
     ok = test_content_length_and_transfer_encoding(),
     ok = test_transfer_encoding_before_content_length(),
     ok = test_chunked_trailer_framing_filtered(),
+    ok = test_bad_content_length_non_numeric(),
+    ok = test_bad_content_length_negative(),
     ok.
 
 test_passive() ->
@@ -353,6 +355,40 @@ test_chunked_trailer_framing_filtered() ->
     Acc = loop_collect_passive(Conn2, #{}),
     #{status := 200, body := <<"Hello">>, done := true} = Acc,
     [] = maps:get(trailers, Acc, []),
+    wait_server(ServerPid),
+    ok.
+
+test_bad_content_length_non_numeric() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: abc\r\n\r\n"
+            "whatever"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {invalid_content_length, <<"abc">>}}} =
+        ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_bad_content_length_negative() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: -1\r\n\r\n"
+            "whatever"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {invalid_content_length, <<"-1">>}}} =
+        ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
     wait_server(ServerPid),
     ok.
 

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -26,6 +26,17 @@ test() ->
     ok = test_active(),
     ok = test_passive_socket(),
     ok = test_active_socket(),
+    ok = test_chunked_passive(),
+    ok = test_chunked_active(),
+    ok = test_chunked_split_across_segments(),
+    ok = test_chunked_extension(),
+    ok = test_chunked_trailer(),
+    ok = test_bad_transfer_encoding(),
+    ok = test_bad_transfer_encoding_stacked(),
+    ok = test_bad_transfer_encoding_bad_order(),
+    ok = test_content_length_and_transfer_encoding(),
+    ok = test_transfer_encoding_before_content_length(),
+    ok = test_chunked_trailer_framing_filtered(),
     ok.
 
 test_passive() ->
@@ -158,3 +169,318 @@ parse_responses(
     _Expected
 ) ->
     Resp#{done => true}.
+
+test_chunked_passive() ->
+    Response = build_chunked_response([], [<<"Hello">>, <<"World">>], []),
+    {ServerPid, Port} = start_chunked_server([Response]),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{status := 200, body := <<"HelloWorld">>, done := true} = Acc,
+    wait_server(ServerPid),
+    ok.
+
+test_chunked_active() ->
+    Response = build_chunked_response([], [<<"ping">>], []),
+    {ServerPid, Port} = start_chunked_server([Response]),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, true}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_active(Conn2, #{}),
+    #{status := 200, body := <<"ping">>, done := true} = Acc,
+    wait_server(ServerPid),
+    ok.
+
+test_chunked_split_across_segments() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+            "a\r\n12345"
+        >>,
+        <<"67890\r\n0\r\n\r\n">>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{status := 200, body := <<"1234567890">>, done := true} = Acc,
+    wait_server(ServerPid),
+    ok.
+
+test_chunked_extension() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+            "5;foo=bar\r\nHello\r\n"
+            "0\r\n\r\n"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{status := 200, body := <<"Hello">>, done := true} = Acc,
+    wait_server(ServerPid),
+    ok.
+
+test_chunked_trailer() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+            "5\r\nHello\r\n"
+            "0\r\nX-Digest: sha256-abc\r\n\r\n"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [
+        {active, false}, {parse_headers, [<<"X-Digest">>]}
+    ]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{
+        status := 200,
+        body := <<"Hello">>,
+        done := true,
+        trailers := [{<<"X-Digest">>, <<"sha256-abc">>}]
+    } = Acc,
+    wait_server(ServerPid),
+    ok.
+
+test_bad_transfer_encoding() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: gzip\r\n\r\n"
+            "whatever"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {unsupported_transfer_encoding, <<"gzip">>}}} =
+        ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_bad_transfer_encoding_stacked() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: gzip, chunked\r\n\r\n"
+            "whatever"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {unsupported_transfer_encoding, <<"gzip, chunked">>}}} =
+        ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_bad_transfer_encoding_bad_order() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked, gzip\r\n\r\n"
+            "whatever"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {unsupported_transfer_encoding, <<"chunked, gzip">>}}} =
+        ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_content_length_and_transfer_encoding() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 5\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+            "5\r\nHello\r\n0\r\n\r\n"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {content_length_with_transfer_encoding, 5}}} =
+        ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_transfer_encoding_before_content_length() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "Content-Length: 5\r\n\r\n"
+            "5\r\nHello\r\n0\r\n\r\n"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {content_length_with_transfer_encoding, 5}}} =
+        ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_chunked_trailer_framing_filtered() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+            "5\r\nHello\r\n"
+            "0\r\n"
+            "Content-Length: 99999\r\n"
+            "Transfer-Encoding: identity\r\n"
+            "\r\n"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{status := 200, body := <<"Hello">>, done := true} = Acc,
+    [] = maps:get(trailers, Acc, []),
+    wait_server(ServerPid),
+    ok.
+
+build_chunked_response(ExtraHeaders, Chunks, Trailers) ->
+    HeaderLines = [[N, <<": ">>, V, <<"\r\n">>] || {N, V} <- ExtraHeaders],
+    ChunkLines = [
+        [integer_to_binary(byte_size(C), 16), <<"\r\n">>, C, <<"\r\n">>]
+     || C <- Chunks
+    ],
+    TrailerLines = [[N, <<": ">>, V, <<"\r\n">>] || {N, V} <- Trailers],
+    iolist_to_binary([
+        <<"HTTP/1.1 200 OK\r\n">>,
+        <<"Transfer-Encoding: chunked\r\n">>,
+        HeaderLines,
+        <<"\r\n">>,
+        ChunkLines,
+        <<"0\r\n">>,
+        TrailerLines,
+        <<"\r\n">>
+    ]).
+
+start_chunked_server(Segments) ->
+    Parent = self(),
+    Pid = spawn(fun() -> chunked_server_loop(Parent, Segments) end),
+    receive
+        {server_port, Pid, Port} -> {Pid, Port}
+    after 5000 ->
+        exit(Pid, kill),
+        error(server_start_timeout)
+    end.
+
+chunked_server_loop(Parent, Segments) ->
+    {ok, LSocket} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    {ok, Port} = inet:port(LSocket),
+    Parent ! {server_port, self(), Port},
+    {ok, Socket} = gen_tcp:accept(LSocket, 5000),
+    ok = drain_request_headers(Socket),
+    send_segments(Socket, Segments),
+    gen_tcp:close(Socket),
+    gen_tcp:close(LSocket).
+
+drain_request_headers(Socket) ->
+    drain_request_headers(Socket, <<>>).
+
+drain_request_headers(Socket, Acc) ->
+    case gen_tcp:recv(Socket, 0, 2000) of
+        {ok, Data} ->
+            NewAcc = <<Acc/binary, Data/binary>>,
+            case binary:match(NewAcc, <<"\r\n\r\n">>) of
+                nomatch -> drain_request_headers(Socket, NewAcc);
+                _ -> ok
+            end;
+        {error, _} ->
+            ok
+    end.
+
+send_segments(_Socket, []) ->
+    ok;
+send_segments(Socket, [Segment | Rest]) ->
+    ok = gen_tcp:send(Socket, Segment),
+    case Rest of
+        [] -> ok;
+        _ -> receive
+            after 50 -> ok
+            end
+    end,
+    send_segments(Socket, Rest).
+
+wait_server(Pid) ->
+    Ref = monitor(process, Pid),
+    receive
+        {'DOWN', Ref, process, Pid, _} -> ok
+    after 5000 ->
+        demonitor(Ref, [flush]),
+        exit(Pid, kill),
+        error(server_did_not_exit)
+    end.
+
+loop_collect_passive(Conn, Acc) ->
+    case ahttp_client:recv(Conn, 0) of
+        {ok, UpdatedConn, Responses} ->
+            NewAcc = accumulate(Responses, Acc),
+            case maps:is_key(done, NewAcc) of
+                true ->
+                    ahttp_client:close(UpdatedConn),
+                    NewAcc;
+                false ->
+                    loop_collect_passive(UpdatedConn, NewAcc)
+            end
+    end.
+
+loop_collect_active(Conn, Acc) ->
+    receive
+        Msg ->
+            case ahttp_client:stream(Conn, Msg) of
+                {ok, _Conn, closed} ->
+                    Acc;
+                {ok, UpdatedConn, Responses} ->
+                    NewAcc = accumulate(Responses, Acc),
+                    case maps:is_key(done, NewAcc) of
+                        true ->
+                            ahttp_client:close(UpdatedConn),
+                            NewAcc;
+                        false ->
+                            loop_collect_active(UpdatedConn, NewAcc)
+                    end;
+                unknown ->
+                    loop_collect_active(Conn, Acc)
+            end
+    after 5000 ->
+        error(no_response_timeout)
+    end.
+
+accumulate([], Acc) ->
+    Acc;
+accumulate([{status, _, Code} | T], Acc) ->
+    accumulate(T, Acc#{status => Code});
+accumulate([{header, _, _KV} | T], Acc) ->
+    accumulate(T, Acc#{has_headers => true});
+accumulate([{header_continuation, _, _KV} | T], Acc) ->
+    accumulate(T, Acc);
+accumulate([{trailer_header, _, KV} | T], Acc) ->
+    Ts = maps:get(trailers, Acc, []),
+    accumulate(T, Acc#{trailers => [KV | Ts]});
+accumulate([{trailer_header_continuation, _, _KV} | T], Acc) ->
+    accumulate(T, Acc);
+accumulate([{data, _, Data} | T], Acc) ->
+    Body = maps:get(body, Acc, <<>>),
+    accumulate(T, Acc#{body => <<Body/binary, Data/binary>>});
+accumulate([{done, _} | T], Acc) ->
+    accumulate(T, Acc#{done => true}).

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -39,6 +39,7 @@ test() ->
     ok = test_chunked_trailer_framing_filtered(),
     ok = test_bad_content_length_non_numeric(),
     ok = test_bad_content_length_negative(),
+    ok = test_empty_header_value(),
     ok.
 
 test_passive() ->
@@ -389,6 +390,27 @@ test_bad_content_length_negative() ->
     {error, {parser, {invalid_content_length, <<"-1">>}}} =
         ahttp_client:recv(Conn2, 0),
     ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_empty_header_value() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "X-Empty:\r\n"
+            "X-Spaces:    \r\n"
+            "Content-Length: 5\r\n"
+            "\r\n"
+            "Hello"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [
+        {active, false}, {parse_headers, [<<"X-Empty">>, <<"X-Spaces">>]}
+    ]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{status := 200, body := <<"Hello">>, done := true} = Acc,
     wait_server(ServerPid),
     ok.
 

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -42,6 +42,7 @@ test() ->
     ok = test_duplicate_content_length_same_value(),
     ok = test_conflicting_content_length(),
     ok = test_content_length_zero(),
+    ok = test_content_length_overrun(),
     ok = test_empty_header_value(),
     ok = test_chunked_truncated(),
     ok.
@@ -445,6 +446,22 @@ test_content_length_zero() ->
     Acc = loop_collect_passive(Conn2, #{}),
     #{status := 204, done := true} = Acc,
     <<>> = maps:get(body, Acc, <<>>),
+    wait_server(ServerPid),
+    ok.
+
+test_content_length_overrun() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 5\r\n\r\n"
+            "HelloExtra"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{status := 200, body := <<"Hello">>, done := true} = Acc,
     wait_server(ServerPid),
     ok.
 

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -39,6 +39,7 @@ test() ->
     ok = test_chunked_trailer_framing_filtered(),
     ok = test_obs_fold_rejected(),
     ok = test_obs_fold_rejected_trailer(),
+    ok = test_header_line_too_long(),
     ok = test_bad_content_length_non_numeric(),
     ok = test_bad_content_length_negative(),
     ok = test_duplicate_content_length_same_value(),
@@ -341,6 +342,22 @@ test_transfer_encoding_before_content_length() ->
     {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
     {error, {parser, {content_length_with_transfer_encoding, 5}}} =
         ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_header_line_too_long() ->
+    %% One header line well over the 16 KiB cap; CRLF never arrives inside the limit.
+    LongValue = binary:copy(<<$A>>, 20000),
+    Segments = [
+        <<"HTTP/1.1 200 OK\r\n">>,
+        <<"X-Huge: ", LongValue/binary, "\r\n">>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    ExpectedPrefix = <<"X-Huge: ", (binary:copy(<<$A>>, 120))/binary>>,
+    {error, {parser, {line_too_long, ExpectedPrefix}}} = drain_until_error(Conn2),
     ahttp_client:close(Conn2),
     wait_server(ServerPid),
     ok.

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -39,6 +39,8 @@ test() ->
     ok = test_chunked_trailer_framing_filtered(),
     ok = test_bad_content_length_non_numeric(),
     ok = test_bad_content_length_negative(),
+    ok = test_duplicate_content_length_same_value(),
+    ok = test_conflicting_content_length(),
     ok = test_empty_header_value(),
     ok = test_chunked_truncated(),
     ok.
@@ -389,6 +391,41 @@ test_bad_content_length_negative() ->
     {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
     {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
     {error, {parser, {invalid_content_length, <<"-1">>}}} =
+        ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_duplicate_content_length_same_value() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 5\r\n"
+            "Content-Length: 5\r\n\r\n"
+            "Hello"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{status := 200, body := <<"Hello">>, done := true} = Acc,
+    wait_server(ServerPid),
+    ok.
+
+test_conflicting_content_length() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 5\r\n"
+            "Content-Length: 10\r\n\r\n"
+            "Hello"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {conflicting_content_length, <<"10">>}}} =
         ahttp_client:recv(Conn2, 0),
     ahttp_client:close(Conn2),
     wait_server(ServerPid),

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -41,6 +41,7 @@ test() ->
     ok = test_bad_content_length_negative(),
     ok = test_duplicate_content_length_same_value(),
     ok = test_conflicting_content_length(),
+    ok = test_content_length_zero(),
     ok = test_empty_header_value(),
     ok = test_chunked_truncated(),
     ok.
@@ -428,6 +429,22 @@ test_conflicting_content_length() ->
     {error, {parser, {conflicting_content_length, <<"10">>}}} =
         ahttp_client:recv(Conn2, 0),
     ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_content_length_zero() ->
+    Segments = [
+        <<
+            "HTTP/1.1 204 No Content\r\n"
+            "Content-Length: 0\r\n\r\n"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    Acc = loop_collect_passive(Conn2, #{}),
+    #{status := 204, done := true} = Acc,
+    <<>> = maps:get(body, Acc, <<>>),
     wait_server(ServerPid),
     ok.
 

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -48,6 +48,8 @@ test() ->
     ok = test_content_length_overrun(),
     ok = test_empty_header_value(),
     ok = test_chunked_truncated(),
+    ok = test_active_close(),
+    ok = test_passive_close(),
     ok.
 
 test_passive() ->
@@ -565,6 +567,43 @@ drain_until_error(Conn) ->
         {ok, UpdatedConn, _Responses} -> drain_until_error(UpdatedConn);
         {error, _} = Error -> Error
     end.
+
+test_active_close() ->
+    %% Active mode surfaces a normal peer close as {ok, Conn, closed}.
+    Segments = [
+        <<"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHello">>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, true}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {ok, _Conn3, closed} = active_wait_for_close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+active_wait_for_close(Conn) ->
+    receive
+        Msg ->
+            case ahttp_client:stream(Conn, Msg) of
+                {ok, _, closed} = R -> R;
+                {ok, UpdatedConn, _Responses} -> active_wait_for_close(UpdatedConn);
+                unknown -> active_wait_for_close(Conn)
+            end
+    after 5000 ->
+        error(no_close_within_timeout)
+    end.
+
+test_passive_close() ->
+    %% Passive mode surfaces a normal peer close as {error, {SocketType, closed}}.
+    Segments = [
+        <<"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHello">>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {gen_tcp, closed}} = drain_until_error(Conn2),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
 
 build_chunked_response(ExtraHeaders, Chunks, Trailers) ->
     HeaderLines = [[N, <<": ">>, V, <<"\r\n">>] || {N, V} <- ExtraHeaders],

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -37,6 +37,8 @@ test() ->
     ok = test_content_length_and_transfer_encoding(),
     ok = test_transfer_encoding_before_content_length(),
     ok = test_chunked_trailer_framing_filtered(),
+    ok = test_obs_fold_rejected(),
+    ok = test_obs_fold_rejected_trailer(),
     ok = test_bad_content_length_non_numeric(),
     ok = test_bad_content_length_negative(),
     ok = test_duplicate_content_length_same_value(),
@@ -343,6 +345,45 @@ test_transfer_encoding_before_content_length() ->
     wait_server(ServerPid),
     ok.
 
+test_obs_fold_rejected() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "X-Folded: first-part\r\n"
+            " continuation\r\n"
+            "Content-Length: 5\r\n\r\n"
+            "Hello"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {deprecated_obs_fold, <<" continuation">>}}} = ahttp_client:recv(Conn2, 0),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+test_obs_fold_rejected_trailer() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+            "5\r\nHello\r\n"
+            "0\r\n"
+            "X-Trailer: value\r\n"
+            "\t continuation\r\n"
+            "\r\n"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, {deprecated_obs_fold, <<"\t continuation">>}}} =
+        drain_until_error(Conn2),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
 test_chunked_trailer_framing_filtered() ->
     Segments = [
         <<
@@ -624,13 +665,9 @@ accumulate([{status, _, Code} | T], Acc) ->
     accumulate(T, Acc#{status => Code});
 accumulate([{header, _, _KV} | T], Acc) ->
     accumulate(T, Acc#{has_headers => true});
-accumulate([{header_continuation, _, _KV} | T], Acc) ->
-    accumulate(T, Acc);
 accumulate([{trailer_header, _, KV} | T], Acc) ->
     Ts = maps:get(trailers, Acc, []),
     accumulate(T, Acc#{trailers => [KV | Ts]});
-accumulate([{trailer_header_continuation, _, _KV} | T], Acc) ->
-    accumulate(T, Acc);
 accumulate([{data, _, Data} | T], Acc) ->
     Body = maps:get(body, Acc, <<>>),
     accumulate(T, Acc#{body => <<Body/binary, Data/binary>>});

--- a/tests/libs/eavmlib/test_ahttp_client.erl
+++ b/tests/libs/eavmlib/test_ahttp_client.erl
@@ -40,6 +40,7 @@ test() ->
     ok = test_bad_content_length_non_numeric(),
     ok = test_bad_content_length_negative(),
     ok = test_empty_header_value(),
+    ok = test_chunked_truncated(),
     ok.
 
 test_passive() ->
@@ -413,6 +414,28 @@ test_empty_header_value() ->
     #{status := 200, body := <<"Hello">>, done := true} = Acc,
     wait_server(ServerPid),
     ok.
+
+test_chunked_truncated() ->
+    Segments = [
+        <<
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+            "a\r\n12345"
+        >>
+    ],
+    {ServerPid, Port} = start_chunked_server(Segments),
+    {ok, Conn} = ahttp_client:connect(http, "localhost", Port, [{active, false}]),
+    {ok, Conn2, _Ref} = ahttp_client:request(Conn, <<"GET">>, <<"/">>, [], undefined),
+    {error, {parser, incomplete_response}} = drain_until_error(Conn2),
+    ahttp_client:close(Conn2),
+    wait_server(ServerPid),
+    ok.
+
+drain_until_error(Conn) ->
+    case ahttp_client:recv(Conn, 0) of
+        {ok, UpdatedConn, _Responses} -> drain_until_error(UpdatedConn);
+        {error, _} = Error -> Error
+    end.
 
 build_chunked_response(ExtraHeaders, Chunks, Trailers) ->
     HeaderLines = [[N, <<": ">>, V, <<"\r\n">>] || {N, V} <- ExtraHeaders],


### PR DESCRIPTION
Parse `Transfer-Encoding: chunked` response bodies so callers can
consume servers that stream without a `Content-Length` header. The
series also lands the review-driven robustness, framing-safety and
documentation fixes to `ahttp_client` that the chunked feature
exposed.

Highlights:

- Chunked responses with HTTP trailers (RFC 9112 §7.1).
- Parser crash fixes on malformed `Content-Length` and empty header
  values.
- Premature close now returns `{error, {parser, unexpected_eof}}`;
  `ssl_closed` is handled.
- Reject conflicting `Content-Length`, `CL + Transfer-Encoding`,
  stacked `Transfer-Encoding`, and obs-fold (RFC 9110 §6.5.2,
  RFC 9112 §5.2, §6.1, §6.3).
- Cap parsed status, header and chunk-size lines at 16 KiB.
- Document `{data, _, _}` binary retention and the asymmetric close
  shapes of `stream/2` vs `recv/2`.
  
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
