### PR TITLE
Bump softprops/action-gh-release to v3 for node 24

### DIFF
--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -129,7 +129,7 @@ jobs:
         sha256sum "examples/erlang/${HELLO_WORLD_FILE}" > "examples/erlang/${HELLO_WORLD_FILE}.sha256"
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3.0.0
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: true

--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -256,7 +256,7 @@ jobs:
         '
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3.0.0
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: true

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -185,7 +185,7 @@ jobs:
         sha256sum "${ATOMVM_IMG}" > "${ATOMVM_IMG}.sha256"
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3.0.0
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: true

--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -253,7 +253,7 @@ jobs:
         path: ${{ env.ATOMVM_COMBINED_FILE }}
 
     - name: Release (Pico & Pico2)
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3.0.0
       if: startsWith(github.ref, 'refs/tags/') && matrix.board != 'pico_w' && matrix.board != 'pico2_w' && matrix.platform == '' && matrix.jit == ''
       with:
         draft: true
@@ -267,7 +267,7 @@ jobs:
           ${{ env.ATOMVM_COMBINED_FILE }}.sha256
 
     - name: Release (PicoW & Pico2W)
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3.0.0
       if: startsWith(github.ref, 'refs/tags/') && (matrix.board == 'pico_w' || matrix.board == 'pico2_w') && matrix.platform == '' && matrix.jit == ''
       with:
         draft: true

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -222,7 +222,7 @@ jobs:
         sha256sum "${ATOMVM_WASM}" > "${ATOMVM_WASM}.sha256"
 
     - name: "Release (node)"
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3.0.0
       if: startsWith(github.ref, 'refs/tags/') && matrix.jit == ''
       with:
         draft: true
@@ -349,7 +349,7 @@ jobs:
         sha256sum "${ATOMVM_WASM}" > "${ATOMVM_WASM}.sha256"
 
     - name: "Release (web)"
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3.0.0
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: true


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
