### PR TITLE
Fix JIT crash on scheduler destroy by joining threads

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -245,6 +245,13 @@ GlobalContext *globalcontext_new(void)
 
 COLD_FUNC void globalcontext_destroy(GlobalContext *glb)
 {
+#ifndef AVM_NO_SMP
+    /* Join sub-threads: a thread may still execute JIT epilogue code after
+     * decrementing running_schedulers, so we must join before munmapping
+     * native code pages. */
+    smp_scheduler_join_all();
+#endif
+
     sys_free_platform(glb);
 
     struct ListHead *item;

--- a/src/libAtomVM/smp.h
+++ b/src/libAtomVM/smp.h
@@ -257,6 +257,15 @@ int smp_get_online_processors(void);
 void smp_scheduler_start(GlobalContext *glb);
 
 /**
+ * @brief Wait for all scheduler sub-threads to fully exit.
+ *
+ * Must be called before destroying resources (e.g. JIT code pages) that
+ * scheduler threads may still access after leaving the scheduler loop.
+ * May be a no-op on platforms without joinable scheduler threads.
+ */
+void smp_scheduler_join_all(void);
+
+/**
  * @brief Determine if caller is in the main thread, i.e. thread that was not
  * started with acmsmp_scheduler_start.
  */

--- a/src/platforms/emscripten/src/lib/smp.c
+++ b/src/platforms/emscripten/src/lib/smp.c
@@ -65,6 +65,11 @@ void smp_scheduler_start(GlobalContext *ctx)
     }
 }
 
+void smp_scheduler_join_all(void)
+{
+    /* Threads are detached on this platform. */
+}
+
 bool smp_is_main_thread(GlobalContext *glb)
 {
     UNUSED(glb);

--- a/src/platforms/esp32/components/avm_sys/smp.c
+++ b/src/platforms/esp32/components/avm_sys/smp.c
@@ -126,6 +126,11 @@ void smp_scheduler_start(GlobalContext *ctx)
     }
 }
 
+void smp_scheduler_join_all(void)
+{
+    /* Threads are detached on this platform. */
+}
+
 bool smp_is_main_thread(GlobalContext *glb)
 {
     UNUSED(glb);

--- a/src/platforms/generic_unix/lib/smp.c
+++ b/src/platforms/generic_unix/lib/smp.c
@@ -44,6 +44,17 @@ struct RWLock
     pthread_rwlock_t lock;
 };
 
+/* Track scheduler thread handles so smp_scheduler_join_all can join them.
+ * A sub-thread may still execute JIT epilogue code after decrementing
+ * running_schedulers; joining prevents munmap races on JIT code pages. */
+struct SchedulerThreadList
+{
+    pthread_t thread;
+    struct SchedulerThreadList *next;
+};
+static pthread_mutex_t scheduler_threads_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct SchedulerThreadList *scheduler_threads = NULL;
+
 // Thread local storage with _Thread_local C11 keyword crashes on i386 with
 // valgrind (Ubutun 18 & 20, gcc 6-10). Use POSIX API instead.
 #ifdef __i386__
@@ -81,8 +92,29 @@ void smp_scheduler_start(GlobalContext *ctx)
     if (UNLIKELY(pthread_create(&thread, NULL, scheduler_thread_entry_point, ctx))) {
         AVM_ABORT();
     }
-    if (UNLIKELY(pthread_detach(thread))) {
+    struct SchedulerThreadList *node = malloc(sizeof(*node));
+    if (IS_NULL_PTR(node)) {
         AVM_ABORT();
+    }
+    node->thread = thread;
+    pthread_mutex_lock(&scheduler_threads_lock);
+    node->next = scheduler_threads;
+    scheduler_threads = node;
+    pthread_mutex_unlock(&scheduler_threads_lock);
+}
+
+void smp_scheduler_join_all(void)
+{
+    struct SchedulerThreadList *list;
+    pthread_mutex_lock(&scheduler_threads_lock);
+    list = scheduler_threads;
+    scheduler_threads = NULL;
+    pthread_mutex_unlock(&scheduler_threads_lock);
+    while (list) {
+        struct SchedulerThreadList *next = list->next;
+        (void) pthread_join(list->thread, NULL);
+        free(list);
+        list = next;
     }
 }
 

