### PR TITLE
Fix gcc warnings with JIT code

### DIFF
--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -276,8 +276,7 @@ static Context *jit_return(Context *ctx, JITState *jit_state)
         TRACE("jit_return: cp=0x%x mod=%d label=%d\n", (unsigned) ctx->cp, module_index, label);
         jit_state->continuation = (NativeContinuation) (label + 1);
 #else
-    // return to native using pointer arithmetics on function pointers
-    const void *native_pc = ((const uint8_t *) mod->native_code) + ((ctx->cp & 0xFFFFFF) >> 2);
+    uintptr_t native_pc = (uintptr_t) mod->native_code + ((ctx->cp & 0xFFFFFF) >> 2);
     jit_state->continuation = (NativeContinuation) native_pc;
 #endif
 #ifndef AVM_NO_EMU

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -1602,7 +1602,7 @@ ModuleNativeEntryPoint module_get_native_entry_point(Module *module, int exporte
     return jit_wasm_get_entry_point((const void *) module->native_code, exported_label);
 #else
     assert(module->native_code);
-    return (ModuleNativeEntryPoint) (((const uint8_t *) module->native_code) + JIT_JUMPTABLE_ENTRY_SIZE * exported_label);
+    return (ModuleNativeEntryPoint) ((uintptr_t) module->native_code + JIT_JUMPTABLE_ENTRY_SIZE * exported_label);
 #endif
 }
 #endif

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -101,14 +101,14 @@ extern "C" {
 #define SET_ERROR(error_type_atom)                \
     context_set_exception_class(ctx, ERROR_ATOM); \
     ctx->exception_reason = error_type_atom;      \
-    ctx->exception_stacktrace = stacktrace_create_raw(ctx, mod, (const uint8_t *) native_pc - (const uint8_t *) mod->native_code);
+    ctx->exception_stacktrace = stacktrace_create_raw(ctx, mod, (uintptr_t) native_pc - (uintptr_t) mod->native_code);
 #else
 #define SET_ERROR(error_type_atom)                                                          \
     context_set_exception_class(ctx, ERROR_ATOM);                                           \
     ctx->exception_reason = error_type_atom;                                                \
     if (mod->native_code) {                                                                 \
         ctx->exception_stacktrace = stacktrace_create_raw(ctx, mod,                         \
-            (const uint8_t *) native_pc - (const uint8_t *) mod->native_code);  \
+            (uintptr_t) native_pc - (uintptr_t) mod->native_code);  \
     } else {                                                                                \
         ctx->exception_stacktrace = stacktrace_create_raw(ctx, mod, pc - code); \
     }
