### PR TITLE
Use EXPORT_ES6 setting and .mjs suffix

### DIFF
--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -187,14 +187,14 @@ jobs:
       run: |
         set -euxo pipefail
         # Test compressed beams
-        node src/AtomVM.js ../../../../build/examples/erlang/hello_world.beam  ../../../../build/libs/eavmlib/src/eavmlib.avm
+        node src/AtomVM.mjs ../../../../build/examples/erlang/hello_world.beam  ../../../../build/libs/eavmlib/src/eavmlib.avm
         # Run tests that pass
-        node src/AtomVM.js ../../../../build/tests/libs/alisp/test_alisp.avm
-        node src/AtomVM.js ../../../../build/tests/libs/estdlib/test_estdlib.avm
+        node src/AtomVM.mjs ../../../../build/tests/libs/alisp/test_alisp.avm
+        node src/AtomVM.mjs ../../../../build/tests/libs/estdlib/test_estdlib.avm
         # test_eavmlib does not work with wasm due to http + ssl test
-        # node src/AtomVM.js ../../../../build/tests/libs/eavmlib/test_eavmlib.avm
-        node src/AtomVM.js ../../../../build/tests/libs/etest/test_etest.avm
-        node src/AtomVM.js ../../../../build/tests/erlang_tests/test_crypto.beam
+        # node src/AtomVM.mjs ../../../../build/tests/libs/eavmlib/test_eavmlib.avm
+        node src/AtomVM.mjs ../../../../build/tests/libs/etest/test_etest.avm
+        node src/AtomVM.mjs ../../../../build/tests/erlang_tests/test_crypto.beam
 
     - name: Test (JIT)
       if: matrix.jit != ''
@@ -203,19 +203,19 @@ jobs:
       run: |
         set -euxo pipefail
         # Test hello_world with JIT compiler (runtime JIT compilation)
-        node src/AtomVM.js ../../../../build/examples/erlang/hello_world.beam ../../../../build/libs/atomvmlib-emscripten-wasm32.avm
+        node src/AtomVM.mjs ../../../../build/examples/erlang/hello_world.beam ../../../../build/libs/atomvmlib-emscripten-wasm32.avm
         # Library tests with JIT compiler (jit-wasm32.avm included in test avms via pack_test)
-        node src/AtomVM.js ../../../../build/tests/libs/alisp/test_alisp.avm
-        node src/AtomVM.js ../../../../build/tests/libs/estdlib/test_estdlib.avm
-        node src/AtomVM.js ../../../../build/tests/libs/etest/test_etest.avm
+        node src/AtomVM.mjs ../../../../build/tests/libs/alisp/test_alisp.avm
+        node src/AtomVM.mjs ../../../../build/tests/libs/estdlib/test_estdlib.avm
+        node src/AtomVM.mjs ../../../../build/tests/libs/etest/test_etest.avm
 
     - name: "Rename and write sha256sum (node)"
       if: startsWith(github.ref, 'refs/tags/') && matrix.jit == ''
       shell: bash
       working-directory: src/platforms/emscripten/build/src
       run: |
-        ATOMVM_JS=AtomVM-node-${{ github.ref_name }}.js
-        mv AtomVM.js "${ATOMVM_JS}"
+        ATOMVM_JS=AtomVM-node-${{ github.ref_name }}.mjs
+        mv AtomVM.mjs "${ATOMVM_JS}"
         sha256sum "${ATOMVM_JS}" > "${ATOMVM_JS}.sha256"
         ATOMVM_WASM=AtomVM-node-${{ github.ref_name }}.wasm
         mv AtomVM.wasm "${ATOMVM_WASM}"
@@ -228,8 +228,8 @@ jobs:
         draft: true
         fail_on_unmatched_files: true
         files: |
-          src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.js
-          src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.js.sha256
+          src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.mjs
+          src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.mjs.sha256
           src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.wasm
           src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.wasm.sha256
 
@@ -283,7 +283,7 @@ jobs:
         name: atomvm-js-web
         path: |
             src/platforms/emscripten/build/**/*.wasm
