### PR TITLE
Add more reset reasons to esp:reset_reason/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `network:wifi_scan/0,1` to ESP32 network driver to scan available APs when in sta or sta+ap mode.
 - Added support for `nif_start`, `executable_line` and `debug_line` opcodes
 - Added named variable debugging support in DWARF when modules are compiled with `beam_debug_info`
+- Added more reset reasons and ensured `esp:reset_reason/0` doesn't return `undefined`
 
 ### Changed
 - Updated network type db() to dbm() to reflect the actual representation of the type

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1378,6 +1378,11 @@ Use the [`esp:reset_reason/0`](./apidocs/erlang/eavmlib/esp.md#reset_reason0) fu
 * `esp_rst_deepsleep`
 * `esp_rst_brownout`
 * `esp_rst_sdio`
+* `esp_rst_usb`
+* `esp_rst_jtag`
+* `esp_rst_efuse`
+* `esp_rst_pwr_glitch`
+* `esp_rst_cpu_lockup`
 
 #### Sleep Mode - Deep Sleep and Light Sleep
 

--- a/libs/avm_esp32/src/esp.erl
+++ b/libs/avm_esp32/src/esp.erl
@@ -88,7 +88,12 @@
     | esp_rst_wdt
     | esp_rst_deepsleep
     | esp_rst_brownout
-    | esp_rst_sdio.
+    | esp_rst_sdio
+    | esp_rst_usb
+    | esp_rst_jtag
+    | esp_rst_efuse
+    | esp_rst_pwr_glitch
+    | esp_rst_cpu_lockup.
 
 -type esp_wakeup_cause() ::
     sleep_wakeup_ext0

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -78,6 +78,11 @@ static const char *const esp_rst_wdt            = "\xB"  "esp_rst_wdt";
 static const char *const esp_rst_deepsleep      = "\x11" "esp_rst_deepsleep";
 static const char *const esp_rst_brownout       = "\x10" "esp_rst_brownout";
 static const char *const esp_rst_sdio           = "\xC"  "esp_rst_sdio";
+static const char *const esp_rst_usb            = "\xB"  "esp_rst_usb";
+static const char *const esp_rst_jtag           = "\xC"  "esp_rst_jtag";
+static const char *const esp_rst_efuse          = "\xD"  "esp_rst_efuse";
+static const char *const esp_rst_pwr_glitch     = "\x12" "esp_rst_pwr_glitch";
+static const char *const esp_rst_cpu_lockup     = "\x12" "esp_rst_cpu_lockup";
 #if ESP_TASK_WDT_API
 static const char *const already_started        = "\xF"  "already_started";
 #endif
@@ -190,8 +195,18 @@ static term nif_esp_reset_reason(Context *ctx, int argc, term argv[])
             return globalcontext_make_atom(ctx->global, esp_rst_brownout);
         case ESP_RST_SDIO:
             return globalcontext_make_atom(ctx->global, esp_rst_sdio);
+        case ESP_RST_USB:
+            return globalcontext_make_atom(ctx->global, esp_rst_usb);
+        case ESP_RST_JTAG:
+            return globalcontext_make_atom(ctx->global, esp_rst_jtag);
+        case ESP_RST_EFUSE:
+            return globalcontext_make_atom(ctx->global, esp_rst_efuse);
+        case ESP_RST_PWR_GLITCH:
+            return globalcontext_make_atom(ctx->global, esp_rst_pwr_glitch);
+        case ESP_RST_CPU_LOCKUP:
+            return globalcontext_make_atom(ctx->global, esp_rst_cpu_lockup);
         default:
-            return UNDEFINED_ATOM;
+            return globalcontext_make_atom(ctx->global, esp_rst_unknown_atom);
     }
 }
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
