### PR TITLE
Fix a race condition in `context_destroy`

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -136,6 +136,9 @@ Context *context_new(GlobalContext *glb)
 
 void context_destroy(Context *ctx)
 {
+    // Hold and release the spin lock for timers and cancel any timer
+    scheduler_cancel_timeout(ctx);
+
     // Another process can get an access to our mailbox until this point.
     struct ListHead *processes_table_list = synclist_wrlock(&ctx->global->processes_table);
     UNUSED(processes_table_list);
@@ -278,10 +281,6 @@ void context_destroy(Context *ctx)
     memory_destroy_heap(&ctx->heap, ctx->global);
 
     dictionary_destroy(&ctx->dictionary);
-
-    if (ctx->timer_list_head.head.next != &ctx->timer_list_head.head) {
-        scheduler_cancel_timeout(ctx);
-    }
 
     // Platform data is freed here to allow drivers to use the
     // globalcontext_get_process_lock lock to protect this pointer


### PR DESCRIPTION
Another scheduler may be running `update_timer_list` while the context was being destroyed. Force synchronization by inconditionally calling `scheduler_cancel_timeout` which holds the spinlock and cancel any timeout before the process is removed from the process table.

This seems to fix some crashes on macOS under heavy load.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