-            src/platforms/emscripten/build/**/*.js
+            src/platforms/emscripten/build/**/*.mjs
         retention-days: 1
 
   wasm_test_web:
@@ -341,8 +341,8 @@ jobs:
       shell: bash
       working-directory: src/platforms/emscripten/build/src
       run: |
-        ATOMVM_JS=AtomVM-web-${{ github.ref_name }}.js
-        mv AtomVM.js "${ATOMVM_JS}"
+        ATOMVM_JS=AtomVM-web-${{ github.ref_name }}.mjs
+        mv AtomVM.mjs "${ATOMVM_JS}"
         sha256sum "${ATOMVM_JS}" > "${ATOMVM_JS}.sha256"
         ATOMVM_WASM=AtomVM-web-${{ github.ref_name }}.wasm
         mv AtomVM.wasm "${ATOMVM_WASM}"
@@ -355,7 +355,7 @@ jobs:
         draft: true
         fail_on_unmatched_files: true
         files: |
-          src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.js
-          src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.js.sha256
+          src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.mjs
+          src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.mjs.sha256
           src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.wasm
           src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.wasm.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated network type db() to dbm() to reflect the actual representation of the type
+- Use ES6 modules for emscripten port, using .mjs suffix
 
 ### Fixed
 - Stop using deprecated `term_from_int32` on STM32 platform

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -35,6 +35,13 @@ standard Erlang/OTP API, that takes maps instead of proplists.
 The `main.avm` offset is now `0x250000` for all images (previously `0x210000` for Erlang-only).
 Update flashing offsets in your tooling, build scripts, and `mix.exs` or `rebar.config` if you
 were using the `0x210000` offset.
+- The emscripten port now uses ES6 modules (`.mjs` suffix). This is a breaking change for
+  existing web integrations:
+  * Replace `<script async src="AtomVM.js"></script>` with a module script
+  * Use `<script type="module">` and `import AtomVM from "AtomVM.mjs"`
+  * Instantiate with `const module = await AtomVM({ arguments: [...] })`
+  * The old implicit global-script pattern is no longer supported
+  * `AtomVM.worker.js` is no longer emitted; only `AtomVM.mjs` and `AtomVM.wasm` are needed
 
 ## v0.6.4 -> v0.6.5
 

--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -1137,7 +1137,7 @@ $ emmake make -j
 AtomVM can then be invoked as on Generic Unix with node:
 
 ```shell
-$ node ./src/AtomVM.js
+$ node ./src/AtomVM.mjs
 ```
 
 ### Running tests with NodeJS
@@ -1150,8 +1150,8 @@ Then execute the tests with:
 
 ```shell
 $ cd src/platforms/emscripten/build/
-$ node ./src/AtomVM.js ../../../../build/tests/libs/eavmlib/test_eavmlib.avm
-$ node ./src/AtomVM.js ../../../../build/tests/libs/alisp/test_alisp.avm
+$ node ./src/AtomVM.mjs ../../../../build/tests/libs/eavmlib/test_eavmlib.avm
+$ node ./src/AtomVM.mjs ../../../../build/tests/libs/alisp/test_alisp.avm
 ```
 
 ### Building for the web