@@ -123,14 +123,14 @@ extern "C" {
 #define SET_ERROR_MFA(error_type_atom, m, f, a)                 \
     context_set_exception_class_use_live_flag(ctx, ERROR_ATOM); \
     ctx->exception_reason = error_type_atom;                    \
-    ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod, (const uint8_t *) native_pc - (const uint8_t *) mod->native_code, m, f, a);
+    ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod, (uintptr_t) native_pc - (uintptr_t) mod->native_code, m, f, a);
 #else
 #define SET_ERROR_MFA(error_type_atom, m, f, a)                                                          \
     context_set_exception_class_use_live_flag(ctx, ERROR_ATOM);                                          \
     ctx->exception_reason = error_type_atom;                                                             \
     if (mod->native_code) {                                                                              \
         ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod,                                  \
-            (const uint8_t *) native_pc - (const uint8_t *) mod->native_code, m, f, a);                  \
+            (uintptr_t) native_pc - (uintptr_t) mod->native_code, m, f, a);                  \
     } else {                                                                                             \
         ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod, pc - code, m, f, a);             \
     }

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -103,13 +103,13 @@ extern "C" {
     ctx->exception_reason = error_type_atom;      \
     ctx->exception_stacktrace = stacktrace_create_raw(ctx, mod, (uintptr_t) native_pc - (uintptr_t) mod->native_code);
 #else
-#define SET_ERROR(error_type_atom)                                                          \
-    context_set_exception_class(ctx, ERROR_ATOM);                                           \
-    ctx->exception_reason = error_type_atom;                                                \
-    if (mod->native_code) {                                                                 \
-        ctx->exception_stacktrace = stacktrace_create_raw(ctx, mod,                         \
-            (uintptr_t) native_pc - (uintptr_t) mod->native_code);  \
-    } else {                                                                                \
+#define SET_ERROR(error_type_atom)                                              \
+    context_set_exception_class(ctx, ERROR_ATOM);                               \
+    ctx->exception_reason = error_type_atom;                                    \
+    if (mod->native_code) {                                                     \
+        ctx->exception_stacktrace = stacktrace_create_raw(ctx, mod,             \
+            (uintptr_t) native_pc - (uintptr_t) mod->native_code);              \
+    } else {                                                                    \
         ctx->exception_stacktrace = stacktrace_create_raw(ctx, mod, pc - code); \
     }
 #endif
@@ -125,14 +125,14 @@ extern "C" {
     ctx->exception_reason = error_type_atom;                    \
     ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod, (uintptr_t) native_pc - (uintptr_t) mod->native_code, m, f, a);
 #else
-#define SET_ERROR_MFA(error_type_atom, m, f, a)                                                          \
-    context_set_exception_class_use_live_flag(ctx, ERROR_ATOM);                                          \
-    ctx->exception_reason = error_type_atom;                                                             \
-    if (mod->native_code) {                                                                              \
-        ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod,                                  \
+#define SET_ERROR_MFA(error_type_atom, m, f, a)                                              \
+    context_set_exception_class_use_live_flag(ctx, ERROR_ATOM);                              \
+    ctx->exception_reason = error_type_atom;                                                 \
+    if (mod->native_code) {                                                                  \
+        ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod,                      \
             (uintptr_t) native_pc - (uintptr_t) mod->native_code, m, f, a);                  \
-    } else {                                                                                             \
-        ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod, pc - code, m, f, a);             \
+    } else {                                                                                 \
+        ctx->exception_stacktrace = stacktrace_create_raw_mfa(ctx, mod, pc - code, m, f, a); \
     }
 #endif
 
@@ -675,7 +675,7 @@ static void destroy_extended_registers(Context *ctx, unsigned int live)
 #ifdef JIT_JUMPTABLE_IS_DATA
 #define DO_RESOLVE_SAVED_FUNC_PTR()                             \
     {                                                           \
-        int _label = (int) ctx->saved_function_ptr - 1; \
+        int _label = (int) ctx->saved_function_ptr - 1;         \
         native_pc = module_get_native_entry_point(mod, _label); \
     }
 #else

--- a/src/platforms/generic_unix/lib/jit_stream_mmap.c
+++ b/src/platforms/generic_unix/lib/jit_stream_mmap.c
@@ -287,7 +287,7 @@ ModuleNativeEntryPoint jit_stream_entry_point(Context *ctx, term jit_stream)
     // Set thumb bit for armv6m
     ModuleNativeEntryPoint result = (ModuleNativeEntryPoint) ((uintptr_t) js_obj->stream_base | 1);
 #else
-    ModuleNativeEntryPoint result = (ModuleNativeEntryPoint) js_obj->stream_base;
+    ModuleNativeEntryPoint result = (ModuleNativeEntryPoint) (uintptr_t) js_obj->stream_base;
 #endif
 
     // Prevent module from being unmapped by dtor — ownership transfers to Module

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -855,7 +855,7 @@ ModuleNativeEntryPoint sys_map_native_code(const uint8_t *code, size_t code_size
     // Set thumb bit for armv6m
     return (ModuleNativeEntryPoint) ((uintptr_t) (header + 1) | 1);
 #else
-    return (ModuleNativeEntryPoint) (header + 1);
+    return (ModuleNativeEntryPoint) (uintptr_t) (header + 1);
 #endif
 #else
     // x86_64: mmap RWX so debuggers can set software breakpoints
@@ -866,7 +866,7 @@ ModuleNativeEntryPoint sys_map_native_code(const uint8_t *code, size_t code_size
     }
     header->mmap_size = total;
     memcpy(header + 1, code, code_size);
-    return (ModuleNativeEntryPoint) (header + 1);
+    return (ModuleNativeEntryPoint) (uintptr_t) (header + 1);
 #endif
 }
 


### PR DESCRIPTION
Also reformat some macros in opcodesswitch.h

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