--- a/src/platforms/rp2/src/lib/smp.c
+++ b/src/platforms/rp2/src/lib/smp.c
@@ -70,6 +70,11 @@ void smp_scheduler_start(GlobalContext *ctx)
     multicore_lockout_victim_init();
 }
 
+void smp_scheduler_join_all(void)
+{
+    /* Core 1 is launched directly, no pthread to join. */
+}
+
 bool smp_is_main_thread(GlobalContext *glb)
 {
     UNUSED(glb);

--- a/tests/test.c
+++ b/tests/test.c
@@ -736,19 +736,6 @@ int test_module_execution(bool beam, struct Test *test)
 
 int test_modules_execution(bool beam, bool skip, int count, char **item)
 {
-    if (chdir("erlang_tests") != 0) {
-        perror("Error: ");
-        return EXIT_FAILURE;
-    }
-#ifndef AVM_NO_JIT
-    if (!beam) {
-        if (chdir(AVM_JIT_TARGET_ARCH_DIR) != 0) {
-            perror("Error: cannot find " AVM_JIT_TARGET_ARCH_DIR " directory");
-            return EXIT_FAILURE;
-        }
-    }
-#endif
-
     int failed_tests = 0;
 
     if (count) {
@@ -793,9 +780,10 @@ int test_modules_execution(bool beam, bool skip, int count, char **item)
 static void usage(const char *name)
 {
     fprintf(stdout, "%s: run AtomVM tests\n", name);
-    fprintf(stdout, "%s [-h] [-s test1,test2] [-b] [test1 test2...]\n", name);
+    fprintf(stdout, "%s [-h] [-s test1,test2] [-c N] [-b] [test1 test2...]\n", name);
     fprintf(stdout, "  -h: display this message\n");
     fprintf(stdout, "  -s test1,test2: skip these tests\n");
+    fprintf(stdout, "  -c N: repeat tests N times or until a failure occurs\n");
     fprintf(stdout, "  -b: run tests against BEAM instead of AtomVM (erl in the PATH)\n");
     fprintf(stdout, "  test1 .. test2: specify tests to run (default to all)\n");
 }
@@ -821,10 +809,17 @@ int main(int argc, char **argv)
     bool beam = false;
     bool skip = false;
     char *skip_list = NULL;
-    while ((opt = getopt(argc, argv, "hbs:")) != -1) {
+    int repeat_count = 1;
+    while ((opt = getopt(argc, argv, "hbc:s:")) != -1) {
         switch (opt) {
             case 'b':
                 beam = true;
+                break;
+            case 'c':
+                repeat_count = atoi(optarg);
+                if (repeat_count <= 0) {
+                    repeat_count = 1;
+                }
                 break;
             case 's':
                 skip_list = optarg;
@@ -865,7 +860,39 @@ int main(int argc, char **argv)
         list = allocated_skip_list;
     }
 
-    int result = test_modules_execution(beam, skip, count, list);
+    if (chdir("erlang_tests") != 0) {
+        perror("Error: ");
+        if (allocated_skip_list) {
+            free(allocated_skip_list);
+        }
+        return EXIT_FAILURE;
+    }
+#ifndef AVM_NO_JIT
+    if (!beam) {
+        if (chdir(AVM_JIT_TARGET_ARCH_DIR) != 0) {
+            perror("Error: cannot find " AVM_JIT_TARGET_ARCH_DIR " directory");
+            if (allocated_skip_list) {
+                free(allocated_skip_list);
+            }
+            return EXIT_FAILURE;
+        }
+    }
+#endif
+
+    int result = 0;
+
+    for (int rep = 1; rep <= repeat_count; rep++) {
+        if (repeat_count > 1) {
+            fprintf(stderr, "=== Run %d of %d ===\n", rep, repeat_count);
+        }
+        result = test_modules_execution(beam, skip, count, list);
+        if (result != EXIT_SUCCESS) {
+            if (allocated_skip_list) {
+                free(allocated_skip_list);
+            }
+            return result;
+        }
+    }
     if (allocated_skip_list) {
         free(allocated_skip_list);
     }


### PR DESCRIPTION
Fix a crash happening on VM teardown with generic_unix and JIT backends
that require an epilog after tail calls (arm32, armv6m, xtensa), observed
in CI with test_exit2 with qemu. The JIT page would be unmapped before the
JIT code returned.

Also add -c option to test-erlang to debug future similar cases.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