--- a/doc/src/getting-started-guide.md
+++ b/doc/src/getting-started-guide.md
@@ -559,23 +559,23 @@ Download the latest [release image](https://github.com/atomvm/AtomVM/releases) f
 
 This image will generally take the form:
 
->`Atomvm-node-<atomvm-version>.js`
+>`Atomvm-node-<atomvm-version>.mjs`
 
 For example:
 
->`Atomvm-node-v0.6.0.js`
+>`Atomvm-node-v0.6.0.mjs`
 
 You will also find the sha256 hash for this file, which you should verify using the `sha256sum` command on your local operating system.
 
-AtomVM's WebAssembly port for NodeJS may be run using `node` command and AtomVM.js, AtomVM.worker.js and AtomVM.wasm files.
+AtomVM's WebAssembly port for NodeJS may be run using `node` command and AtomVM.mjs and AtomVM.wasm files.
 
 ```shell
-$ node /path/to/Atomvm-node-v0.6.0.js /path/to/myapp.avm
+$ node /path/to/Atomvm-node-v0.6.0.mjs /path/to/myapp.avm
 ```
 
 ### Getting Started with AtomVM WebAssembly port for browsers
 
-AtomVM may also be run in modern browsers (Safari, Chrome and Chrome-based, Firefox) using AtomVM.js, AtomVM.worker.js and AtomVM.wasm files.
+AtomVM may also be run in modern browsers (Safari, Chrome and Chrome-based, Firefox) using AtomVM.mjs and AtomVM.wasm files.
 
 Please note that these files are different from the NodeJS ones.
 

--- a/examples/emscripten/call_cast.html
+++ b/examples/emscripten/call_cast.html
@@ -35,13 +35,14 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
     <p>Call button was clicked <span id="call-counter">0</span> time(s).</p>
     <p>Cast button was clicked <span id="cast-counter">0</span> time(s).</p>
 
-    <script>
+    <script type="module">
+      import AtomVM from "/AtomVM.mjs";
+
       // Arguments are loaded using fetch API.
       // wasm_webserver serves under /build/ files in build subdirectory.
-      var Module = {
+      window.Module = await AtomVM({
         arguments: ["/build/examples/emscripten/call_cast.avm"],
-      };
+      });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/examples/emscripten/echo_websocket.html
+++ b/examples/emscripten/echo_websocket.html
@@ -76,13 +76,14 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
     <input type="text" name="text" id="send-text" disabled></input>
     <button id="send-button" disabled>Send</button>
 
-    <script>
+    <script type="module">
+      import AtomVM from "/AtomVM.mjs";
+
       // Arguments are loaded using fetch API.
       // wasm_webserver serves under /build/ files in build subdirectory.
-      var Module = {
+      window.Module = await AtomVM({
         arguments: ["/build/examples/emscripten/echo_websocket.avm"],
-      };
+      });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/examples/emscripten/hello_world_avm.html
+++ b/examples/emscripten/hello_world_avm.html
@@ -26,13 +26,14 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
   <body>
     <h1>Hello world (AVM version)</h1>
     <p>Please check the console for hello_world output.</p>
-    <script>
+    <script type="module">
+      import AtomVM from "/AtomVM.mjs";
+
       // Arguments are loaded using fetch API.
       // wasm_webserver serves under /build/ files in build subdirectory.
-      var Module = {
+      window.Module = await AtomVM({
         arguments: ["/build/examples/erlang/hello_world.avm"],
-      };
+      });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/examples/emscripten/hello_world_beam.html
+++ b/examples/emscripten/hello_world_beam.html
@@ -30,16 +30,17 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
       in arguments, typically loading AtomVM library as a packed avm file.
     </p>
     <p>Please check the console for hello_world output.</p>
-    <script>
+    <script type="module">
+      import AtomVM from "/AtomVM.mjs";
+
       // Arguments are loaded using fetch API.
       // wasm_webserver serves under /build/ files in build subdirectory.
-      var Module = {
+      window.Module = await AtomVM({
         arguments: [
           "/build/examples/erlang/hello_world.beam",
           "/build/libs/atomvmlib.avm",
         ],
-      };
+      });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/examples/emscripten/html5_events.html
+++ b/examples/emscripten/html5_events.html
@@ -144,13 +144,14 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
       <tbody id="events"></tbody>
     </table>
 
-    <script>
+    <script type="module">
+      import AtomVM from "/AtomVM.mjs";
+
       // Arguments are loaded using fetch API.
       // wasm_webserver serves under /build/ files in build subdirectory.
-      var Module = {
+      window.Module = await AtomVM({
         arguments: ["/build/examples/emscripten/html5_events.avm"],
-      };
+      });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/examples/emscripten/run_script.html
+++ b/examples/emscripten/run_script.html
@@ -50,13 +50,14 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
       the main thread) using JS function.
     </p>
 
-    <script>
+    <script type="module">
+      import AtomVM from "/AtomVM.mjs";
+
       // Arguments are loaded using fetch API.
       // wasm_webserver serves under /build/ files in build subdirectory.
-      var Module = {
+      window.Module = await AtomVM({
         arguments: ["/build/examples/emscripten/run_script.avm"],
-      };
+      });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/examples/emscripten/wasm_webserver.erl
+++ b/examples/emscripten/wasm_webserver.erl
@@ -40,12 +40,10 @@ handle_req(Method, Path, Conn) when Method =:= "GET" orelse Method =:= "HEAD" ->
         case Path of
             [] ->
                 "../examples/emscripten/index.html";
-            ["AtomVM.js"] ->
-                "../src/platforms/emscripten/build/src/AtomVM.js";
+            ["AtomVM.mjs"] ->
+                "../src/platforms/emscripten/build/src/AtomVM.mjs";
             ["AtomVM.wasm"] ->
                 "../src/platforms/emscripten/build/src/AtomVM.wasm";
-            ["AtomVM.worker.js"] ->
-                "../src/platforms/emscripten/build/src/AtomVM.worker.js";
             ["tests", "build" | Tail] ->
                 lists:flatten([
                     "../src/platforms/emscripten/build/tests/src/" | lists:join($/, Tail)
@@ -60,6 +58,7 @@ handle_req(Method, Path, Conn) when Method =:= "GET" orelse Method =:= "HEAD" ->
     MimeType =
         case lists:reverse(Filename) of
             "sj." ++ _ -> "text/javascript";
+            "sjm." ++ _ -> "text/javascript";
             "lmth." ++ _ -> "text/html";
             "msaw." ++ _ -> "application/wasm";
             "mva." ++ _ -> "application/binary";

--- a/src/platforms/emscripten/src/CMakeLists.txt
+++ b/src/platforms/emscripten/src/CMakeLists.txt
@@ -21,6 +21,7 @@
 cmake_minimum_required (VERSION 3.13)
 
 add_executable(AtomVM main.c)
+set_target_properties(AtomVM PROPERTIES SUFFIX ".mjs")
 
 target_compile_features(AtomVM PUBLIC c_std_11)
 
@@ -30,11 +31,14 @@ target_compile_options(libAtomVM PUBLIC -O3 -fno-exceptions -fno-rtti -pthread -
 target_compile_definitions(libAtomVM PRIVATE WITH_ZLIB)
 if (NOT AVM_DISABLE_JIT)
     # JIT requires addFunction to register dynamically compiled WASM functions
-    set(JIT_LINK_FLAGS -sALLOW_TABLE_GROWTH -sEXPORTED_RUNTIME_METHODS=ccall,addFunction)
+    set(JIT_LINK_FLAGS
+        -sALLOW_TABLE_GROWTH
+        "-sEXPORTED_RUNTIME_METHODS=['ccall','addFunction','ENV']"
+    )
 else()
-    set(JIT_LINK_FLAGS -sEXPORTED_RUNTIME_METHODS=ccall)
+    set(JIT_LINK_FLAGS "-sEXPORTED_RUNTIME_METHODS=['ccall','ENV']")
 endif()
-target_link_options(AtomVM PRIVATE ${JIT_LINK_FLAGS} -sUSE_ZLIB=1 -O3 -pthread -sFETCH -lwebsocket.js --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.pre.js -sINITIAL_MEMORY=67108864 -sALLOW_MEMORY_GROWTH)
+target_link_options(AtomVM PRIVATE ${JIT_LINK_FLAGS} -sEXPORT_ES6 -sUSE_ZLIB=1 -O3 -pthread -sFETCH -lwebsocket.js --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.pre.js --extern-post-js ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.extern-post.js -sINITIAL_MEMORY=67108864 -sALLOW_MEMORY_GROWTH)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_link_options(AtomVM PRIVATE -sASSERTIONS=2 -sSAFE_HEAP -sSTACK_OVERFLOW_CHECK)

--- a/src/platforms/emscripten/src/atomvm.extern-post.js
+++ b/src/platforms/emscripten/src/atomvm.extern-post.js
@@ -1,0 +1,27 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+if (typeof process === "object" && process.versions?.node && process.argv[1]) {
+  const { pathToFileURL } = await import("url");
+  const { realpathSync } = await import("fs");
+
+  if (import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href) {
+    await Module();
+  }
+}

--- a/src/platforms/emscripten/tests/src/test_atomvm.html
+++ b/src/platforms/emscripten/tests/src/test_atomvm.html
@@ -27,19 +27,20 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
     <div id="random"></div>
     <div id="pi"></div>
     <div id="pierror"></div>
-    <script>
+    <script type="module">
+      import AtomVM from "/AtomVM.mjs";
+
       // Arguments are loaded using fetch API.
       // wasm_webserver serves under /tests/build/ files in src/platform/escripten/build/tests/src subdirectory
       // and under /build/ files in build/ subdirectory.
-      var Module = {
+      window.Module = await AtomVM({
         arguments: [
           "/tests/build/test_atomvm.beam",
           "/build/libs/estdlib/src/estdlib.avm",
           "/build/libs/eavmlib/src/eavmlib.avm",
           "/build/libs/avm_emscripten/src/avm_emscripten.avm",
         ],
-      };
+      });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/src/platforms/emscripten/tests/src/test_call.html
+++ b/src/platforms/emscripten/tests/src/test_call.html
@@ -28,14 +28,15 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
     <button id="call-button" disabled>Call</button>
     <div id="result"></div>
     <div id="error"></div>
-    <script>
+    <script type="module">
+    import AtomVM from "/AtomVM.mjs";
+
     // Arguments are loaded using fetch API.
     // wasm_webserver serves under /tests/build/ files in src/platform/escripten/build/tests/src subdirectory
     // and under /build/ files in build/ subdirectory.
-    var Module = {
+    window.Module = await AtomVM({
         arguments: ['/tests/build/test_call.beam', '/build/libs/eavmlib/src/eavmlib.avm', '/build/libs/avm_emscripten/src/avm_emscripten.avm']
-    }
+    });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/src/platforms/emscripten/tests/src/test_html5.html
+++ b/src/platforms/emscripten/tests/src/test_html5.html
@@ -29,14 +29,15 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
     <div id="register-once-and-exit" hidden>register once and exit</div>
     <div id="result"></div>
     <div id="error"></div>
-    <script>
+    <script type="module">
+    import AtomVM from "/AtomVM.mjs";
+
     // Arguments are loaded using fetch API.
     // wasm_webserver serves under /tests/build/ files in src/platform/escripten/build/tests/src subdirectory
     // and under /build/ files in build/ subdirectory.
-    var Module = {
+    window.Module = await AtomVM({
         arguments: ['/tests/build/test_html5.beam', '/build/libs/estdlib/src/estdlib.avm', '/build/libs/eavmlib/src/eavmlib.avm', '/build/libs/avm_emscripten/src/avm_emscripten.avm']
-    }
+    });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>

--- a/src/platforms/emscripten/tests/src/test_websockets.html
+++ b/src/platforms/emscripten/tests/src/test_websockets.html
@@ -24,7 +24,9 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
   </head>
   <body>
     <pre id="result">N/A</pre>
-    <script>
+    <script type="module">
+    import AtomVM from "/AtomVM.mjs";
+
     // Arguments are loaded using fetch API.
     // wasm_webserver serves under /tests/build/ files in src/platform/escripten/build/tests/src subdirectory
     // and under /build/ files in build/ subdirectory.
@@ -34,16 +36,15 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
     const hashParams = new URLSearchParams(hash);
     const echoServer = hashParams.get('echo_server');
 
-    var Module = {
+    window.Module = await AtomVM({
         arguments: ['/tests/build/test_websockets.beam', '/build/libs/eavmlib/src/eavmlib.avm', '/build/libs/avm_emscripten/src/avm_emscripten.avm', '/build/libs/estdlib/src/estdlib.avm'],
-        preRun: [function() {
+        preRun: [function(module) {
             if (echoServer) {
                 // Set environment variable for the Erlang code to read
-                ENV['ECHO_WEBSOCKET_URL'] = echoServer;
+                module.ENV['ECHO_WEBSOCKET_URL'] = echoServer;
             }
         }]
-    }
+    });
     </script>
-    <script async src="/AtomVM.js"></script>
   </body>
 </html>


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
